### PR TITLE
Added screenshot for side quest in oss.gg hackathon

### DIFF
--- a/oss-gg/5-follow-twitter-x.md
+++ b/oss-gg/5-follow-twitter-x.md
@@ -25,4 +25,6 @@ Your turn 👇
 
 » 10-October-2024 by Piyush Mishra [@PiyushXmishra](https://x.com/Piyuxh1501)
 
+» 12-October-2024 by Hiren Dhola [@HIRENDHOLA1](https://x.com/HIRENDHOLA1)
+
 ---


### PR DESCRIPTION
Fixes #795 
This PR fixes issue #795 by adding a screenshot for the side quest in the oss.gg hackathon. The screenshot shows proof of the completed task as per the challenge guidelines.

Screenshot Path:
![image](https://github.com/user-attachments/assets/205d184d-0eb4-47bc-aa45-e8eb4b175959)
