### PR TITLE
Implemented changes to de-activating AI Assistant

### DIFF
--- a/pages/api/assistants/index.ts
+++ b/pages/api/assistants/index.ts
@@ -113,10 +113,11 @@ export default async function handle(
         return;
       }
 
-      // Upload the file to OpenAI
+      // get the open AI file Id from db
       const fileId = document.versions[0].fileId;
 
       if (fileId) {
+        //deleting the file from openai
         await openai.files.del(fileId);
       }
 

--- a/pages/api/assistants/index.ts
+++ b/pages/api/assistants/index.ts
@@ -75,9 +75,74 @@ export default async function handle(
     } catch (error) {
       errorhandler(error, res);
     }
+  } else if (req.method === "DELETE") {
+    // DELETE /api/assistants
+    const session = await getServerSession(req, res, authOptions);
+    if (!session) {
+      return res.status(401).end("Unauthorized");
+    }
+
+    const { documentId } = req.body as { documentId: string };
+
+    try {
+      const document = await prisma.document.findUnique({
+        where: {
+          id: documentId,
+        },
+        select: {
+          assistantEnabled: true,
+          versions: {
+            where: { isPrimary: true },
+            take: 1,
+            select: {
+              id: true,
+              fileId: true,
+              file: true,
+            },
+          },
+        },
+      });
+
+      if (!document) {
+        res.status(400).json("No document found");
+        return;
+      }
+
+      if (!document.assistantEnabled) {
+        res.status(200).json("Assistant is already disabled");
+        return;
+      }
+
+      // Upload the file to OpenAI
+      const fileId = document.versions[0].fileId;
+
+      if (fileId) {
+        await openai.files.del(fileId);
+      }
+
+      // Update the document and documentVersion in the database
+      await prisma.documentVersion.update({
+        where: {
+          id: document.versions[0].id,
+        },
+        data: {
+          fileId: null,
+          document: {
+            update: {
+              assistantEnabled: false,
+            },
+          },
+        },
+      });
+
+      res.status(200).json("Assistant Disabled");
+      return;
+    } catch (error) {
+      errorhandler(error, res);
+    }
   } else {
-    // We only allow GET and DELETE requests
-    res.setHeader("Allow", ["POST"]);
+    // We only allow POST and DELETE requests
+    res.setHeader("Allow", ["POST", "DELETE"]);
     return res.status(405).end(`Method ${req.method} Not Allowed`);
   }
 }

--- a/pages/documents/[id]/index.tsx
+++ b/pages/documents/[id]/index.tsx
@@ -293,10 +293,10 @@ export default function DocumentPage() {
                             });
 
                             toast.promise(fetchPromise, {
-                              loading: "Activating Assistant...",
+                              loading: "Deactivating Assistant...",
                               success:
-                                "Papermark Assistant successfully activated.",
-                              error: "Activation failed. Please try again.",
+                                "Papermark Assistant successfully de-activated.",
+                              error: "De-activation failed. Please try again.",
                             });
                           }}
                         >


### PR DESCRIPTION
Current AI assistant de-activation option is not working, this PR fixes it. #192 

Changes summary:

- Deleting the file from `OpenAI` after disabling the assistant, potentially leading to cost savings.
- In the `DocumentVersion` table, updating `FileId` as null.
- In the `Document` table, updating `AssistantEnabled` to false.

These changes have been locally validated and are functioning as expected.

Here's working demo: 
https://github.com/mfts/papermark/assets/39481600/916d0fd4-4b16-4b62-98ae-7b7397ea0de1

