### PR TITLE
fix: escape worker if it doesn't load

### DIFF
--- a/lib/utils/get-page-number-count.ts
+++ b/lib/utils/get-page-number-count.ts
@@ -1,11 +1,42 @@
 import { pdfjs } from "react-pdf";
 import * as XLSX from "xlsx";
 
-pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
+// Default to CDN worker URL
+const cdnWorkerUrl = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
+pdfjs.GlobalWorkerOptions.workerSrc = cdnWorkerUrl;
 
 export const getPagesCount = async (arrayBuffer: ArrayBuffer) => {
-  const pdf = await pdfjs.getDocument(arrayBuffer).promise;
-  return pdf.numPages;
+  try {
+    // Only in browser context
+    if (typeof window !== "undefined") {
+      try {
+        // First attempt with the current worker configuration
+        const pdf = await pdfjs.getDocument({ data: arrayBuffer }).promise;
+        return pdf.numPages;
+      } catch (workerError) {
+        console.warn("PDF worker error, trying fallback:", workerError);
+
+        // Fall back to local worker
+        pdfjs.GlobalWorkerOptions.workerSrc = `/pdf.worker.min.js`;
+
+        try {
+          // Try again with local worker
+          const pdf = await pdfjs.getDocument({ data: arrayBuffer }).promise;
+          return pdf.numPages;
+        } catch (fallbackError) {
+          console.warn("Both CDN and local worker failed:", fallbackError);
+          return 1; // Default to 1 page if both attempts fail
+        }
+      }
+    } else {
+      // Server-side rendering case
+      const pdf = await pdfjs.getDocument(arrayBuffer).promise;
+      return pdf.numPages;
+    }
+  } catch (error) {
+    console.error("Error getting PDF page count:", error);
+    return 1; // Assuming at least one page if we can't determine
+  }
 };
 
 export const getSheetsCount = (arrayBuffer: ArrayBuffer) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when loading PDF files by adding fallback mechanisms and better error handling, ensuring a default page count is provided if loading fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->