### PR TITLE
fix: banner cover on larger screens

### DIFF
--- a/components/view/dataroom/nav-dataroom.tsx
+++ b/components/view/dataroom/nav-dataroom.tsx
@@ -206,7 +206,7 @@ export default function DataroomNav({
       {/* Banner section */}
       <div className="relative h-[20vh] sm:h-auto sm:max-h-80">
         <img
-          className="h-full w-full object-cover sm:max-h-80 sm:object-contain"
+          className="h-full w-full object-cover sm:max-h-80 sm:object-contain xl:object-cover"
           src={brand?.banner || DEFAULT_BANNER_IMAGE}
           alt="Banner"
           width={1920}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved banner image display in the dataroom navigation, ensuring better coverage and visual consistency on extra-large screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->