### PR TITLE
fix: gif in link's name

### DIFF
--- a/components/view/viewer/pages-horizontal-viewer.tsx
+++ b/components/view/viewer/pages-horizontal-viewer.tsx
@@ -668,7 +668,7 @@ export default function PagesHorizontalViewer({
                       {page.pageLinks ? (
                         <map name={`page-map-${index + 1}`}>
                           {page.pageLinks
-                            .filter((link) => !link.href.includes(".gif"))
+                            .filter((link) => !link.href.endsWith(".gif"))
                             .map((link, index) => (
                               <area
                                 key={index}
@@ -698,7 +698,7 @@ export default function PagesHorizontalViewer({
                       {/** Automatically Render Overlays **/}
                       {page.pageLinks
                         ? page.pageLinks
-                            .filter((link) => link.href.includes(".gif"))
+                            .filter((link) => link.href.endsWith(".gif"))
                             .map((link, linkIndex) => {
                               const [x1, y1, x2, y2] = scaleCoordinates(
                                 link.coords,
@@ -830,9 +830,7 @@ export default function PagesHorizontalViewer({
         {showPoweredByBanner ? <PoweredBy linkId={linkId} /> : null}
         <AwayPoster
           isVisible={isInactive}
-          inactivityThreshold={
-            getTrackingOptions().inactivityThreshold
-          }
+          inactivityThreshold={getTrackingOptions().inactivityThreshold}
           onDismiss={updateActivity}
         />
       </div>

--- a/components/view/viewer/pages-vertical-viewer.tsx
+++ b/components/view/viewer/pages-vertical-viewer.tsx
@@ -871,7 +871,7 @@ export default function PagesVerticalViewer({
                         {page.pageLinks ? (
                           <map name={`page-map-${index + 1}`}>
                             {page.pageLinks
-                              .filter((link) => !link.href.includes(".gif"))
+                              .filter((link) => !link.href.endsWith(".gif"))
                               .map((link, linkIndex) => (
                                 <area
                                   key={linkIndex}
@@ -902,7 +902,7 @@ export default function PagesVerticalViewer({
 
                         {page.pageLinks
                           ? page.pageLinks
-                              .filter((link) => link.href.includes(".gif"))
+                              .filter((link) => link.href.endsWith(".gif"))
                               .map((link, linkIndex) => {
                                 const [x1, y1, x2, y2] = scaleCoordinates(
                                   link.coords,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved filtering of GIF image links to only match links ending with ".gif", ensuring more accurate categorization and display of GIF overlays and clickable areas.
- **Style**
	- Minor formatting update to the inactivity threshold property for improved code readability (no impact on functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->