### PR TITLE
Fix for page freeze after clicking on edit link option

### DIFF
--- a/components/links/links-table.tsx
+++ b/components/links/links-table.tsx
@@ -28,20 +28,22 @@ import MoreHorizontal from "../shared/icons/more-horizontal";
 import { Skeleton } from "../ui/skeleton";
 import LinksVisitors from "./links-visitors";
 import ChevronDown from "../shared/icons/chevron-down";
-import LinkSheet, { DEFAULT_LINK_PROPS, type DEFAULT_LINK_TYPE } from "./link-sheet";
+import LinkSheet, {
+  DEFAULT_LINK_PROPS,
+  type DEFAULT_LINK_TYPE,
+} from "./link-sheet";
 import { useState } from "react";
 import { LinkWithViews } from "@/lib/types";
 import { mutate } from "swr";
 import { toast } from "sonner";
-
-
 
 export default function LinksTable() {
   const { links } = useDocumentLinks();
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isLinkSheetVisible, setIsLinkSheetVisible] = useState<boolean>(false);
-  const [selectedLink, setSelectedLink] = useState<DEFAULT_LINK_TYPE>(DEFAULT_LINK_PROPS);
+  const [selectedLink, setSelectedLink] =
+    useState<DEFAULT_LINK_TYPE>(DEFAULT_LINK_PROPS);
 
   const handleCopyToClipboard = (linkString: string) => {
     copyToClipboard(`${linkString}`, "Link copied to clipboard.");
@@ -57,10 +59,17 @@ export default function LinksTable() {
       password: link.password,
       emailProtected: link.emailProtected,
     });
-    setIsLinkSheetVisible(true);
+    //wait for dropdown to close before opening the link sheet
+    setTimeout(() => {
+      setIsLinkSheetVisible(true);
+    }, 0);
   };
 
-  const handleArchiveLink = async (linkId: string, documentId: string, isArchived: boolean) => {
+  const handleArchiveLink = async (
+    linkId: string,
+    documentId: string,
+    isArchived: boolean
+  ) => {
     setIsLoading(true);
 
     const response = await fetch(`/api/links/${linkId}/archive`, {
@@ -82,18 +91,22 @@ export default function LinksTable() {
     // Update the archived link in the list of links
     mutate(
       `/api/documents/${encodeURIComponent(documentId)}/links`,
-      (links || []).map(link => link.id === linkId ? archivedLink : link),
+      (links || []).map((link) => (link.id === linkId ? archivedLink : link)),
       false
     );
 
-    toast.success(!isArchived ? "Link successfully archived" : "Link successfully reactivated");
+    toast.success(
+      !isArchived
+        ? "Link successfully archived"
+        : "Link successfully reactivated"
+    );
     setIsLoading(false);
-  }
+  };
 
   const archivedLinksCount = links
     ? links.filter((link) => link.isArchived).length
     : 0;
-  
+
   return (
     <>
       <div className="w-full sm:p-4">


### PR DESCRIPTION
This issue occurs because when the edit link button is clicked on the Actions dropdown, this dropdown does not get a chance to close before opening the edit link pop-up. 

#102 