### PR TITLE
✨ feature - Automatic Notion file name implementation

### DIFF
--- a/components/documents/add-document-modal.tsx
+++ b/components/documents/add-document-modal.tsx
@@ -20,8 +20,6 @@ import { usePlausible } from "next-plausible";
 import { toast } from "sonner";
 import { useTeam } from "@/context/team-context";
 import { parsePageId } from "notion-utils";
-import useDocuments from "@/lib/swr/use-documents";
-import { DocumentWithLinksAndLinkCountAndViewCount } from "@/lib/types";
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
@@ -38,7 +36,6 @@ export function AddDocumentModal({
   const [currentFile, setCurrentFile] = useState<File | null>(null);
   const [notionLink, setNotionLink] = useState<string | null>(null);
   const teamInfo = useTeam();
-  const { documents } = useDocuments();
 
   const handleBrowserUpload = async (
     event: FormEvent<HTMLFormElement>,
@@ -181,23 +178,11 @@ export function AddDocumentModal({
   const createNotionFileName = () => {
     // Extract Notion file name from the URL
     const urlSegments = (notionLink as string).split("/")[3];
-
     // Remove the last hyphen along with the Notion ID
     const extractName = urlSegments.replace(/-([^/-]+)$/, "");
     const notionFileName = extractName.replaceAll("-", " ") || "Notion Link";
 
-    // Check if a Notion file with the same name already exists
-    const existingNotionFiles = documents
-      ?.filter((item) => item.type === "notion")
-      .filter((item) =>
-        item.name.includes(notionFileName),
-      ) as DocumentWithLinksAndLinkCountAndViewCount[];
-
-    if (existingNotionFiles?.length > 0) {
-      return `${notionFileName} ${existingNotionFiles.length}`;
-    } else {
-      return notionFileName;
-    }
+    return notionFileName;
   };
 
   const handleNotionUpload = async (


### PR DESCRIPTION
## Description 

**I've implemented 2 major features in this PR:**

1. **Automatic Notion Name Implementation**: When a Notion URL is pasted, a `function`  named  `createNotionFileName` will automatically extract the Notion page name and set it as the file name. This eliminates the same file name confusion.

2. **Handle same file name**: If a file with the same name already exists, the `function`  named  `createNotionFileName` will automatically append a counter ("1", "2", etc.) to the new file name, preventing overwriting and confusion.

## Changes

1.  Added a new function named `createNotionFileName` to extract name from the Notion URL and also to add a counter("1", "2", etc.)  on the name if the same name already exists.

## PR Preview


https://github.com/mfts/papermark/assets/87828904/4923fa85-41ea-4662-b7a9-9fb98df4b4a3

## Issue

Closes #212 