### PR TITLE
fix: child folder is allowed but parent not

### DIFF
--- a/pages/api/links/[id]/index.ts
+++ b/pages/api/links/[id]/index.ts
@@ -63,6 +63,7 @@ export default async function handle(
           groupId: true,
           permissionGroupId: true,
           audienceType: true,
+          dataroomId: true,
           teamId: true,
           team: {
             select: {
@@ -115,6 +116,7 @@ export default async function handle(
         console.time("get-dataroom-link-data");
         const data = await fetchDataroomLinkData({
           linkId: id,
+          dataroomId: link.dataroomId,
           teamId: link.teamId!,
           permissionGroupId: link.permissionGroupId || undefined,
           ...(link.audienceType === LinkAudienceType.GROUP &&
@@ -134,6 +136,7 @@ export default async function handle(
       const returnLink = {
         ...link,
         ...linkData,
+        dataroomId: undefined,
         ...(teamPlan === "free" && {
           customFields: [], // reset custom fields for free plan
           enableAgreement: false,

--- a/pages/api/links/domains/[...domainSlug].ts
+++ b/pages/api/links/domains/[...domainSlug].ts
@@ -164,6 +164,7 @@ export default async function handle(
         } else {
           const data = await fetchDataroomLinkData({
             linkId: link.id,
+            dataroomId: link.dataroomId,
             teamId: link.teamId!,
             permissionGroupId: link.permissionGroupId || undefined,
             ...(link.audienceType === LinkAudienceType.GROUP &&


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved folder access for dataroom links by ensuring all parent folders are included when permissions exist on subfolders, providing a more complete folder hierarchy view.

- **Bug Fixes**
  - Enhanced link retrieval to properly handle and process the dataroom identifier, ensuring accurate data representation in link responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->