### PR TITLE
1464-fix 404 for Breadcrumb settings

### DIFF
--- a/components/layouts/breadcrumb.tsx
+++ b/components/layouts/breadcrumb.tsx
@@ -184,7 +184,7 @@ const SettingsBreadcrumb = () => {
       <BreadcrumbList>
         <BreadcrumbItem>
           <BreadcrumbLink asChild>
-            <Link href="/settings">Settings</Link>
+            <Link href="/settings/general">Settings</Link>
           </BreadcrumbLink>
         </BreadcrumbItem>
         <BreadcrumbSeparator />

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,6 +30,11 @@ const nextConfig = {
         destination: "/view/cm68iygxd0005wuf5svbr6c1x",
         permanent: false,
       },
+      {
+        source: "/settings",
+        destination: "/settings/general",
+        permanent: false,
+      },
     ];
   },
   async headers() {


### PR DESCRIPTION
#1464 :
- Added a redirect in next.config.js to ensure /settings automatically navigates to /settings/general.
- Updated the Breadcrumb component to link "Settings" to /settings/general instead of /settings.
- Clicking "Settings" now correctly redirects to /settings/general.
- Ensures consistent navigation and prevents 404 issues when accessing /settings.