### PR TITLE
fix: added validation to check whether the Notion page is public or private

### DIFF
--- a/components/documents/add-document-modal.tsx
+++ b/components/documents/add-document-modal.tsx
@@ -236,7 +236,9 @@ export function AddDocumentModal({
       }
     } catch (error) {
       setUploading(false);
-      toast.error("An error occurred while processing the Notion link.");
+      toast.error(
+        "Oops! Can't access the Notion page. Please double-check it's set to 'Public'.",
+      );
       console.error(
         "An error occurred while processing the Notion link: ",
         error,

--- a/pages/api/teams/[teamId]/documents/index.ts
+++ b/pages/api/teams/[teamId]/documents/index.ts
@@ -8,6 +8,8 @@ import { identifyUser, trackAnalytics } from "@/lib/analytics";
 import { getTeamWithUsersAndDocument } from "@/lib/team/helper";
 import { errorhandler } from "@/lib/errorHandler";
 import { client } from "@/trigger";
+import notion from "@/lib/notion";
+import { parsePageId } from "notion-utils";
 
 export default async function handle(
   req: NextApiRequest,
@@ -84,7 +86,14 @@ export default async function handle(
       // Get passed type property or alternatively, the file extension and save it as the type
       const type = fileType || getExtension(name);
 
-      // You could perform some validation here
+      // Check whether the Notion page is publically accessible or not
+      try {
+        const pageId = parsePageId(fileUrl, { uuid: false });
+        // if the page isn't accessible then end the process here.
+        await notion.getPage(pageId);
+      } catch (error) {
+        return res.status(404).end("This Notion page isn't publically available.");
+      }
 
       // Save data to the database
       const document = await prisma.document.create({

--- a/pages/api/teams/[teamId]/documents/index.ts
+++ b/pages/api/teams/[teamId]/documents/index.ts
@@ -87,12 +87,16 @@ export default async function handle(
       const type = fileType || getExtension(name);
 
       // Check whether the Notion page is publically accessible or not
-      try {
-        const pageId = parsePageId(fileUrl, { uuid: false });
-        // if the page isn't accessible then end the process here.
-        await notion.getPage(pageId);
-      } catch (error) {
-        return res.status(404).end("This Notion page isn't publically available.");
+      if (type === "notion") {
+        try {
+          const pageId = parsePageId(fileUrl, { uuid: false });
+          // if the page isn't accessible then end the process here.
+          await notion.getPage(pageId);
+        } catch (error) {
+          return res
+            .status(404)
+            .end("This Notion page isn't publically available.");
+        }
       }
 
       // Save data to the database


### PR DESCRIPTION
## Description
**Added validation to check whether the Notion page is publically accessible or not.** If the Notion page is not accessible it will terminate the process and will return an error message to the user.

## Changes
1. Validation added to check if the Notion page is publically accessible before saving to the database.
2. Implemented try-catch to handle errors and prevent global error messages.
3. Updated the user-facing error message to clarify the issue properly


## Preview


https://github.com/mfts/papermark/assets/87828904/0d24c3b4-23b3-40ff-825f-8b8cdb0582e8



## Issue

Closes #221 