### PR TITLE
Fixed the tracking in Client page Hero message

### DIFF
--- a/app/(static)/open-source-investors/ClientPage.tsx
+++ b/app/(static)/open-source-investors/ClientPage.tsx
@@ -81,7 +81,7 @@ export default function Dashboard({ data }: any) {
       <div className="mx-auto max-w-6xl pt-4 mb-10">
         <div className="max-w-6xl mx-auto px-4 md:px-8 sm:pt-16 pt-8 text-gray-600">
           <div className="space-y-5 max-w-4xl mx-auto text-center">
-            <h1 className="text-3xl text-gray-800 font-extrabold mx-auto sm:text-6xl max-w-3xl">
+            <h1 className="text-3xl text-gray-800 font-extrabold mx-auto sm:text-6xl max-w-3xl tracking-tighter">
               Find the next angel investor for your open-source project
             </h1>
           </div>


### PR DESCRIPTION
The client page's hero message was looking a bit odd. Added tracking-tighter here too (previously did this with the footer logo) and it looks a lot more elegant now.

There are a lot of other places as well where the font tracking needs to be tighter so as to match the overall aesthetics of the brand. Perhaps, would create another PR incorporating these updates.

![clientpage](https://github.com/mfts/papermark/assets/62953974/32af9b10-6754-40d4-8368-1403370ec9e7)
