### PR TITLE
Add Seed to Scale theme with terracotta color

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# Papermark Dev Guide
+
+## Build & Run Commands
+- `npm run dev` - Start development server
+- `npm run build` - Build for production
+- `npm run lint` - Run ESLint
+- `npm run format` - Format code with Prettier
+- `npm run dev:prisma` - Generate Prisma client and run migrations
+- `npm run email` - Start email preview server (port 3001)
+- `npm run trigger:v3:dev` - Run Trigger.dev locally
+
+## Code Style
+- **Formatting**: Use Prettier with 2-space indentation, double quotes
+- **Imports**: Order - next, react, third-party, components, lib, styles, relative
+- **TypeScript**: Strict mode, prefer explicit types over `any`
+- **Components**: Use functional components with proper props typing
+- **Naming**: PascalCase for components, camelCase for variables/functions
+- **Error Handling**: Use try/catch for async operations, avoid uncaught rejections
+- **State Management**: Prefer SWR for data fetching with proper error handling
+- **CSS**: Use Tailwind CSS utility classes, prefer composition over custom classes
+
+## Project Structure
+- `/app`: Next.js App Router components and routes
+- `/components`: Reusable UI components
+- `/lib`: Utility functions and business logic
+- `/pages`: Next.js Pages Router (legacy)
+- `/prisma`: Database schema and migrations

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -39,6 +39,10 @@ export function ModeToggle() {
               <Moon className="mr-2 h-4 w-4" />
               Dark
             </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="seed-theme">
+              <div className="mr-2 h-4 w-4 rounded-full bg-[#b25447]" />
+              Seed to Scale
+            </DropdownMenuRadioItem>
             <DropdownMenuRadioItem value="system">
               <Monitor className="mr-2 h-4 w-4" />
               System

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -72,7 +72,7 @@ export default function App({
       </Head>
       <SessionProvider session={session}>
         <PostHogCustomProvider>
-          <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+          <ThemeProvider attribute="class" defaultTheme="light" enableSystem themes={["light", "dark", "seed-theme"]}>
             <PlausibleProvider
               domain="papermark.io"
               enabled={process.env.NEXT_PUBLIC_VERCEL_ENV === "production"}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -90,6 +90,52 @@
     --sidebar-border: 240 3.7% 15.9%; /* gray-200 */
     --sidebar-ring: 217.2 91.2% 59.8%; /* gray-400 */
   }
+  
+  .seed-theme {
+    /* Convert #b25447 to HSL - it's approximately 7 42% 49% */
+    --background: 0 0% 100%; /* white */
+    --foreground: 7 42% 30%; /* darker terracotta */
+    
+    --muted: 7 42% 95%; /* light terracotta */
+    --muted-foreground: 7 42% 40%; /* medium terracotta */
+    
+    --popover: 0 0% 100%; /* white */
+    --popover-foreground: 7 42% 30%; /* darker terracotta */
+    
+    --card: 0 0% 100%; /* white */
+    --card-foreground: 7 42% 30%; /* darker terracotta */
+    
+    --border: 7 42% 90%; /* very light terracotta */
+    --input: 7 42% 85%; /* light terracotta */
+    
+    --primary: 7 42% 49%; /* terracotta (#b25447) */
+    --primary-foreground: 0 0% 100%; /* white */
+    
+    --secondary: 7 42% 95%; /* very light terracotta */
+    --secondary-foreground: 7 42% 30%; /* darker terracotta */
+    
+    --accent: 7 42% 40%; /* medium-dark terracotta */
+    --accent-foreground: 0 0% 100%; /* white */
+    
+    --destructive: 0 84% 60%; /* red-500 */
+    --destructive-foreground: 210 20% 98%; /* gray-50 */
+    
+    --warning: 38 92% 50%; /* amber-500 */
+    --warning-foreground: 210 20% 98%; /* gray-50 */
+    
+    --ring: 7 42% 40%; /* medium terracotta */
+    
+    --radius: 0.5rem; /* md */
+    
+    --sidebar-background: 7 42% 35%; /* dark terracotta */
+    --sidebar-foreground: 0 0% 100%; /* white */
+    --sidebar-primary: 7 42% 49%; /* terracotta */
+    --sidebar-primary-foreground: 0 0% 100%; /* white */
+    --sidebar-accent: 7 42% 25%; /* darker terracotta */
+    --sidebar-accent-foreground: 0 0% 100%; /* white */
+    --sidebar-border: 7 42% 20%; /* very dark terracotta */
+    --sidebar-ring: 7 42% 60%; /* lighter terracotta */
+  }
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- Add new seed-theme CSS class with #b25447 (terracotta) as primary color
- Update ThemeProvider to support the new theme option
- Add Seed to Scale theme to the theme toggle dropdown
- Create CLAUDE.md with build commands and coding style guidelines

## Test plan
- Run the app with `npm run dev`
- Click on the theme toggle in the dropdown menu
- Select "Seed to Scale" theme
- Verify the UI updates with the terracotta color scheme

🤖 Generated with [Claude Code](https://claude.ai/code)