### PR TITLE
Enable login on selfhosted instances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ NEXTAUTH_URL=http://localhost:3000
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 NEXT_PUBLIC_MARKETING_URL=http://localhost:3000
 
+# Domain where Papermark is being server
+DOMAIN="papermark.io"
+
 # These variables are from Vercel Storage Postgres
 POSTGRES_PRISMA_URL=
 POSTGRES_PRISMA_URL_NON_POOLING=

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ GOOGLE_CLIENT_SECRET=
 
 # This variable is from Resend to send emails
 RESEND_API_KEY=
+RESEND_SENDER_SYSTEM=""
+RESEND_SENDER_VERIFY=""
 
 # This variable is from Tinybird to publish and read event data
 TINYBIRD_TOKEN=

--- a/lib/resend.ts
+++ b/lib/resend.ts
@@ -44,12 +44,12 @@ export const sendEmail = async ({
       from: marketing
         ? "Marc from Papermark <marc@ship.papermark.io>"
         : system
-          ? "Papermark <system@papermark.io>"
+          ? process.env.RESEND_SENDER_SYSTEM || "Papermark <system@papermark.io>"
           : verify
-            ? "Papermark <system@verify.papermark.io>"
+            ? process.env.RESEND_SENDER_VERIFY || "Papermark <system@verify.papermark.io>"
             : !!scheduledAt
-              ? "Marc Seitz <marc@papermark.io>"
-              : "Marc from Papermark <marc@papermark.io>",
+              ? process.env.RESEND_SENDER_SYSTEM || "Marc Seitz <marc@papermark.io>"
+              : process.env.RESEND_SENDER_SYSTEM || "Marc from Papermark <marc@papermark.io>",
       to: test ? "delivered@resend.dev" : to,
       cc: cc,
       replyTo: marketing ? "marc@papermark.io" : undefined,

--- a/middleware.ts
+++ b/middleware.ts
@@ -51,7 +51,7 @@ export default async function middleware(req: NextRequest, ev: NextFetchEvent) {
     (process.env.NODE_ENV !== "development" &&
       !(
         host?.includes("localhost") ||
-        host?.includes("papermark.io") ||
+        host?.includes(process.env.DOMAIN || "papermark.io") ||
         host?.endsWith(".vercel.app")
       ))
   ) {

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -13,7 +13,7 @@ import prisma from "@/lib/prisma";
 import { CreateUserEmailProps, CustomUser } from "@/lib/types";
 import { generateChecksum } from "@/lib/utils/generate-checksum";
 
-const VERCEL_DEPLOYMENT = !!process.env.VERCEL_URL;
+const VERCEL_DEPLOYMENT = (!!process.env.VERCEL_URL || !!process.env.DOMAIN);
 
 // This function can run for a maximum of 180 seconds
 export const config = {
@@ -88,7 +88,7 @@ export const authOptions: NextAuthOptions = {
         sameSite: "lax",
         path: "/",
         // When working on localhost, the cookie domain must be omitted entirely (https://stackoverflow.com/a/1188145)
-        domain: VERCEL_DEPLOYMENT ? ".papermark.io" : undefined,
+        // TODO: Verify if we really need to set a domain
         secure: VERCEL_DEPLOYMENT,
       },
     },


### PR DESCRIPTION
Allow the user to define a main custom domain for self-hosting, under the DOMAIN environment variable,
this custom domain will be recognized by the middleware when run in production (local, non vercel) mode.

Secure cookies are used when a custom domain is set, thus requiring papermark to be served on https.

Finally, sender addresses can be customized with the RESEND_SENDER_SYSTEM and RESEND_SENDER_VERIFY environment variables, to be able to deliver emails from domains allowed in the instance RESEND api key.

Fixes #1353 