### PR TITLE
fix: remove black color for subheading in dataroom groups page

### DIFF
--- a/pages/datarooms/[id]/groups/index.tsx
+++ b/pages/datarooms/[id]/groups/index.tsx
@@ -58,9 +58,7 @@ export default function DataroomGroupPage() {
           <div className="grid gap-5">
             <div className="flex flex-wrap justify-between gap-6">
               <div className="flex items-center gap-x-2">
-                <h1 className="text-xl font-semibold tracking-tight text-black">
-                  Groups
-                </h1>
+                <h1 className="text-xl font-semibold tracking-tight">Groups</h1>
               </div>
               <div className="flex w-full flex-wrap items-center gap-3 sm:w-auto">
                 <ButtonComponent />


### PR DESCRIPTION
Fixes #692

<img width="1132" alt="Screenshot 2024-10-08 at 9 27 17 PM" src="https://github.com/user-attachments/assets/7ab63da4-ba14-421d-9215-f013154aa5e7">
