### PR TITLE
fix: Keep state in dataroom view between document and dataroom view #783

### DIFF
--- a/components/view/DataroomViewer.tsx
+++ b/components/view/DataroomViewer.tsx
@@ -76,6 +76,8 @@ export default function DataroomViewer({
   setDocumentData,
   setDataroomVerified,
   isPreview,
+  folderId,
+  setFolderId
 }: {
   brand: Partial<DataroomBrand>;
   viewId?: string;
@@ -89,8 +91,9 @@ export default function DataroomViewer({
   setDocumentData: React.Dispatch<React.SetStateAction<TDocumentData | null>>;
   setDataroomVerified: React.Dispatch<React.SetStateAction<boolean>>;
   isPreview?: boolean;
+  folderId: string | null;
+  setFolderId: React.Dispatch<React.SetStateAction<string | null>>;
 }) {
-  const [folderId, setFolderId] = useState<string | null>(null);
   const { documents, folders } = dataroom as {
     documents: DataroomDocument[];
     folders: DataroomFolder[];

--- a/components/view/dataroom/dataroom-view.tsx
+++ b/components/view/dataroom/dataroom-view.tsx
@@ -110,6 +110,7 @@ export default function DataroomView({
   const plausible = usePlausible();
   const analytics = useAnalytics();
   const router = useRouter();
+  const [folderId, setFolderId] = useState<string | null>(null);
 
   const didMount = useRef<boolean>(false);
   const [submitted, setSubmitted] = useState<boolean>(false);
@@ -442,6 +443,8 @@ export default function DataroomView({
           setDocumentData={setDocumentData}
           setViewType={setViewType}
           setDataroomVerified={setDataroomVerified}
+          folderId={folderId}
+          setFolderId={setFolderId}
         />
       </div>
     );


### PR DESCRIPTION
Bug: The folderId state is getting resetted everytime when we changing the view.

Fix: I lifted the state of folderId in DataroomViewer component to DataroomView component.

[Screencast from 13-10-24 11_40_10 PM IST.webm](https://github.com/user-attachments/assets/7531f705-ca8e-4e4e-8766-bd6d6f2e3ccb)
