### PR TITLE
fix #259 Replaced headlessui components with DropdownMenu and Accordion components from the shadcn library.

### DIFF
--- a/app/(static)/deck/components/DropdownProto.tsx
+++ b/app/(static)/deck/components/DropdownProto.tsx
@@ -1,6 +1,7 @@
-import { Menu, Transition } from "@headlessui/react";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem } from "@radix-ui/react-dropdown-menu";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
-import { Fragment, Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
+import { DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 
 function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(" ");
@@ -17,58 +18,45 @@ export default function DropDown({
   option,
   setOption,
 }: DropDownProps) {
-  return (
-    <Menu as="div" className="relative block text-left w-full">
-      <div>
-        <Menu.Button className="inline-flex w-full justify-between items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-400 font-light shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue">
-          {option}
-          <ChevronDownIcon
-            className="-mr-1 ml-2 h-5 w-5 ui-open:hidden"
-            aria-hidden="true"
-          />
-          <ChevronUpIcon
-            className="-mr-1 ml-2 h-5 w-5 hidden ui-open:block"
-            aria-hidden="true"
-          />
-        </Menu.Button>
-      </div>
 
-      <Transition
-        as={Fragment}
-        enter="transition ease-out duration-100"
-        enterFrom="transform opacity-0 scale-95"
-        enterTo="transform opacity-100 scale-100"
-        leave="transition ease-in duration-75"
-        leaveFrom="transform opacity-100 scale-100"
-        leaveTo="transform opacity-0 scale-95"
-      >
-        <Menu.Items
-          className="absolute left-0 z-10 mt-2 w-full origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
-          key={option}
-        >
-          <div className="">
-            {options.map((optionItem) => (
-              <Menu.Item key={optionItem}>
-                {({ active }) => (
-                  <button
-                    onClick={() => setOption(optionItem)}
-                    className={classNames(
-                      active ? "bg-gray-100 text-gray-900" : "text-gray-700",
-                      option === optionItem ? "bg-gray-200" : "",
-                      "px-4 py-2 text-sm w-full text-left flex items-center space-x-2 justify-between",
-                    )}
-                  >
-                    <span>{optionItem}</span>
-                    {option === optionItem ? (
-                      <CheckIcon className="w-4 h-4 text-bold" />
-                    ) : null}
-                  </button>
-                )}
-              </Menu.Item>
-            ))}
-          </div>
-        </Menu.Items>
-      </Transition>
-    </Menu>
+  const [menuOpen, setMenuOpen] = useState<boolean>(false);
+  
+  const handleMenuStateChange = (open: boolean) => {
+    setMenuOpen(open);
+  };
+
+  return (
+    <DropdownMenu open={menuOpen} onOpenChange={handleMenuStateChange}>
+      <DropdownMenuTrigger asChild>
+        <button className="inline-flex w-full justify-between text-md items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-400 font-light shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue">
+          {option}
+          {menuOpen ? <ChevronUpIcon
+            className="-mr-1 ml-2 h-5 w-5"
+            aria-hidden="true"
+          /> : <ChevronDownIcon
+            className="-mr-1 ml-2 h-5 w-5"
+            aria-hidden="true"
+          />}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent onFocusOutside={(e) => e.preventDefault()} className="w-[--radix-dropdown-menu-trigger-width] mt-2 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+          {options.map((optionItem) => (
+            <DropdownMenuItem key={optionItem} className="text-gray-700 border-none hover:outline-none hover:bg-gray-100 hover:text-gray-900 ">
+                <button
+                  onClick={() => setOption(optionItem)}
+                  className={classNames(
+                    option === optionItem ? "bg-gray-200" : "",
+                    "px-4 py-2 text-sm w-full text-left flex items-center space-x-2 justify-between",
+                  )}
+                >
+                  <span>{optionItem}</span>
+                  {option === optionItem ? (
+                    <CheckIcon className="w-4 h-4 text-bold" />
+                  ) : null}
+                </button>
+            </DropdownMenuItem>
+          ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/app/(static)/investors/[slug]/page.tsx
+++ b/app/(static)/investors/[slug]/page.tsx
@@ -2,7 +2,6 @@ import Head from "next/head";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { Disclosure } from "@headlessui/react";
 import { CheckIcon } from "lucide-react";
 import { XIcon } from "lucide-react";
 import {

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
-import { ChevronDown } from "lucide-react";
+import { Minus as MinusSmallIcon, Plus as PlusSmallIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -27,13 +27,14 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline group",
         className,
       )}
       {...props}
     >
       {children}
-      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+      <PlusSmallIcon className="h-6 w-6 shrink-0 transition-transform duration-200 group-data-[state=open]:hidden" />
+      <MinusSmallIcon className="h-6 w-6 shrink-0 transition-transform duration-200 group-data-[state=closed]:hidden" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ));

--- a/components/web/alternatives/dropdownproto.tsx
+++ b/components/web/alternatives/dropdownproto.tsx
@@ -1,7 +1,8 @@
-import { Dispatch, Fragment, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 
-import { Menu, Transition } from "@headlessui/react";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
 
 function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(" ");
@@ -18,58 +19,43 @@ export default function DropDown({
   option,
   setOption,
 }: DropDownProps) {
+  const [menuOpen, setMenuOpen] = useState<boolean>(false);
+  
+  const handleMenuStateChange = (open: boolean) => {
+    setMenuOpen(open);
+  };
   return (
-    <Menu as="div" className="relative block w-full text-left">
-      <div>
-        <Menu.Button className="inline-flex w-full items-center justify-between rounded-md border border-black bg-white px-4 py-2 text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none">
+    <DropdownMenu open={menuOpen} onOpenChange={handleMenuStateChange}>
+      <DropdownMenuTrigger asChild>
+        <Button className="inline-flex w-full items-center justify-between rounded-md border border-black font-normal text-md bg-white px-4 py-2 text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none">
           {option}
-          <ChevronDownIcon
-            className="-mr-1 ml-2 h-5 w-5 ui-open:hidden"
+          {menuOpen ? <ChevronUpIcon
+            className="-mr-1 ml-2 h-5 w-5"
             aria-hidden="true"
-          />
-          <ChevronUpIcon
-            className="-mr-1 ml-2 hidden h-5 w-5 ui-open:block"
+          /> : <ChevronDownIcon
+            className="-mr-1 ml-2 h-5 w-5"
             aria-hidden="true"
-          />
-        </Menu.Button>
-      </div>
-
-      <Transition
-        as={Fragment}
-        enter="transition ease-out duration-100"
-        enterFrom="transform opacity-0 scale-95"
-        enterTo="transform opacity-100 scale-100"
-        leave="transition ease-in duration-75"
-        leaveFrom="transform opacity-100 scale-100"
-        leaveTo="transform opacity-0 scale-95"
-      >
-        <Menu.Items
-          className="absolute left-0 z-10 mt-2 w-full origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
-          key={option}
-        >
-          <div className="">
-            {options.map((optionItem) => (
-              <Menu.Item key={optionItem}>
-                {({ active }) => (
-                  <button
-                    onClick={() => setOption(optionItem)}
-                    className={classNames(
-                      active ? "bg-gray-100 text-gray-900" : "text-gray-700",
-                      option === optionItem ? "bg-gray-200" : "",
-                      "flex w-full items-center justify-between space-x-2 px-4 py-2 text-left text-sm",
-                    )}
-                  >
-                    <span>{optionItem}</span>
-                    {option === optionItem ? (
-                      <CheckIcon className="text-bold h-4 w-4" />
-                    ) : null}
-                  </button>
-                )}
-              </Menu.Item>
-            ))}
-          </div>
-        </Menu.Items>
-      </Transition>
-    </Menu>
+          />}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent onFocusOutside={(e) => e.preventDefault()} className="w-[--radix-dropdown-menu-trigger-width] p-0 mt-2 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" key={option}>
+          {options.map((optionItem) => (
+            <DropdownMenuItem key={optionItem} className="text-gray-700 border-none hover:outline-none p-0 hover:bg-gray-100 hover:text-gray-900">
+                <button
+                  onClick={() => setOption(optionItem)}
+                  className={classNames(
+                    option === optionItem ? "bg-gray-200" : "",
+                    "flex w-full items-center justify-between space-x-2 px-4 py-2 text-left text-sm",
+                  )}
+                >
+                  <span>{optionItem}</span>
+                  {option === optionItem ? (
+                    <CheckIcon className="w-4 h-4 text-bold" />
+                  ) : null}
+                </button>
+            </DropdownMenuItem>
+          ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/components/web/faq.tsx
+++ b/components/web/faq.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { Disclosure } from "@headlessui/react";
-import { Minus as MinusSmallIcon, Plus as PlusSmallIcon } from "lucide-react";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 
 const faqs = [
   {
@@ -44,36 +43,18 @@ const faqs = [
 export default function Faq() {
   return (
     <div className="">
-      <dl className="mt-10 space-y-6 divide-y divide-gray-800/10 ">
+      <dl className="mt-10 divide-y divide-gray-800/10 ">
         {faqs.map((faq) => (
-          <Disclosure as="div" key={faq.question} className="pt-6">
-            {({ open }) => (
-              <>
-                <dt>
-                  <Disclosure.Button className="flex w-full items-start justify-between text-left text-gray-800">
-                    <span className="text-balance  font-medium leading-7">
-                      {faq.question}
-                    </span>
-                    <span className="ml-6 flex h-7 items-center">
-                      {open ? (
-                        <MinusSmallIcon
-                          className="h-6 w-6"
-                          aria-hidden="true"
-                        />
-                      ) : (
-                        <PlusSmallIcon className="h-6 w-6" aria-hidden="true" />
-                      )}
-                    </span>
-                  </Disclosure.Button>
-                </dt>
-                <Disclosure.Panel as="dd" className="mt-2 pr-12">
-                  <p className="text-balance leading-7 text-gray-500">
-                    {faq.answer}
-                  </p>
-                </Disclosure.Panel>
-              </>
-            )}
-          </Disclosure>
+          <Accordion key={faq.question} type="single" collapsible>
+            <AccordionItem value={faq.question} className="py-2 border-none">
+              <AccordionTrigger className="text-left text-gray-800 dark:text-gray-200 text-balance font-medium leading-7 hover:no-underline">
+                {faq.question}
+              </AccordionTrigger>
+              <AccordionContent className="text-base leading-7 text-gray-500">
+                {faq.answer}
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
         ))}
       </dl>
     </div>

--- a/pages/ai.tsx
+++ b/pages/ai.tsx
@@ -1,15 +1,12 @@
 import Head from "next/head";
 import Link from "next/link";
 
-import { Disclosure } from "@headlessui/react";
 import {
   RefreshCw as ArrowPathIcon,
   GitPullRequestArrow as CloudArrowUpIcon,
   Settings as Cog6ToothIcon,
   Fingerprint as FingerPrintIcon,
   Lock as LockClosedIcon,
-  Minus as MinusSmallIcon,
-  Plus as PlusSmallIcon,
   HardDrive as ServerIcon,
 } from "lucide-react";
 
@@ -19,6 +16,7 @@ import Footer from "@/components/web/footer";
 import Navbar from "@/components/web/navbar";
 
 import { classNames } from "@/lib/utils";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 
 const scrollDown = () => {
   window.scrollBy({
@@ -472,39 +470,18 @@ export default function Home() {
                 <h2 className="text-2xl font-bold leading-10 tracking-tight text-white">
                   Frequently asked questions
                 </h2>
-                <dl className="mt-10 space-y-6 divide-y divide-gray-900/10 dark:divide-gray-200/10">
+                <dl className="mt-10 divide-y divide-gray-900/10 dark:divide-gray-200/10">
                   {faqs.map((faq) => (
-                    <Disclosure as="div" key={faq.question} className="pt-6">
-                      {({ open }) => (
-                        <>
-                          <dt>
-                            <Disclosure.Button className="flex w-full items-start justify-between text-left text-gray-900 dark:text-gray-200">
-                              <span className="text-base font-semibold leading-7">
-                                {faq.question}
-                              </span>
-                              <span className="ml-6 flex h-7 items-center">
-                                {open ? (
-                                  <MinusSmallIcon
-                                    className="h-6 w-6"
-                                    aria-hidden="true"
-                                  />
-                                ) : (
-                                  <PlusSmallIcon
-                                    className="h-6 w-6"
-                                    aria-hidden="true"
-                                  />
-                                )}
-                              </span>
-                            </Disclosure.Button>
-                          </dt>
-                          <Disclosure.Panel as="dd" className="mt-2 pr-12">
-                            <p className="text-base leading-7 text-gray-500">
-                              {faq.answer}
-                            </p>
-                          </Disclosure.Panel>
-                        </>
-                      )}
-                    </Disclosure>
+                    <Accordion key={faq.question} type="single" collapsible>
+                    <AccordionItem value={faq.question} className="py-2 border-none">
+                      <AccordionTrigger className="text-left text-gray-900 dark:text-gray-200 text-base font-semibold leading-7 hover:no-underline">
+                        {faq.question}
+                      </AccordionTrigger>
+                      <AccordionContent className="text-base leading-7 text-gray-500">
+                        {faq.answer}
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
                   ))}
                 </dl>
               </div>

--- a/pages/share-notion-page.tsx
+++ b/pages/share-notion-page.tsx
@@ -1,7 +1,6 @@
 import Head from "next/head";
 import Link from "next/link";
 
-import { Disclosure } from "@headlessui/react";
 import {
   RefreshCw as ArrowPathIcon,
   GitPullRequestArrow as CloudArrowUpIcon,
@@ -15,6 +14,7 @@ import {
 
 import Footer from "@/components/web/footer";
 import Navbar from "@/components/web/navbar";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 
 const features = [
   {
@@ -249,39 +249,18 @@ export default function Home() {
                 <h2 className="text-2xl font-bold leading-10 tracking-tight text-white">
                   Frequently asked questions
                 </h2>
-                <dl className="mt-10 space-y-6 divide-y divide-gray-900/10 dark:divide-gray-200/10">
+                <dl className="mt-10 divide-y divide-gray-900/10 dark:divide-gray-200/10">
                   {faqs.map((faq) => (
-                    <Disclosure as="div" key={faq.question} className="pt-6">
-                      {({ open }) => (
-                        <>
-                          <dt>
-                            <Disclosure.Button className="flex w-full items-start justify-between text-left text-gray-900 dark:text-gray-200">
-                              <span className="text-base font-semibold leading-7">
-                                {faq.question}
-                              </span>
-                              <span className="ml-6 flex h-7 items-center">
-                                {open ? (
-                                  <MinusSmallIcon
-                                    className="h-6 w-6"
-                                    aria-hidden="true"
-                                  />
-                                ) : (
-                                  <PlusSmallIcon
-                                    className="h-6 w-6"
-                                    aria-hidden="true"
-                                  />
-                                )}
-                              </span>
-                            </Disclosure.Button>
-                          </dt>
-                          <Disclosure.Panel as="dd" className="mt-2 pr-12">
-                            <p className="text-base leading-7 text-gray-500">
-                              {faq.answer}
-                            </p>
-                          </Disclosure.Panel>
-                        </>
-                      )}
-                    </Disclosure>
+                    <Accordion key={faq.question} type="single" collapsible>
+                    <AccordionItem value={faq.question} className="py-2 border-none">
+                      <AccordionTrigger className="text-left text-gray-900 dark:text-gray-200 text-base font-semibold leading-7 hover:no-underline">
+                        {faq.question}
+                      </AccordionTrigger>
+                      <AccordionContent className="text-base leading-7 text-gray-500">
+                        {faq.answer}
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
                   ))}
                 </dl>
               </div>


### PR DESCRIPTION
fix #259 
DropdownMenu from shadcn
<img width="377" alt="community" src="https://github.com/user-attachments/assets/d65db625-41c0-4c77-96b3-a20e50444b9d">
<img width="397" alt="docsend" src="https://github.com/user-attachments/assets/43677756-1b3d-4de6-bb0f-a1ba9187c6ce">

Accordion component from shadcn (Preserving the minus and plus icon)

<img width="593" alt="disclosure" src="https://github.com/user-attachments/assets/b2a7073a-6440-40d7-a7a5-2dcf54675b83">
