### PR TITLE
fix: made the dataroom route protected in case user hasn't opted for any trial or plan

### DIFF
--- a/pages/datarooms/index.tsx
+++ b/pages/datarooms/index.tsx
@@ -21,9 +21,12 @@ import { usePlan } from "@/lib/swr/use-billing";
 import useDatarooms from "@/lib/swr/use-datarooms";
 import useLimits from "@/lib/swr/use-limits";
 import { daysLeft } from "@/lib/utils";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
 
 export default function DataroomsPage() {
   const { datarooms } = useDatarooms();
+  const router = useRouter();
   const { plan, trial } = usePlan();
   const { limits } = useLimits();
 
@@ -35,6 +38,10 @@ export default function DataroomsPage() {
   const isTrialDatarooms = trial === "drtrial";
   const canCreateUnlimitedDatarooms =
     isDatarooms || (isBusiness && numDatarooms < limitDatarooms);
+  
+  useEffect(()=>{
+    if(trial == null) router.push('/documents')
+  },[trial])  
 
   return (
     <AppLayout>


### PR DESCRIPTION
Solution - Made a check of trial variable from usePlan() hook to see if its null or not,if its null,navigate the user back to /documents page