### PR TITLE
1046 [BUG] Link Sheet toggles hidden on mobile devices when "custom social media card toggle" active

### DIFF
--- a/components/links/link-sheet/og-section.tsx
+++ b/components/links/link-sheet/og-section.tsx
@@ -200,7 +200,7 @@ export default function OGSection({
             </div>
             <label
               htmlFor="image"
-              className="group relative mt-1 flex aspect-[1200/630] h-full min-h-[14rem] cursor-pointer flex-col items-center justify-center rounded-md border border-input bg-white shadow-sm transition-all hover:border-muted-foreground hover:bg-gray-50 hover:ring-muted-foreground dark:bg-gray-800 hover:dark:bg-transparent"
+              className="group relative mt-1 flex aspect-auto h-full min-h-[14rem] cursor-pointer flex-col items-center justify-center rounded-md border border-input bg-white shadow-sm transition-all hover:border-muted-foreground hover:bg-gray-50 hover:ring-muted-foreground dark:bg-gray-800 hover:dark:bg-transparent sm:aspect-[1200/630]"
             >
               {false && (
                 <div className="absolute z-[5] flex h-full w-full items-center justify-center rounded-md bg-white">

--- a/components/links/link-sheet/watermark-panel/index.tsx
+++ b/components/links/link-sheet/watermark-panel/index.tsx
@@ -108,7 +108,7 @@ export default function WatermarkConfigSheet({
                 onChange={handleInputChange}
                 className="focus:ring-inset"
               />
-              <div className="space-x-1">
+              <div className="space-x-1 space-y-1">
                 {["email", "date", "time", "link", "ipAddress"].map((item) => (
                   <Button
                     key={item}

--- a/components/links/link-sheet/watermark-section.tsx
+++ b/components/links/link-sheet/watermark-section.tsx
@@ -111,7 +111,7 @@ export default function WatermarkSection({
                 }}
                 className="focus:ring-inset"
               />
-              <div className="space-x-1">
+              <div className="space-x-1 space-y-1">
                 {["email", "date", "time", "link", "ipAddress"].map((item) => (
                   <Button
                     key={item}


### PR DESCRIPTION
Fixes : #1046 
First Fix: Link Sheet toggles hidden on mobile devices when "custom social media card toggle" active
Second Fix: 
![issue11223](https://github.com/user-attachments/assets/04e15e89-651f-4989-9220-75b85872567a)

![image](https://github.com/user-attachments/assets/1523eb8a-b9be-4db7-9199-23c93e15e653)
seconf Fix: on 2 places
![image](https://github.com/user-attachments/assets/e937a2f3-dfd8-4b75-a325-56797e7a7679)
