### PR TITLE
opt-in-to-group-permission

### DIFF
--- a/components/datarooms/dataroom-document-card.tsx
+++ b/components/datarooms/dataroom-document-card.tsx
@@ -5,7 +5,12 @@ import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
 
 import { TeamContextType } from "@/context/team-context";
-import { ArchiveXIcon, FolderInputIcon, MoreVertical } from "lucide-react";
+import {
+  ArchiveXIcon,
+  FileSlidersIcon,
+  FolderInputIcon,
+  MoreVertical,
+} from "lucide-react";
 import { useTheme } from "next-themes";
 import { toast } from "sonner";
 import { mutate } from "swr";
@@ -26,6 +31,7 @@ import { type DocumentWithLinksAndLinkCountAndViewCount } from "@/lib/types";
 import { cn, nFormatter, timeAgo } from "@/lib/utils";
 import { fileIcon } from "@/lib/utils/get-file-icon";
 
+import { GroupNavigation } from "./group-navigation";
 import { MoveToDataroomFolderModal } from "./move-dataroom-folder-modal";
 
 type DocumentsCardProps = {
@@ -53,7 +59,8 @@ export default function DataroomDocumentCard({
   const [menuOpen, setMenuOpen] = useState<boolean>(false);
   const [moveFolderOpen, setMoveFolderOpen] = useState<boolean>(false);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
-
+  const [groupPermissionOpen, setGroupPermissionOpen] =
+    useState<boolean>(false);
   /** current folder name */
   const currentFolderPath = router.query.name as string[] | undefined;
 
@@ -230,6 +237,15 @@ export default function DataroomDocumentCard({
               <DropdownMenuItem
                 onClick={(e) => {
                   e.stopPropagation();
+                  setGroupPermissionOpen(true);
+                }}
+              >
+                <FileSlidersIcon className="mr-2 h-4 w-4" />
+                Set permission
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={(e) => {
+                  e.stopPropagation();
                   setMoveFolderOpen(true);
                 }}
               >
@@ -263,6 +279,13 @@ export default function DataroomDocumentCard({
           dataroomId={dataroomDocument.dataroomId}
           documentIds={[dataroomDocument.id]}
           documentName={dataroomDocument.document.name}
+        />
+      ) : null}
+      {groupPermissionOpen ? (
+        <GroupNavigation
+          open={groupPermissionOpen}
+          setOpen={setGroupPermissionOpen}
+          dataroomId={dataroomId as string}
         />
       ) : null}
     </>

--- a/components/datarooms/group-navigation.tsx
+++ b/components/datarooms/group-navigation.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link";
+
+import { BoxesIcon } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+import useDataroomGroups from "@/lib/swr/use-dataroom-groups";
+import { cn } from "@/lib/utils";
+
+import LoadingSpinner from "../ui/loading-spinner";
+
+export function GroupNavigation({
+  open,
+  setOpen,
+  dataroomId,
+  children,
+}: {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  dataroomId: string;
+  children?: React.ReactNode;
+}) {
+  const { viewerGroups, loading } = useDataroomGroups();
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader className="text-start">
+          <DialogTitle>Set Permission</DialogTitle>
+          <DialogDescription>
+            Move to group for set permission
+          </DialogDescription>
+        </DialogHeader>
+        <div>
+          {loading ? <LoadingSpinner className="mr-1 h-5 w-5" /> : null}
+          <div className="flex max-h-[260px] flex-col overflow-auto">
+            {viewerGroups &&
+              viewerGroups.map((g) => {
+                return (
+                  <Link
+                    href={`/datarooms/${dataroomId}/groups/${g.id}/permissions`}
+                    key={g.id}
+                    className="inline-flex w-full cursor-pointer items-center rounded-md px-3 py-1.5 font-semibold leading-6 text-foreground duration-100 hover:bg-gray-100 hover:dark:bg-muted"
+                  >
+                    <div className="flex min-w-0 items-center gap-4">
+                      <div className="hidden rounded-full border border-gray-200 sm:block">
+                        <div
+                          className={cn(
+                            "rounded-full border border-white bg-gradient-to-t from-gray-100 p-1 md:p-3",
+                          )}
+                        >
+                          <BoxesIcon className="size-3" />
+                        </div>
+                      </div>
+                      <div className="overflow-hidden">
+                        <div className="flex flex-col gap-1">
+                          <p className="truncate text-sm font-medium text-foreground">
+                            {g.name}
+                          </p>
+                          <span className="text-xs text-muted-foreground">
+                            {g._count.members} members
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </Link>
+                );
+              })}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/datarooms/sortable/sortable-list.tsx
+++ b/components/datarooms/sortable/sortable-list.tsx
@@ -128,6 +128,9 @@ export function DataroomSortableList({
         `/api/teams/${teamInfo?.currentTeam?.id}/datarooms/${dataroomId}/folders${folderPathName ? `/${folderPathName.join(" / ")}` : "?root=true"}`,
       );
       mutate(
+        `/api/teams/${teamInfo?.currentTeam?.id}/datarooms/${dataroomId}/folders`,
+      );
+      mutate(
         `/api/teams/${teamInfo?.currentTeam?.id}/datarooms/${dataroomId}${folderPathName ? `/folders/documents/${folderPathName.join("/")}` : "/documents"}`,
       );
       setIsReordering(false);

--- a/components/documents/add-document-modal.tsx
+++ b/components/documents/add-document-modal.tsx
@@ -234,7 +234,9 @@ export function AddDocumentModal({
         toast.error(message);
         return;
       }
-
+      mutate(
+        `/api/teams/${teamInfo?.currentTeam?.id}/datarooms/${dataroomId}/folders`,
+      );
       mutate(
         `/api/teams/${teamInfo?.currentTeam?.id}/datarooms/${dataroomId}/documents`,
       );

--- a/components/documents/folder-card.tsx
+++ b/components/documents/folder-card.tsx
@@ -26,6 +26,7 @@ import { DataroomFolderWithCount } from "@/lib/swr/use-dataroom";
 import { FolderWithCount } from "@/lib/swr/use-documents";
 import { timeAgo } from "@/lib/utils";
 
+import { GroupNavigation } from "../datarooms/group-navigation";
 import { EditFolderModal } from "../folders/edit-folder-modal";
 import { AddFolderToDataroomModal } from "./add-folder-to-dataroom-modal";
 
@@ -50,6 +51,8 @@ export default function FolderCard({
   const [isFirstClick, setIsFirstClick] = useState<boolean>(false);
   const [menuOpen, setMenuOpen] = useState<boolean>(false);
   const [addDataroomOpen, setAddDataroomOpen] = useState<boolean>(false);
+  const [groupPermissionOpen, setGroupPermissionOpen] =
+    useState<boolean>(false);
 
   const dropdownRef = useRef<HTMLDivElement | null>(null);
 
@@ -253,6 +256,14 @@ export default function FolderCard({
               <DropdownMenuLabel>Actions</DropdownMenuLabel>
               <DropdownMenuItem
                 onClick={(e) => {
+                  e.stopPropagation();
+                  setGroupPermissionOpen(true);
+                }}
+              >
+                Set Permission
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
                   setOpenFolder(true);
@@ -323,6 +334,13 @@ export default function FolderCard({
           setOpen={setAddDataroomOpen}
           folderId={folder.id}
           folderName={folder.name}
+        />
+      ) : null}
+      {groupPermissionOpen ? (
+        <GroupNavigation
+          open={groupPermissionOpen}
+          setOpen={setGroupPermissionOpen}
+          dataroomId={dataroomId as string}
         />
       ) : null}
     </>

--- a/components/upload-zone.tsx
+++ b/components/upload-zone.tsx
@@ -226,7 +226,9 @@ export default function UploadZone({
               );
               return;
             }
-
+            mutate(
+              `/api/teams/${teamInfo?.currentTeam?.id}/datarooms/${dataroomId}/folders`,
+            );
             mutate(
               `/api/teams/${teamInfo?.currentTeam?.id}/datarooms/${dataroomId}/documents`,
             );

--- a/lib/documents/move-dataroom-documents.ts
+++ b/lib/documents/move-dataroom-documents.ts
@@ -61,6 +61,7 @@ export const moveDataroomDocumentToFolder = async ({
     mutate(
       `/api/teams/${teamId}/datarooms/${dataroomId}/folders${folderPathName ? `/${folderPathName.join("/")}` : "?root=true"}`,
     );
+    mutate(`/api/teams/${teamId}/datarooms/${dataroomId}/folders`);
     // update folder document counts in home
     !newPath &&
       mutate(`/api/teams/${teamId}/datarooms/${dataroomId}/folders?root=true`);

--- a/lib/swr/use-dataroom.ts
+++ b/lib/swr/use-dataroom.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 
 import { useTeam } from "@/context/team-context";
 import { Dataroom, DataroomDocument, DataroomFolder } from "@prisma/client";
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
 
 import { LinkWithViews } from "@/lib/types";
 import { fetcher } from "@/lib/utils";
@@ -102,6 +102,7 @@ export function useDataroomItems({
       dedupingInterval: 30000,
     },
   );
+  mutate(`/api/teams/${teamId}/datarooms/${id}/folders}`);
 
   const isLoading =
     !folderData && !documentData && !folderError && !documentError;


### PR DESCRIPTION
fixes #697 

- The user can go to a specific group from the document page to set permissions.
- There were 3 or 4 cases where the folder tree view was not updated, and this has also been fixed.

![image](https://github.com/user-attachments/assets/9a38ca40-5fbf-4e33-9228-c5a886467b8b)
![image](https://github.com/user-attachments/assets/6fa03cf1-2a22-4b29-a808-627ebb2a0bd1)

It will redirect to group permission page