### PR TITLE
fix: Keep state in dataroom view between document and dataroom view #783

### DIFF
--- a/components/view/DataroomViewer.tsx
+++ b/components/view/DataroomViewer.tsx
@@ -76,6 +76,8 @@ export default function DataroomViewer({
   setDocumentData,
   setDataroomVerified,
   isPreview,
+  folderId,
+  setFolderId
 }: {
   brand: Partial<DataroomBrand>;
   viewId?: string;
@@ -89,8 +91,10 @@ export default function DataroomViewer({
   setDocumentData: React.Dispatch<React.SetStateAction<TDocumentData | null>>;
   setDataroomVerified: React.Dispatch<React.SetStateAction<boolean>>;
   isPreview?: boolean;
+  folderId: string | null;
+  setFolderId: React.Dispatch<React.SetStateAction<string | null>>;
 }) {
-  const [folderId, setFolderId] = useState<string | null>(null);
+  // const [folderId, setFolderId] = useState<string | null>(null);
   const { documents, folders } = dataroom as {
     documents: DataroomDocument[];
     folders: DataroomFolder[];

--- a/components/view/dataroom/dataroom-view.tsx
+++ b/components/view/dataroom/dataroom-view.tsx
@@ -110,6 +110,7 @@ export default function DataroomView({
   const plausible = usePlausible();
   const analytics = useAnalytics();
   const router = useRouter();
+  const [folderId, setFolderId] = useState<string | null>(null);
 
   const didMount = useRef<boolean>(false);
   const [submitted, setSubmitted] = useState<boolean>(false);
@@ -442,6 +443,8 @@ export default function DataroomView({
           setDocumentData={setDocumentData}
           setViewType={setViewType}
           setDataroomVerified={setDataroomVerified}
+          folderId={folderId}
+          setFolderId={setFolderId}
         />
       </div>
     );


### PR DESCRIPTION
Currently, the state of the folderId is getting resetted when we are moving from one view to another view.

Solution: I lifted the state of the folderId to it's parent component.

[Screencast from 13-10-24 11:40:10 PM IST.webm](https://github.com/user-attachments/assets/7980f069-cbfe-42ad-954c-efda8f4165f5)
