### PR TITLE
fix: check if team can send webhooks

### DIFF
--- a/lib/api/views/send-webhook-event.ts
+++ b/lib/api/views/send-webhook-event.ts
@@ -1,4 +1,3 @@
-import { getFeatureFlags } from "@/lib/featureFlags";
 import prisma from "@/lib/prisma";
 import { log } from "@/lib/utils";
 import { sendWebhooks } from "@/lib/webhook/send-webhooks";
@@ -22,9 +21,18 @@ export async function sendLinkViewWebhook({
       throw new Error("Missing required parameters");
     }
 
-    const features = await getFeatureFlags({ teamId });
-    if (!features.webhooks) {
-      // webhooks are not enabled for this team
+    // check if team is on paid plan
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      select: { plan: true },
+    });
+
+    if (
+      team?.plan === "free" ||
+      team?.plan === "pro" ||
+      team?.plan.includes("trial")
+    ) {
+      // team is not on paid plan, so we don't need to send webhooks
       return;
     }
 

--- a/lib/webhook/triggers/link-created.ts
+++ b/lib/webhook/triggers/link-created.ts
@@ -1,4 +1,3 @@
-import { getFeatureFlags } from "@/lib/featureFlags";
 import prisma from "@/lib/prisma";
 import { log } from "@/lib/utils";
 import { sendWebhooks } from "@/lib/webhook/send-webhooks";
@@ -21,9 +20,18 @@ export async function sendLinkCreatedWebhook({
       throw new Error("Missing required parameters");
     }
 
-    const features = await getFeatureFlags({ teamId });
-    if (!features.webhooks) {
-      // webhooks are not enabled for this team
+    // check if team is on paid plan
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      select: { plan: true },
+    });
+
+    if (
+      team?.plan === "free" ||
+      team?.plan === "pro" ||
+      team?.plan.includes("trial")
+    ) {
+      // team is not on paid plan, so we don't need to send webhooks
       return;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Webhook sending is now available only for teams on paid plans. Teams on free, pro, or trial plans will not receive webhook events.

- **Bug Fixes**
  - Improved accuracy in determining webhook eligibility based on the team's subscription plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->