### PR TITLE
fix: truncate long file names for better ui display

### DIFF
--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -123,13 +123,6 @@ export default function DocumentUpload({
     [currentFile],
   );
 
-  const truncateFileName = (filename: string) => {
-    if (filename.length < 40) return filename;
-    else{
-
-    }
-  };
-  {console.log(currentFile)}
   return (
     <div className="col-span-full">
       <div
@@ -148,7 +141,7 @@ export default function DocumentUpload({
               }}
             />
           ) : null}
-        
+
           <div className="text-center">
             {currentFile ? (
               <div className="flex flex-col items-center text-foreground sm:flex-row sm:space-x-2">
@@ -158,7 +151,9 @@ export default function DocumentUpload({
                     isLight,
                   })}
                 </div>
-                <p>{truncateFileName(currentFile?.name)}</p>
+                <p className="max-w-[280px] truncate">
+                  {(currentFile.name)}
+                </p>
                 <p className="text-gray-500">{bytesToSize(currentFile.size)}</p>
               </div>
             ) : (

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -123,6 +123,13 @@ export default function DocumentUpload({
     [currentFile],
   );
 
+  const truncateFileName = (filename: string) => {
+    if (filename.length < 40) return filename;
+    else{
+
+    }
+  };
+  {console.log(currentFile)}
   return (
     <div className="col-span-full">
       <div
@@ -141,6 +148,7 @@ export default function DocumentUpload({
               }}
             />
           ) : null}
+        
           <div className="text-center">
             {currentFile ? (
               <div className="flex flex-col items-center text-foreground sm:flex-row sm:space-x-2">
@@ -150,7 +158,7 @@ export default function DocumentUpload({
                     isLight,
                   })}
                 </div>
-                <p>{currentFile.name}</p>
+                <p>{truncateFileName(currentFile?.name)}</p>
                 <p className="text-gray-500">{bytesToSize(currentFile.size)}</p>
               </div>
             ) : (


### PR DESCRIPTION
Fixes: #1184 
Truncated the filenames if they are large.
![image](https://github.com/user-attachments/assets/c6309abd-78d5-4a2e-896b-c288af417275)
