### PR TITLE
♻️ refactor: document upload model data will get clear after closing it

### DIFF
--- a/components/documents/add-document-modal.tsx
+++ b/components/documents/add-document-modal.tsx
@@ -246,8 +246,13 @@ export function AddDocumentModal({
     }
   };
 
+  const clearModelStates = () => {
+    currentFile !== null && setCurrentFile(null);
+    notionLink !== null && setNotionLink(null);
+  };
+
   return (
-    <Dialog>
+    <Dialog onOpenChange={clearModelStates}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
         className="text-foreground bg-transparent border-none shadow-none"


### PR DESCRIPTION
## Description
I have created a function called `clearModelState` that clears the model documents or links once the model is closed. 

The function will execute only if the Document model has previously selected a document or link.

## Changes
1. Created a function named `clearModelState` to clear model states.
2. Added conditions to the states to prevent them from being called without any data.
3. Attached the function with the `Dialog` component.

## Preview


https://github.com/mfts/papermark/assets/87828904/e29b1892-f6d6-4468-8fa4-2b6f08624f68


## Issue

Closes #217 