### PR TITLE
fix: disabled to create links & duplicate documents due to free version limit

### DIFF
--- a/components/documents/document-card.tsx
+++ b/components/documents/document-card.tsx
@@ -33,7 +33,7 @@ import { DocumentWithLinksAndLinkCountAndViewCount } from "@/lib/types";
 import { cn, nFormatter, timeAgo } from "@/lib/utils";
 import { fileIcon } from "@/lib/utils/get-file-icon";
 import { useCopyToClipboard } from "@/lib/utils/use-copy-to-clipboard";
-
+import useLimits from "@/lib/swr/use-limits";
 import { AddToDataroomModal } from "./add-document-to-dataroom-modal";
 import { MoveToFolderModal } from "./move-folder-modal";
 
@@ -62,6 +62,7 @@ export default function DocumentsCard({
   const [moveFolderOpen, setMoveFolderOpen] = useState<boolean>(false);
   const [addDataroomOpen, setAddDataroomOpen] = useState<boolean>(false);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const { canAddDocuments } = useLimits();
 
   /** current folder name */
   const currentFolderPath = router.query.name as string[] | undefined;
@@ -279,7 +280,7 @@ export default function DocumentsCard({
                 <FolderInputIcon className="mr-2 h-4 w-4" />
                 Move to folder
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={(e) => handleDuplicateDocument(e)}>
+              <DropdownMenuItem onClick={(e) => handleDuplicateDocument(e)} disabled={!canAddDocuments}>
                 <Layers2Icon className="mr-2 h-4 w-4" />
                 Duplicate document
               </DropdownMenuItem>

--- a/components/documents/document-card.tsx
+++ b/components/documents/document-card.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
 
 import { TeamContextType } from "@/context/team-context";
-import { useLimits } from "@/ee/limits/swr-handler";
 import {
   BetweenHorizontalStartIcon,
   FolderInputIcon,
@@ -33,11 +32,12 @@ import {
 
 import { usePlan } from "@/lib/swr/use-billing";
 import useDatarooms from "@/lib/swr/use-datarooms";
+import useLimits from "@/lib/swr/use-limits";
 import { DocumentWithLinksAndLinkCountAndViewCount } from "@/lib/types";
 import { cn, nFormatter, timeAgo } from "@/lib/utils";
 import { fileIcon } from "@/lib/utils/get-file-icon";
 import { useCopyToClipboard } from "@/lib/utils/use-copy-to-clipboard";
-import useLimits from "@/lib/swr/use-limits";
+
 import { UpgradePlanModal } from "../billing/upgrade-plan-modal";
 import { AddDataroomModal } from "../datarooms/add-dataroom-modal";
 import { DataroomTrialModal } from "../datarooms/dataroom-trial-modal";
@@ -331,7 +331,10 @@ export default function DocumentsCard({
                 <FolderInputIcon className="mr-2 h-4 w-4" />
                 Move to folder
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={(e) => handleDuplicateDocument(e)} disabled={!canAddDocuments}>
+              <DropdownMenuItem
+                onClick={(e) => handleDuplicateDocument(e)}
+                disabled={!canAddDocuments}
+              >
                 <Layers2Icon className="mr-2 h-4 w-4" />
                 Duplicate document
               </DropdownMenuItem>
@@ -376,7 +379,7 @@ export default function DocumentsCard({
           documentName={prismaDocument.name}
         />
       ) : null}
-      
+
       {trialModalOpen ? (
         <DataroomTrialModal
           openModal={trialModalOpen}

--- a/components/links/links-table.tsx
+++ b/components/links/links-table.tsx
@@ -412,6 +412,7 @@ export default function LinksTable({
                                   Edit Link
                                 </DropdownMenuItem>
                                 <DropdownMenuItem
+                                  disabled={!canAddLinks}
                                   onClick={() => handleDuplicateLink(link)}
                                 >
                                   Duplicate Link

--- a/components/links/links-table.tsx
+++ b/components/links/links-table.tsx
@@ -7,7 +7,8 @@ import { DocumentVersion } from "@prisma/client";
 import { BoxesIcon, EyeIcon, LinkIcon, Settings2Icon } from "lucide-react";
 import { toast } from "sonner";
 import { mutate } from "swr";
-
+import useLimits from "@/lib/swr/use-limits";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { Button } from "@/components/ui/button";
 import {
   Collapsible,
@@ -59,6 +60,8 @@ export default function LinksTable({
   const router = useRouter();
   const { plan } = usePlan();
   const teamInfo = useTeam();
+
+  const { canAddLinks } = useLimits();
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isLinkSheetVisible, setIsLinkSheetVisible] = useState<boolean>(false);
@@ -169,6 +172,24 @@ export default function LinksTable({
 
     toast.success("Link duplicated successfully");
     setIsLoading(false);
+  };
+
+  const AddLinkButton = () => {
+    if (!canAddLinks) {
+      return (
+        <UpgradePlanModal clickedPlan="Pro" trigger={"limit_add_link"}>
+          <Button>
+            Upgrade to Create Link
+          </Button>
+        </UpgradePlanModal>
+      );
+    } else {
+      return (
+        <Button onClick={() => setIsLinkSheetVisible(true)}>
+          Create link to share
+        </Button>
+      );
+    }
   };
 
   const handleArchiveLink = async (
@@ -434,9 +455,7 @@ export default function LinksTable({
                         </div>
                       </div>
                       <p>No links found for this {targetType.toLowerCase()}</p>
-                      <Button onClick={() => setIsLinkSheetVisible(true)}>
-                        Create link to share
-                      </Button>
+                     <AddLinkButton/>
                     </div>
                   </TableCell>
                 </TableRow>


### PR DESCRIPTION
Fixes #854
Added condition with the help of `useLimits` hooks to restrict creating of links on free version in links table.
![image](https://github.com/user-attachments/assets/deb12fc4-a03d-44fa-a897-57d7cedae5cf)

Disabled duplicate document option
![image](https://github.com/user-attachments/assets/8af4a854-845a-48e2-9dcb-938f52d26782)

Links Table
![image](https://github.com/user-attachments/assets/8d56e9c8-e269-484d-9bb7-5b73e0f70e6a)
