### PR TITLE
Minor UI warning fix in Add Document Modal

### DIFF
--- a/components/documents/add-document-modal.tsx
+++ b/components/documents/add-document-modal.tsx
@@ -34,6 +34,7 @@ import useLimits from "@/lib/swr/use-limits";
 import { getSupportedContentType } from "@/lib/utils/get-content-type";
 
 import { UpgradePlanModal } from "../billing/upgrade-plan-modal";
+import { DialogDescription, DialogTitle } from "@radix-ui/react-dialog";
 
 export function AddDocumentModal({
   newVersion,
@@ -410,6 +411,10 @@ export function AddDocumentModal({
         className="border-none bg-transparent text-foreground shadow-none"
         isDocumentDialog
       >
+        <DialogTitle className="sr-only">Add Document</DialogTitle>
+        <DialogDescription className="sr-only">
+          An overlayed modal that can be clicked to upload a document
+        </DialogDescription>
         <Tabs defaultValue="document">
           {!newVersion ? (
             <TabsList className="grid w-full grid-cols-2">


### PR DESCRIPTION
### What was wrong?
When you open the add-document-modal, an error and a warning will come up on the browser console (see screenshot of papermark.io below).
<img width="1440" alt="Screenshot 2024-12-25 at 8 38 53 AM" src="https://github.com/user-attachments/assets/b8611e2b-9d6a-4bfe-a34f-e5d86395baae" />

### How did I fix it?
I just followed the instructions in the error/warning messages (add invisible `DialogTitle` and `DialogDescription` elements). The error/warning messages no longer show up (see screenshot of localhost below).
<img width="1440" alt="Screenshot 2024-12-25 at 8 46 12 AM" src="https://github.com/user-attachments/assets/cf39d9f2-4692-4505-8420-1671e990a374" />
