### PR TITLE
Fix: Deleting a document containing notion throws error

### DIFF
--- a/pages/api/teams/[teamId]/documents/[id]/index.ts
+++ b/pages/api/teams/[teamId]/documents/[id]/index.ts
@@ -9,7 +9,7 @@ import { errorhandler } from "@/lib/errorHandler";
 
 export default async function handle(
   req: NextApiRequest,
-  res: NextApiResponse
+  res: NextApiResponse,
 ) {
   if (req.method === "GET") {
     // GET /api/teams/:teamId/documents/:id
@@ -71,12 +71,17 @@ export default async function handle(
             id: true,
             ownerId: true,
             file: true,
+            type: true,
           },
         },
       });
 
-      // delete the document from vercel blob
-      await del(document!.file);
+      //if it is not notion document then only delete the document from vercel blob
+      if (document?.type !== "notion") {
+        // delete the document from vercel blob
+        await del(document!.file);
+      }
+
       // delete the document from database
       await prisma.document.delete({
         where: {


### PR DESCRIPTION
This PR addresses the issue related to deleting documents when a Notion page is selected. 

The problem arises from the fact that there is no actual file being uploaded to `Vercel Blob` for Notion document uploads. Consequently, when attempting to delete the document, an error occurs as we are trying to remove it from the `Vercel blob`. To resolve this, a check has been added to ensure that we only attempt to delete files from the `Vercel blob` that are not of `Notion` type

This has been tested locally and it's working fine.