### PR TITLE
Tinybird forward compatible

### DIFF
--- a/lib/tinybird/datasources/click_events__v1.datasource
+++ b/lib/tinybird/datasources/click_events__v1.datasource
@@ -1,5 +1,3 @@
-VERSION 1
-
 DESCRIPTION >
     Click events track when a user clicks a link within a document
 

--- a/lib/tinybird/datasources/page_views__v3.datasource
+++ b/lib/tinybird/datasources/page_views__v3.datasource
@@ -1,5 +1,3 @@
-VERSION 3
-
 DESCRIPTION >
   Page views are events when a user views a document
 

--- a/lib/tinybird/datasources/pm_click_events__v1.datasource
+++ b/lib/tinybird/datasources/pm_click_events__v1.datasource
@@ -1,5 +1,3 @@
-VERSION 1
-
 DESCRIPTION >
     Event track when a visitor clicks a link
 

--- a/lib/tinybird/datasources/video_views__v1.datasource
+++ b/lib/tinybird/datasources/video_views__v1.datasource
@@ -1,5 +1,3 @@
-VERSION 1
-
 DESCRIPTION >
   Video views are events when a user views a video
 

--- a/lib/tinybird/datasources/video_views__v1.datasource
+++ b/lib/tinybird/datasources/video_views__v1.datasource
@@ -44,4 +44,4 @@ SCHEMA >
 
 ENGINE "MergeTree"
 ENGINE_SORTING_KEY "timestamp,link_id,document_id,view_id,version_number,event_type"
-
+ENGINE_PARTITION_KEY "toYear(timestamp)"

--- a/lib/tinybird/datasources/webhook_events__v1.datasource
+++ b/lib/tinybird/datasources/webhook_events__v1.datasource
@@ -1,5 +1,3 @@
-VERSION 1
-
 DESCRIPTION >
   Webhook events are events when a webhook is triggered
 

--- a/lib/tinybird/endpoints/get_click_events_by_view__v1.pipe
+++ b/lib/tinybird/endpoints/get_click_events_by_view__v1.pipe
@@ -1,5 +1,3 @@
-VERSION 1
-
 DESCRIPTION >
     Get all click events for a specific view
 
@@ -18,3 +16,5 @@ SQL >
     WHERE document_id = {{ String(document_id, required=True) }}
         AND view_id = {{ String(view_id, required=True) }}
     ORDER BY timestamp ASC
+
+TYPE endpoint

--- a/lib/tinybird/endpoints/get_click_events_by_view__v1.pipe
+++ b/lib/tinybird/endpoints/get_click_events_by_view__v1.pipe
@@ -12,7 +12,7 @@ SQL >
         page_number,
         version_number,
         href
-    FROM click_events
+    FROM click_events__v1
     WHERE document_id = {{ String(document_id, required=True) }}
         AND view_id = {{ String(view_id, required=True) }}
     ORDER BY timestamp ASC

--- a/lib/tinybird/endpoints/get_document_duration_per_viewer__v1.pipe
+++ b/lib/tinybird/endpoints/get_document_duration_per_viewer__v1.pipe
@@ -1,5 +1,3 @@
-VERSION 1
-
 NODE endpoint
 SQL >
     %
@@ -10,3 +8,5 @@ SQL >
     WHERE
         documentId = {{ String(documentId, required=True)}}
         AND viewId IN splitByChar(',', {{ String(viewIds, required=True) }})
+
+TYPE endpoint

--- a/lib/tinybird/endpoints/get_page_duration_per_view__v4.pipe
+++ b/lib/tinybird/endpoints/get_page_duration_per_view__v4.pipe
@@ -1,5 +1,3 @@
-VERSION 4
-
 NODE endpoint
 SQL >
     %
@@ -16,3 +14,5 @@ SQL >
         pageNumber
     ORDER BY
         pageNumber ASC
+
+TYPE endpoint

--- a/lib/tinybird/endpoints/get_total_average_page_duration__v5.pipe
+++ b/lib/tinybird/endpoints/get_total_average_page_duration__v5.pipe
@@ -1,5 +1,3 @@
-VERSION 5
-
 NODE endpoint
 SQL >
     %
@@ -18,3 +16,5 @@ SQL >
     FROM DistinctDurations
     GROUP BY versionNumber, pageNumber
     ORDER BY versionNumber ASC, pageNumber ASC
+
+TYPE endpoint

--- a/lib/tinybird/endpoints/get_total_dataroom_duration__v1.pipe
+++ b/lib/tinybird/endpoints/get_total_dataroom_duration__v1.pipe
@@ -1,5 +1,3 @@
-VERSION 1
-
 NODE endpoint
 SQL >
     %
@@ -15,3 +13,5 @@ SQL >
         AND viewId NOT IN {{ Array(excludedViewIds, String) }}
     GROUP BY
         viewId
+
+TYPE endpoint

--- a/lib/tinybird/endpoints/get_total_document_duration__v1.pipe
+++ b/lib/tinybird/endpoints/get_total_document_duration__v1.pipe
@@ -1,5 +1,3 @@
-VERSION 1
-
 NODE endpoint
 SQL >
     %
@@ -10,3 +8,5 @@ SQL >
         AND time >= {{ Int64(since, required=true) }}
         AND linkId NOT IN splitByChar(',', {{ String(excludedLinkIds, required=True) }})
         AND viewId NOT IN splitByChar(',', {{ String(excludedViewIds, required=True) }})
+
+TYPE endpoint

