### PR TITLE
update invitation expire link time to 7days

### DIFF
--- a/pages/api/teams/[teamId]/invitations/resend.ts
+++ b/pages/api/teams/[teamId]/invitations/resend.ts
@@ -58,7 +58,7 @@ export default async function handle(
       });
 
       const expiresAt = new Date();
-      expiresAt.setHours(expiresAt.getHours() + 24); // invitation expires in 24 hour
+      expiresAt.setHours(expiresAt.getHours() + 168); // invitation expires in 7 days
 
       // update invitation
       const invitation = await prisma.invitation.update({

--- a/pages/api/teams/[teamId]/invite.ts
+++ b/pages/api/teams/[teamId]/invite.ts
@@ -110,7 +110,7 @@ export default async function handle(
 
       const token = newId("inv");
       const expiresAt = new Date();
-      expiresAt.setHours(expiresAt.getHours() + 24); // invitation expires in 24 hour
+      expiresAt.setHours(expiresAt.getHours() + 168); // 7 days // invitation expires in 24 hour
 
       // create invitation
       await prisma.invitation.create({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Extended the validity period of team invitation links from 24 hours to 7 days, allowing more time for invitees to accept invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->