### PR TITLE
fix - fixed the Notion page URL validation bug

### DIFF
--- a/components/documents/add-document-modal.tsx
+++ b/components/documents/add-document-modal.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { usePlausible } from "next-plausible";
 import { toast } from "sonner";
 import { useTeam } from "@/context/team-context";
+import { parsePageId } from "notion-utils";
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
@@ -178,11 +179,19 @@ export function AddDocumentModal({
     event: FormEvent<HTMLFormElement>,
   ): Promise<void> => {
     event.preventDefault();
+    const validateNotionPageURL = parsePageId(notionLink);
+    // Check if it's a valid URL or not by Regx
+    const isValidURL =
+      /^(https?:\/\/)?([a-zA-Z0-9-]+\.){1,}[a-zA-Z]{2,}([a-zA-Z0-9-._~:/?#[\]@!$&'()*+,;=]+)?$/;
 
-    // Check if the file is chosen
+    // Check if the field is empty or not
     if (!notionLink) {
       toast.error("Please enter a Notion link to proceed.");
       return; // prevent form from submitting
+    }
+    if (validateNotionPageURL === null || !isValidURL.test(notionLink)) {
+      toast.error("Please enter a valid Notion link to proceed.");
+      return;
     }
 
     try {


### PR DESCRIPTION
## Description
I have successfully implemented a condition to verify whether a URL is valid or not. Moreover, I have incorporated a check to ensure that the URL is a valid Notion URL to prevent users from adding an invalid URL accidentally.

## Changes
1. Created a variable named `validateNotionPageURL` to check if it's a valid notion page URL or not.
2. Created another variable named `isValidURL` which continues some Regc to check if it's a valid  URL or not.
3. Added a `condition` to validate user-given URL

## Preview

https://github.com/mfts/papermark/assets/87828904/dfc8dbfe-d9e0-463b-b45b-398db48e31b8

## Issue

Closes #201