### PR TITLE
Update Node.js version requirement to >= 18.17.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Papermark is the open-source document sharing alternative to DocSend with built-
 
 Here's what you need to be able to run Papermark:
 
-- Node.js (version >= 18)
+- Node.js (version >= 18.17.0)
 - PostgreSQL Database
 - Blob storage (currently [AWS S3](https://aws.amazon.com/s3/) or [Vercel Blob](https://vercel.com/storage/blob))
 - [Resend](https://resend.com) (for sending emails)


### PR DESCRIPTION
This pull request updates the "Prerequisites" section of the README to specify the correct Node.js version requirement for Next.js. The current README mentions "Node.js (version >= 18)," which can lead to compatibility issues for users running earlier versions of Node 18.

fixes #704 
