### PR TITLE
Added Loading Indicator in Folder Creation and Restrict Empty Folder Names

### DIFF
--- a/components/folders/add-folder-modal.tsx
+++ b/components/folders/add-folder-modal.tsx
@@ -117,8 +117,13 @@ export function AddFolderModal({
     }
   }
 
+  const clearModelState = () => {
+    setOpen(!open);
+    folderName !== null && setFolderName("");
+  };
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={clearModelState}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader className="text-start">
@@ -134,10 +139,16 @@ export function AddFolderModal({
             placeholder="folder-123"
             className="mb-4 mt-1 w-full"
             onChange={(e) => setFolderName(e.target.value)}
+            value={folderName || ""}
           />
           <DialogFooter>
-            <Button type="submit" className="h-9 w-full">
-              Add new folder
+            <Button
+              type="submit"
+              className="h-9 w-full"
+              disabled={folderName?.trim() == "" || loading}
+              loading={loading}
+            >
+              {loading ? "Adding..." : "Add new folder"}
             </Button>
           </DialogFooter>
         </form>

--- a/components/folders/edit-folder-modal.tsx
+++ b/components/folders/edit-folder-modal.tsx
@@ -94,8 +94,13 @@ export function EditFolderModal({
     }
   };
 
+  const clearModelState = () => {
+    setOpen(!open);
+    folderName !== null && setFolderName("");
+  };
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={clearModelState}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader className="text-start">
@@ -108,14 +113,19 @@ export function EditFolderModal({
           </Label>
           <Input
             id="folder-name-update"
-            value={folderName}
+            value={folderName || ""}
             placeholder="folder-123"
             className="mb-4 mt-1 w-full"
             onChange={(e) => setFolderName(e.target.value)}
           />
           <DialogFooter>
-            <Button type="submit" className="h-9 w-full" loading={loading}>
-              Update folder
+            <Button
+              type="submit"
+              className="h-9 w-full"
+              loading={loading}
+              disabled={folderName?.trim() == "" || loading}
+            >
+              {loading? "Updating":"Update folder"}
             </Button>
           </DialogFooter>
         </form>


### PR DESCRIPTION
Addressing #1317
1. A loading indicator has been added during the folder creation process
2. Restricts the creation or updating of folders with empty names