### PR TITLE
fix description typo

### DIFF
--- a/pages/documents/new.tsx
+++ b/pages/documents/new.tsx
@@ -181,8 +181,7 @@ export default function Form() {
                         />
                       </div>
                       <p className="mt-3 text-sm leading-6 text-gray-400">
-                        This is description will help you find your document
-                        later.
+                        This description will help you find your document later.
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
Resolves #10 

Changes description text from

> "This is description will help you find your document later."

to

> "This description will help you find your document later."