### PR TITLE
Feat: papermark logo redirect to /document

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -29,6 +29,7 @@ import { AddTeamModal } from "./teams/add-team-modal";
 import SelectTeam from "./teams/select-team";
 import { Progress } from "./ui/progress";
 import { ScrollArea } from "./ui/scroll-area";
+import Link from "next/link";
 
 export default function Sidebar() {
   return (
@@ -156,7 +157,7 @@ export const SidebarComponent = ({ className }: { className?: string }) => {
 
         <div className="flex h-16 shrink-0 items-center space-x-3">
           <p className="flex items-center text-2xl font-bold tracking-tighter text-black dark:text-white">
-            Papermark{" "}
+        <Link href="/documents">  Papermark{" "}</Link> 
             {userPlan && userPlan != "free" ? (
               <span className="ml-4 rounded-full bg-background px-2.5 py-1 text-xs tracking-normal text-foreground ring-1 ring-gray-800">
                 {userPlan.charAt(0).toUpperCase() + userPlan.slice(1)}


### PR DESCRIPTION
Fixes: #772 

This PR implements a feature where clicking on the Papermark logo now redirects the user to the /document.This change improves navigation by providing a direct link to the document section, enhancing user accessibility.


Changes:
    Updated the logo's link to point to /document.
    Ensured that the routing is correctly handled without breaking any other functionality.