### PR TITLE
Add search bar to Dataroom viewer mode

### DIFF
--- a/components/view/viewer/dataroom-viewer.tsx
+++ b/components/view/viewer/dataroom-viewer.tsx
@@ -450,6 +450,21 @@ export default function DataroomViewer({
                 </div>
               </div>
 
+              {/* Search results banner */}
+              {searchQuery && (
+                <div className="mt-4 rounded-md border border-muted/50 bg-muted px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <div className="text-sm font-medium text-muted-foreground">
+                      Search results for &quot;{searchQuery}&quot;
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      ({mixedItems.length} result
+                      {mixedItems.length !== 1 ? "s" : ""} across all folders)
+                    </div>
+                  </div>
+                </div>
+              )}
+
               <ul role="list" className="-mx-4 space-y-4 overflow-auto p-4">
                 {mixedItems.length === 0 ? (
                   <li className="py-6 text-center text-muted-foreground">


### PR DESCRIPTION
<img width="1080" alt="Screenshot 2025-02-20 at 9 12 34 PM" src="https://github.com/user-attachments/assets/9c8921da-deb9-4136-9ed0-c14b3de40be0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a search bar to the Dataroom Viewer, allowing users to filter documents by name.
  * Displayed a message when no documents match the search query.

* **User Interface**
  * Updated the header area to include the new search functionality.
  * Improved feedback when no items are available or match the search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->