### PR TITLE
fix: resolve margin issues in DocumentList and Tree components

### DIFF
--- a/components/documents/documents-list.tsx
+++ b/components/documents/documents-list.tsx
@@ -347,7 +347,7 @@ export function DocumentsList({
                 },
               }}
             >
-              <div className="space-y-4">
+              <div className="space-y-4 pb-3">
                 {/* Folders list */}
                 <ul role="list" className="space-y-4">
                   {folders

--- a/components/ui/nextra-filetree.tsx
+++ b/components/ui/nextra-filetree.tsx
@@ -108,7 +108,7 @@ const Folder = memo<FolderProps>(
     const isFolderOpen = open === undefined ? isOpen : open;
 
     return (
-      <li className="flex w-full list-none flex-col">
+      <li className="flex w-full list-none flex-col py-0.5">
         <div
           title={name}
           className={cn(
@@ -145,7 +145,7 @@ const Folder = memo<FolderProps>(
           </span>
         </div>
         {isFolderOpen && (
-          <ul>
+          <ul className="py-0.5">
             <ctx.Provider value={indent + 1}>{children}</ctx.Provider>
           </ul>
         )}

--- a/pages/documents/index.tsx
+++ b/pages/documents/index.tsx
@@ -54,7 +54,7 @@ export default function Documents() {
           </div>
         </section>
 
-        <div className="flex justify-end">
+        <div className="flex justify-end mb-2">
           <div className="relative w-full sm:max-w-xs">
             <SearchBoxPersisted loading={isValidating} inputClassName="h-10" />
           </div>


### PR DESCRIPTION
This PR addresses margin and padding issues in the DocumentList and Tree components. The following changes were made
Current version:
1. Search is overlapped 
![image](https://github.com/user-attachments/assets/98beb279-561b-477e-9110-7a79bd27d4fd)
2. In documents list there is no space at bottom on the last document card
![image](https://github.com/user-attachments/assets/c194539a-eb9f-4060-b501-0b6780bd7d4b)
3. The folder and also files on hovering in tree structure it lacks some space inbetween.
![image](https://github.com/user-attachments/assets/83fb930e-fc90-4b93-aa87-6c0cf9851443)

Fixed:
1 ![image](https://github.com/user-attachments/assets/6fac6954-6986-43cf-88c2-e673c3ad296e)
2 ![image](https://github.com/user-attachments/assets/48c2e0bf-8bec-4dad-b941-f0d597251373)
3 ![image](https://github.com/user-attachments/assets/2cc4b513-0d88-430d-a93f-a2c6a4c36c20)

