### PR TITLE
fix: typo in /documents page

### DIFF
--- a/components/documents/stats-card.tsx
+++ b/components/documents/stats-card.tsx
@@ -32,7 +32,7 @@ export default function StatsCard() {
       active: true,
     },
     {
-      name: "Total avgerage view duration",
+      name: "Total average view duration",
       value:
         stats?.total_duration == null
           ? "46"


### PR DESCRIPTION
![Typo](https://github.com/mfts/papermark/assets/73285842/1e866ce9-8ef3-4b96-b815-0e1d4f7dfe46)

Typo in /documents page: Total avgerage view duration