### PR TITLE
Update Papermark logo's tracking in footer

### DIFF
--- a/components/web/footer.tsx
+++ b/components/web/footer.tsx
@@ -84,7 +84,7 @@ export default function Footer() {
       <div className="mx-auto max-w-7xl px-6 py-16 sm:py-20 lg:px-8 lg:py-12">
         <div className="xl:grid xl:grid-cols-3 xl:gap-8">
           {/* Text-based Logo */}
-          <h1 className="text-2xl font-bold  text-black dark:text-white">
+          <h1 className="text-2xl font-bold tracking-tighter text-black dark:text-white">
             Papermark
           </h1>
 


### PR DESCRIPTION
The logo in the header has 'tracking-tighter' whereas, in the footer, there's no tracking applied. Fixed this.

Before:
![bef](https://github.com/mfts/papermark/assets/62953974/7def7eed-fe58-4d04-8942-ba493da0726c)

After:
![aft](https://github.com/mfts/papermark/assets/62953974/a6168305-f5fe-41fe-be53-ec4814e07fda)



