### PR TITLE
fix: view github link on pricing page

### DIFF
--- a/pages/pricing.tsx
+++ b/pages/pricing.tsx
@@ -239,7 +239,7 @@ export default function PricingPage() {
               <h2 className="text-3xl text-nowrap">Looking to self-host?</h2>
               <div className="space-x-2 flex items-center">
                 <Link
-                  href="https://cal.com/marcseitz/papermark"
+                  href="https://github.com/mfts/papermark"
                   target="_blank"
                   rel="noopener noreferrer"
                 >


### PR DESCRIPTION
### Description
Currently, the `View Github` button on the pricing page on the banner `Looking to self-host?` has the same calendar link for `Book a demo`.

### Changes
Changed the View Github link to this repo. https://github.com/mfts/papermark 

### Screenshot
My cursor was on View Github button

![Screenshot 2024-02-22 at 12 12 59 PM](https://github.com/mfts/papermark/assets/19797958/7645eb52-f489-4fe3-b60e-8263788f9345)

### Issue:
fixes: https://github.com/mfts/papermark/issues/304
