### PR TITLE
fix: the unscrollability across the /settings/branding page across navbar-and-frontpage

### DIFF
--- a/pages/settings/branding.tsx
+++ b/pages/settings/branding.tsx
@@ -351,7 +351,7 @@ export default function Branding() {
                   <TabsContent value="account">
                     <div className="flex justify-center">
                       <div className="relative h-[450px] w-[698px] rounded-lg bg-gray-200 p-1 shadow-lg">
-                        <div className="relative h-[442px] overflow-hidden rounded-lg bg-gray-100">
+                      <div className="relative h-[442px] lg:overflow-x-hidden overflow-x-auto rounded-lg bg-gray-100">
                           <div className="mx-auto flex h-7 items-center justify-center">
                             <div className="pointer-events-none absolute left-3">
                               <div className="flex flex-row flex-nowrap justify-start">
@@ -425,7 +425,7 @@ export default function Branding() {
                   <TabsContent value="password">
                     <div className="flex justify-center">
                       <div className="relative h-[450px] w-[698px] rounded-lg bg-gray-200 p-1 shadow-lg">
-                        <div className="relative h-[442px] overflow-hidden rounded-lg bg-gray-100">
+                        <div className="relative h-[442px] lg:overflow-x-hidden overflow-x-auto rounded-lg bg-gray-100">
                           <div className="mx-auto flex h-7 items-center justify-center">
                             <div className="pointer-events-none absolute left-3">
                               <div className="flex flex-row flex-nowrap justify-start">


### PR DESCRIPTION
The Problem : 

on smaller devices on the branding page the preview of the navbar and frontpage doesn't seem to be scroll showing only half the full image that's displayed on larger devices

![beforepp](https://github.com/user-attachments/assets/b2460244-29ab-4ca1-94ea-2f0385bc4e39)

it is unscrollable, doesnt let the user see the entire image 

What does this PR do : 
 
it fixes this problem and makes both the navbar and frontpage scrollable on smaller devices 
users can effectively scroll across the image even on smaller devices enabling them to see the full pic

![mm](https://github.com/user-attachments/assets/2039ab7f-63e2-4fb2-947c-13b67369ac79)

![afpp3](https://github.com/user-attachments/assets/db9e024d-b7df-4f80-b152-76e14b08f7df)

ps: couldn't capture a video because of my system but i assure this works