### PR TITLE
Handle Duplicate Data Room Error and Display Subscription Modal When Limit Reached

### DIFF
--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -36,7 +36,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
+      "text-2xl font-semibold leading-snug tracking-tight",
       className,
     )}
     {...props}


### PR DESCRIPTION
This PR fix the issue: https://github.com/mfts/papermark/issues/652

- Fix error mesage
- Show update plan modal when limit reached
- The data room box name appears cut off at the bottom; this has also been fixed.

![image](https://github.com/user-attachments/assets/a0f1bfa2-7678-45e0-a280-d19f64272ce5)
![image](https://github.com/user-attachments/assets/c83c7a5f-379b-49aa-9bd0-8d01af654f33)

If we directly show the "Upgrade Plan" button, users will never encounter an error. However, if we allow them to duplicate the data room even after reaching the limit, the correct error message will now be displayed instead of not showing right error message previously.