### PR TITLE
feat: add msg file to document types

### DIFF
--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -87,6 +87,7 @@ export default function DocumentUpload({
             "video/ogg": [], // ".ogg"
             "application/vnd.google-earth.kml+xml": [".kml"], // ".kml"
             "application/vnd.google-earth.kmz": [".kmz"], // ".kmz"
+            "application/vnd.ms-outlook": [".msg"], // ".msg"
           },
     multiple: false,
     onDropAccepted: (acceptedFiles) => {

--- a/components/documents/document-header.tsx
+++ b/components/documents/document-header.tsx
@@ -756,7 +756,9 @@ export default function DocumentHeader({
               )}
 
               {primaryVersion.type !== "notion" &&
-                primaryVersion.type !== "zip" && (
+                primaryVersion.type !== "zip" &&
+                primaryVersion.type !== "map" &&
+                primaryVersion.type !== "email" && (
                   <DropdownMenuItem
                     onClick={() =>
                       isFree

--- a/components/view/view-data.tsx
+++ b/components/view/view-data.tsx
@@ -93,7 +93,9 @@ export default function ViewData({
         ? viewData.conversationsEnabled
         : false),
     assistantEnabled: document.assistantEnabled,
-    allowDownload: isDownloadAllowed(canDownload, link.allowDownload ?? false),
+    allowDownload:
+      document.downloadOnly ||
+      isDownloadAllowed(canDownload, link.allowDownload ?? false),
     isTeamMember: viewData.isTeamMember,
   };
 

--- a/components/viewer-upload-zone.tsx
+++ b/components/viewer-upload-zone.tsx
@@ -20,6 +20,7 @@ const acceptableViewerFileTypes = {
   "image/jpeg": [], // ".jpg"
   "image/png": [], // ".png"
   "image/jpg": [], // ".jpg"
+  "application/vnd.ms-outlook": [".msg"], // ".msg"
 };
 
 export default function ViewerUploadZone({

--- a/components/viewer-upload-zone.tsx
+++ b/components/viewer-upload-zone.tsx
@@ -20,7 +20,6 @@ const acceptableViewerFileTypes = {
   "image/jpeg": [], // ".jpg"
   "image/png": [], // ".png"
   "image/jpg": [], // ".jpg"
-  "application/vnd.ms-outlook": [".msg"], // ".msg"
 };
 
 export default function ViewerUploadZone({

--- a/lib/api/documents/process-document.ts
+++ b/lib/api/documents/process-document.ts
@@ -73,7 +73,7 @@ export const processDocument = async ({
   });
 
   // determine if the document is download only
-  const isDownloadOnly = type === "zip" || type === "map";
+  const isDownloadOnly = type === "zip" || type === "map" || type === "email";
 
   // Save data to the database
   const document = await prisma.document.create({

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -87,6 +87,7 @@ export const SUPPORTED_DOCUMENT_MIME_TYPES = [
   "video/ogg", // .ogg
   "application/vnd.google-earth.kml+xml", // .kml
   "application/vnd.google-earth.kmz", // .kmz
+  "application/vnd.ms-outlook", // .msg
 ];
 
 export const SUPPORTED_DOCUMENT_SIMPLE_TYPES = [
@@ -100,6 +101,7 @@ export const SUPPORTED_DOCUMENT_SIMPLE_TYPES = [
   "zip",
   "video",
   "map",
+  "email",
 ] as const;
 
 export const VIDEO_EVENT_TYPES = [

--- a/lib/utils/get-content-type.ts
+++ b/lib/utils/get-content-type.ts
@@ -35,6 +35,8 @@ export function getSupportedContentType(contentType: string): string | null {
     case "application/vnd.google-earth.kml+xml":
     case "application/vnd.google-earth.kmz":
       return "map";
+    case "application/vnd.ms-outlook":
+      return "email";
     default:
       return null;
   }
@@ -92,6 +94,8 @@ export function getExtensionFromContentType(
       return "kml";
     case "application/vnd.google-earth.kmz":
       return "kmz";
+    case "application/vnd.ms-outlook":
+      return "msg";
     default:
       return null;
   }

--- a/lib/utils/get-file-icon.tsx
+++ b/lib/utils/get-file-icon.tsx
@@ -1,4 +1,4 @@
-import { FileIcon } from "lucide-react";
+import { FileIcon, MailIcon } from "lucide-react";
 
 import CadIcon from "@/components/shared/icons/files/cad";
 import DocsIcon from "@/components/shared/icons/files/docs";
@@ -61,6 +61,9 @@ export function fileIcon({
     case "application/vnd.google-earth.kmz":
     case "map":
       return <MapIcon className={className} isLight={isLight} />;
+    case "application/vnd.ms-outlook":
+    case "email":
+      return <MailIcon className={className} />;
     default:
       return <FileIcon className={className} />;
   }

--- a/pages/api/links/download/index.ts
+++ b/pages/api/links/download/index.ts
@@ -61,8 +61,8 @@ export default async function handle(
         return res.status(404).json({ error: "Error downloading" });
       }
 
-      // if link does not allow download, we should not allow the download
-      if (!view.link.allowDownload && !view.document?.downloadOnly) {
+      // if document is downloadOnly, always allow. Otherwise, check link settings.
+      if (!view.document?.downloadOnly && !view.link.allowDownload) {
         return res.status(403).json({ error: "Error downloading" });
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for uploading and handling Microsoft Outlook email files (.msg).
  - Outlook email files now display a dedicated email icon in file listings.

- **Bug Fixes**
  - Improved accuracy in detecting and correcting MIME types for files with missing type information during upload.

- **Enhancements**
  - Updated download permissions to always allow downloads for documents marked as "download only," including email files.
  - Refined visibility of the "Set viewable" / "Set download only" option for certain document types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->