### PR TITLE
fix: add proper spacing to add-document-button

### DIFF
--- a/pages/documents/index.tsx
+++ b/pages/documents/index.tsx
@@ -26,22 +26,22 @@ export default function Documents() {
     <AppLayout>
       <div className="sticky top-0 z-50 bg-white p-4 pb-0 dark:bg-gray-900 sm:mx-4 sm:pt-8">
         <section className="mb-4 flex items-center justify-between space-x-2 sm:space-x-0 md:mb-8 lg:mb-12">
-          <div className="space-y-1">
+          <div className="space-y-0 sm:space-y-1">
             <h2 className="text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
               All Documents
             </h2>
-            <p className="text-xs text-muted-foreground sm:text-sm">
+            <p className="text-xs text-muted-foreground leading-4 sm:leading-none sm:text-sm">
               Manage all your documents in one place.
             </p>
           </div>
           <div className="flex items-center gap-x-1">
             <AddDocumentModal>
               <Button
-                className="group flex flex-1 items-center justify-start gap-x-2 sm:gap-x-3 px-3 leading-4 sm:leading-none text-left"
+                className="group flex flex-1 items-center justify-start whitespace-nowrap gap-x-1 sm:gap-x-3 px-1 sm:px-3 text-left"
                 title="Add New Document"
               >
                 <PlusIcon className="h-5 w-5 shrink-0" aria-hidden="true" />
-                <span>Add New Document</span>
+                <span className=" text-xs sm:text-base">Add New Document</span>
               </Button>
             </AddDocumentModal>
             <AddFolderModal>

--- a/pages/documents/index.tsx
+++ b/pages/documents/index.tsx
@@ -25,7 +25,7 @@ export default function Documents() {
   return (
     <AppLayout>
       <div className="sticky top-0 z-50 bg-white p-4 pb-0 dark:bg-gray-900 sm:mx-4 sm:pt-8">
-        <section className="mb-4 flex items-center justify-between md:mb-8 lg:mb-12">
+        <section className="mb-4 flex items-center justify-between space-x-2 sm:space-x-0 md:mb-8 lg:mb-12">
           <div className="space-y-1">
             <h2 className="text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
               All Documents
@@ -37,7 +37,7 @@ export default function Documents() {
           <div className="flex items-center gap-x-1">
             <AddDocumentModal>
               <Button
-                className="group flex flex-1 items-center justify-start gap-x-3 px-3 text-left"
+                className="group flex flex-1 items-center justify-start gap-x-2 sm:gap-x-3 px-3 leading-4 sm:leading-none text-left"
                 title="Add New Document"
               >
                 <PlusIcon className="h-5 w-5 shrink-0" aria-hidden="true" />


### PR DESCRIPTION
fixes #752 
 This PR addresses the inconsistent spacing on the https://app.papermark.io/documents on mobile view. Adjustments have been made to ensure a more uniform and visually appealing layout.

![Screenshot 2024-10-11 161833](https://github.com/user-attachments/assets/66c0e111-77df-4311-9a9d-e0ec484a1f1a)

![Screenshot 2024-10-11 170423](https://github.com/user-attachments/assets/9e544887-4326-4b54-b24c-ea4de01fdace)
