### PR TITLE
fix: Upgrade button dark mode visibility

### DIFF
--- a/components/billing/upgrade-plan-modal.tsx
+++ b/components/billing/upgrade-plan-modal.tsx
@@ -230,8 +230,8 @@ export function UpgradePlanModal({
                   variant={planOption === "Business" ? "default" : "outline"}
                   className={`w-full py-2 text-sm ${
                     planOption === "Business"
-                      ? "bg-[#fb7a00] text-white hover:bg-[#fb7a00]"
-                      : "bg-gray-800 text-white hover:bg-gray-900 hover:text-white"
+                      ? "bg-[#fb7a00]/90 text-white hover:bg-[#fb7a00]"
+                      : "bg-gray-800 text-white hover:bg-gray-900 hover:text-white dark:hover:bg-gray-700/80"
                   }`}
                   loading={selectedPlan === planOption} // Show loading only for the clicked plan
                   disabled={selectedPlan !== null}

--- a/pages/settings/upgrade.tsx
+++ b/pages/settings/upgrade.tsx
@@ -147,8 +147,8 @@ export default function UpgradePage() {
                 variant={planOption === "Business" ? "default" : "default"}
                 className={`w-full py-2 text-sm ${
                   planOption === "Business"
-                    ? "bg-[#fb7a00] text-white hover:bg-[#fb7a00]/80"
-                    : "bg-gray-800 text-white hover:bg-gray-900"
+                    ? "bg-[#fb7a00]/90 text-white hover:bg-[#fb7a00]"
+                    : "bg-gray-800 text-white hover:bg-gray-900 dark:hover:bg-gray-700/80"
                 }`}
                 loading={selectedPlan === planOption} // Show loading only for the clicked plan
                 disabled={selectedPlan !== null}


### PR DESCRIPTION
This PR partially address https://github.com/mfts/papermark/issues/981 as loading state is fixed on other commit (reopening since #982 got auto locked)
The button backdrop getting merged with the background in dark mode.

Current version: **(the screen recording app cause that flickers when modal is open)**

https://github.com/user-attachments/assets/8e258771-9891-48f6-99ad-4b93d6750bab

Fix:

https://github.com/user-attachments/assets/350a6ef5-3e62-4eea-8d8a-806d38630586

