### PR TITLE
Handle duplicate classes

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,6 @@
 export function classNames(...classes: string[]) {
-  return classes.filter(Boolean).join(" ");
+  const uniqueClasses = Array.from(new Set(classes.join(" ").split(" ")));
+  return uniqueClasses.join(" ");
 }
 
 export function getExtension(url: string) {


### PR DESCRIPTION
Resolves #3 

A slight modification of `classNames` function that returns a unique string solves the duplicate classNames issue