--- a/lib/tinybird/endpoints/get_total_link_duration__v1.pipe
+++ b/lib/tinybird/endpoints/get_total_link_duration__v1.pipe
@@ -1,5 +1,3 @@
-VERSION 1
-
 NODE endpoint
 SQL >
     %
@@ -10,3 +8,5 @@ SQL >
         AND time >= {{ Int64(since, required=true) }}
         AND documentId = {{ String(documentId, required=true) }}
         AND viewId NOT IN splitByChar(',', {{ String(excludedViewIds, required=true) }})
+
+TYPE endpoint

--- a/lib/tinybird/endpoints/get_total_viewer_duration__v1.pipe
+++ b/lib/tinybird/endpoints/get_total_viewer_duration__v1.pipe
@@ -1,5 +1,3 @@
-VERSION 1
-
 NODE endpoint
 SQL >
     %
@@ -10,3 +8,5 @@ SQL >
     WHERE
         viewId IN splitByChar(',', {{ String(viewIds, required=true) }})
         AND time >= {{ Int64(since, required=true) }} 
+
+TYPE endpoint

--- a/lib/tinybird/endpoints/get_useragent_per_view__v1.pipe
+++ b/lib/tinybird/endpoints/get_useragent_per_view__v1.pipe
@@ -1,5 +1,3 @@
-VERSION 1
-
 NODE endpoint
 SQL >
     %
@@ -18,3 +16,5 @@ SQL >
     ORDER BY
         viewId, time ASC
     LIMIT 1
+
+TYPE endpoint

--- a/lib/tinybird/endpoints/get_video_events_by_document__v1.pipe
+++ b/lib/tinybird/endpoints/get_video_events_by_document__v1.pipe
@@ -15,7 +15,7 @@ SQL >
         is_muted,
         is_focused,
         is_fullscreen
-    FROM video_views
+    FROM video_views__v1
     WHERE document_id = {{String(document_id, required=True)}}
     ORDER BY timestamp ASC
 

--- a/lib/tinybird/endpoints/get_video_events_by_document__v1.pipe
+++ b/lib/tinybird/endpoints/get_video_events_by_document__v1.pipe
@@ -1,5 +1,3 @@
-VERSION 1
-
 DESCRIPTION >
     Get all video views for a specific document
 
@@ -21,5 +19,4 @@ SQL >
     WHERE document_id = {{String(document_id, required=True)}}
     ORDER BY timestamp ASC
 
-
-
+TYPE endpoint

--- a/lib/tinybird/endpoints/get_video_events_by_view__v1.pipe
+++ b/lib/tinybird/endpoints/get_video_events_by_view__v1.pipe
@@ -1,5 +1,3 @@
-VERSION 1
-
 DESCRIPTION >
     Get all video events for a specific view 
 
@@ -21,4 +19,4 @@ SQL >
     AND view_id = {{String(view_id, required=True)}}
     ORDER BY timestamp ASC
 
-
+TYPE endpoint

--- a/lib/tinybird/endpoints/get_video_events_by_view__v1.pipe
+++ b/lib/tinybird/endpoints/get_video_events_by_view__v1.pipe
@@ -14,7 +14,7 @@ SQL >
         is_muted,
         is_focused,
         is_fullscreen
-    FROM video_views
+    FROM video_views__v1
     WHERE document_id = {{String(document_id, required=True)}}
     AND view_id = {{String(view_id, required=True)}}
     ORDER BY timestamp ASC

--- a/lib/tinybird/endpoints/get_webhook_events__v1.pipe
+++ b/lib/tinybird/endpoints/get_webhook_events__v1.pipe
@@ -1,5 +1,3 @@
-VERSION 1
-
 NODE endpoint
 SQL >
     %
@@ -12,3 +10,5 @@ SQL >
     ORDER BY
         timestamp DESC
     LIMIT 100
+
+TYPE endpoint


### PR DESCRIPTION
# Description of changes
Changes to make the project compatible with Tinybird Forward:
- Add TYPE endpoint to endpoint pipes. This is the default in Tinybird Classic, and has to be explicit in Tinybird Forward.
- Add an explicit partition key, that was implicit in Classic and reflects the current schema of the data source.
- Remove VERSION from resources, rename the files to include the suffix of the last version, and always refer to resources with the suffix.

The first and second changes are completely inoffensive.  

The third change deserves some comments: pipes will be updated atomically for Tinybird Classic with the usual `tb push -f`, but data sources will refuse to update. This is not an issue because the changes in files in this PR don't actually change the resources in Tinybird. However, removing `VERSION` and explicitly pinning the resources to the latest one will make iterating them with Tinybird Classic more cumbersome, if anyone does this.   

Happy to discuss these changes in this PR, or you can email me at eclbg at tinybird.co if you prefer.

# How to check full compatibility with Tinybird Forward

These steps rely on `uv` ([installation](https://docs.astral.sh/uv/getting-started/installation/))for working with the Classic and Forward CLIs without issues.

1. Create a new Tinybird Classic workspace.
2. In `main` branch of the repo
3. Authenticate with Classic CLI: `uvx --from tinybird-cli tb auth --interactive`. Select region and use admin email token.
4. Push files to workspace: `uvx --from tinybird-cli tb push lib/tinybird/`
5. Use the Forward CLI to check that the first Forward deployment detects no changes: `uvx --from tinybird tb --cloud deploy --check`. Output should be:

```
Running against Tinybird Cloud: Workspace <your workspace>

» Validating deployment...

* No changes to be deployed
* No changes in tokens to be deployed
```
