### PR TITLE
feat: make agreement name customizable

### DIFF
--- a/components/links/link-sheet/agreement-panel/index.tsx
+++ b/components/links/link-sheet/agreement-panel/index.tsx
@@ -162,7 +162,7 @@ export default function AgreementSheet({
         <form className="flex grow flex-col" onSubmit={handleSubmit}>
           <div className="flex-grow space-y-6">
             <div className="w-full space-y-2">
-              <Label htmlFor="name">Name</Label>
+              <Label htmlFor="name">Display name</Label>
               <Input
                 className="flex w-full rounded-md border-0 bg-background py-1.5 text-foreground shadow-sm ring-1 ring-inset ring-input placeholder:text-muted-foreground focus:ring-2 focus:ring-inset focus:ring-gray-400 sm:text-sm sm:leading-6"
                 id="name"

--- a/components/view/access-form/agreement-section.tsx
+++ b/components/view/access-form/agreement-section.tsx
@@ -12,12 +12,14 @@ export default function AgreementSection({
   data,
   setData,
   agreementContent,
+  agreementName,
   brand,
   useCustomAccessForm,
 }: {
   data: DEFAULT_ACCESS_FORM_TYPE;
   setData: Dispatch<SetStateAction<DEFAULT_ACCESS_FORM_TYPE>>;
   agreementContent: string;
+  agreementName: string;
   brand?: Partial<Brand> | Partial<DataroomBrand> | null;
   useCustomAccessForm?: boolean;
 }) {
@@ -55,9 +57,7 @@ export default function AgreementSection({
                   : "white",
             }}
           >
-            {useCustomAccessForm
-              ? "Privacy Policy"
-              : "Non-Disclosure Agreement"}
+            {agreementName}
           </a>
           .
         </label>

--- a/components/view/access-form/index.tsx
+++ b/components/view/access-form/index.tsx
@@ -35,6 +35,7 @@ export default function AccessForm({
   requireEmail,
   requirePassword,
   requireAgreement,
+  agreementName,
   agreementContent,
   requireName,
   isLoading,
@@ -50,6 +51,7 @@ export default function AccessForm({
   requireEmail: boolean;
   requirePassword: boolean;
   requireAgreement?: boolean;
+  agreementName?: string;
   agreementContent?: string;
   requireName?: boolean;
   isLoading: boolean;
@@ -128,10 +130,11 @@ export default function AccessForm({
             {requirePassword ? (
               <PasswordSection {...{ data, setData, brand }} />
             ) : null}
-            {requireAgreement && agreementContent ? (
+            {requireAgreement && agreementContent && agreementName ? (
               <AgreementSection
                 {...{ data, setData, brand }}
                 agreementContent={agreementContent}
+                agreementName={agreementName}
                 useCustomAccessForm={useCustomAccessForm}
               />
             ) : null}

--- a/components/view/dataroom/dataroom-view.tsx
+++ b/components/view/dataroom/dataroom-view.tsx
@@ -308,6 +308,7 @@ export default function DataroomView({
         requireEmail={emailProtected}
         requirePassword={!!linkPassword}
         requireAgreement={enableAgreement!}
+        agreementName={link.agreement?.name}
         agreementContent={link.agreement?.content}
         requireName={link.agreement?.requireName}
         isLoading={isLoading}

--- a/components/view/document-view.tsx
+++ b/components/view/document-view.tsx
@@ -246,6 +246,7 @@ export default function DocumentView({
         requireEmail={emailProtected}
         requirePassword={!!linkPassword}
         requireAgreement={enableAgreement!}
+        agreementName={link.agreement?.name}
         agreementContent={link.agreement?.content}
         requireName={link.agreement?.requireName}
         isLoading={isLoading}


### PR DESCRIPTION
fixes #651 

I have utilised the name field of the agreement to show instead of NDA or privacy policy which were hardcoded. I have tested locally when the linkType was DATAROOM.
![image](https://github.com/user-attachments/assets/e8bfa7a4-77e8-4730-a0f0-575e4059f460)

but for linkType as DOCUMENT, I am unable to do so as I am encountering an error on viewing an uploaded document 
![image](https://github.com/user-attachments/assets/745df489-7dac-479b-ba1a-253d38ab3d69)


this error is not on production, I am still trying to figure what might have caused this.