### PR TITLE
fix: update to correct .env variable in .env.example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ NEXTAUTH_URL=http://localhost:3000
 
 # These variables are from Vercel Storage Postgres
 POSTGRES_PRISMA_URL=
-POSTGRES_URL_NON_POOLING=
+POSTGRES_PRISMA_URL_NON_POOLING=
 # This variable is from Vercel Storage Blob
 BLOB_READ_WRITE_TOKEN=
 


### PR DESCRIPTION
- Change POSTGRES_URL_NON_POOLING to POSTGRES_PRISMA_URL_NON_POOLING in .env.example
- Prisma schema is looking for `POSTGRES_PRISMA_URL_NON_POOLING`
- 
<img width="1178" alt="Screenshot 2023-09-14 at 11 30 40 PM" src="https://github.com/mfts/papermark/assets/97662335/02ca9a49-e829-48a0-88d1-4c34c955b516">

