### PR TITLE
Fix/made the dataroom route protected in case user hasn't opted for any trial or plan

### DIFF
--- a/pages/datarooms/index.tsx
+++ b/pages/datarooms/index.tsx
@@ -39,9 +39,6 @@ export default function DataroomsPage() {
   const canCreateUnlimitedDatarooms =
     isDatarooms || (isBusiness && numDatarooms < limitDatarooms);
 
-    console.log(plan,trial);
-    
-
     useEffect(()=>{
       if(trial == null && plan == 'free') router.push('/documents')
     },[trial,plan])  

--- a/pages/datarooms/index.tsx
+++ b/pages/datarooms/index.tsx
@@ -21,11 +21,14 @@ import { usePlan } from "@/lib/swr/use-billing";
 import useDatarooms from "@/lib/swr/use-datarooms";
 import useLimits from "@/lib/swr/use-limits";
 import { daysLeft } from "@/lib/utils";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 export default function DataroomsPage() {
   const { datarooms } = useDatarooms();
   const { plan, trial } = usePlan();
   const { limits } = useLimits();
+  const router = useRouter()
 
   const numDatarooms = datarooms?.length ?? 0;
   const limitDatarooms = limits?.datarooms ?? 1;
@@ -35,6 +38,13 @@ export default function DataroomsPage() {
   const isTrialDatarooms = trial === "drtrial";
   const canCreateUnlimitedDatarooms =
     isDatarooms || (isBusiness && numDatarooms < limitDatarooms);
+
+    console.log(plan,trial);
+    
+
+    useEffect(()=>{
+      if(trial == null && plan == 'free') router.push('/documents')
+    },[trial,plan])  
 
   return (
     <AppLayout>


### PR DESCRIPTION
Fixes issue #587 
 Ensuring that if user hasnt opted for any plan that is he is having free plan and no trial as well then no access to this dataroom route.
If user has lets say business plan but no trial at the moment,he can visit this dataroom page,he shudnt be redirected 