### PR TITLE
feat: add team-aware multi-region S3 storage support

### DIFF
--- a/app/api/views-dataroom/route.ts
+++ b/app/api/views-dataroom/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { getTeamStorageConfigById } from "@/ee/features/storage/config";
 import { authOptions } from "@/pages/api/auth/[...nextauth]";
 import { ItemType, LinkAudienceType } from "@prisma/client";
 import { ipAddress, waitUntil } from "@vercel/functions";
@@ -837,9 +838,15 @@ export async function POST(request: NextRequest) {
           useAdvancedExcelViewer = document?.advancedExcelEnabled ?? false;
 
           if (useAdvancedExcelViewer) {
-            documentVersion.file = documentVersion.file.includes("https://")
-              ? documentVersion.file
-              : `https://${process.env.NEXT_PRIVATE_ADVANCED_UPLOAD_DISTRIBUTION_HOST}/${documentVersion.file}`;
+            if (documentVersion.file.includes("https://")) {
+              documentVersion.file = documentVersion.file;
+            } else {
+              // Get team-specific storage config for advanced distribution host
+              const storageConfig = await getTeamStorageConfigById(
+                link.teamId!,
+              );
+              documentVersion.file = `https://${storageConfig.advancedDistributionHost}/${documentVersion.file}`;
+            }
           } else {
             const fileUrl = await getFile({
               data: documentVersion.file,

--- a/app/api/views/route.ts
+++ b/app/api/views/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { getTeamStorageConfigById } from "@/ee/features/storage/config";
 // Import authOptions directly from the source
 import { authOptions } from "@/pages/api/auth/[...nextauth]";
 import { ipAddress, waitUntil } from "@vercel/functions";
@@ -586,9 +587,15 @@ export async function POST(request: NextRequest) {
 
         if (documentVersion.type === "sheet") {
           if (useAdvancedExcelViewer) {
-            documentVersion.file = documentVersion.file.includes("https://")
-              ? documentVersion.file
-              : `https://${process.env.NEXT_PRIVATE_ADVANCED_UPLOAD_DISTRIBUTION_HOST}/${documentVersion.file}`;
+            if (documentVersion.file.includes("https://")) {
+              documentVersion.file = documentVersion.file;
+            } else {
+              // Get team-specific storage config for advanced distribution host
+              const storageConfig = await getTeamStorageConfigById(
+                link.teamId!,
+              );
+              documentVersion.file = `https://${storageConfig.advancedDistributionHost}/${documentVersion.file}`;
+            }
           } else {
             const fileUrl = await getFile({
               data: documentVersion.file,

--- a/ee/features/storage/config.ts
+++ b/ee/features/storage/config.ts
@@ -1,0 +1,101 @@
+import { getFeatureFlags } from "@/lib/featureFlags";
+
+export interface StorageConfig {
+  bucket: string;
+  advancedBucket?: string;
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  endpoint?: string;
+  distributionHost?: string;
+  advancedDistributionHost?: string;
+  distributionKeyId?: string;
+  distributionKeyContents?: string;
+}
+
+export type StorageRegion = "eu-central-1" | "us-east-2";
+
+/**
+ * Gets AWS storage configuration based on the storage region.
+ * Uses environment variables with _US suffix for US region, no suffix for EU region.
+ *
+ * @param storageRegion - The storage region ('us-east-2' for US, defaults to 'eu-central-1' for EU)
+ * @returns StorageConfig object with all necessary AWS configuration
+ */
+export function getStorageConfig(storageRegion?: string): StorageConfig {
+  const isUS = storageRegion === "us-east-2";
+  const suffix = isUS ? "_US" : "";
+
+  // Get base environment variables with optional suffix
+  const getBucket = () => {
+    const bucketVar = `NEXT_PRIVATE_UPLOAD_BUCKET${suffix}`;
+    const bucket = process.env[bucketVar];
+    if (!bucket) {
+      throw new Error(`Missing environment variable: ${bucketVar}`);
+    }
+    return bucket;
+  };
+
+  const getAccessKeyId = () => {
+    const keyVar = `NEXT_PRIVATE_UPLOAD_ACCESS_KEY_ID${suffix}`;
+    const key = process.env[keyVar];
+    if (!key) {
+      throw new Error(`Missing environment variable: ${keyVar}`);
+    }
+    return key;
+  };
+
+  const getSecretAccessKey = () => {
+    const secretVar = `NEXT_PRIVATE_UPLOAD_SECRET_ACCESS_KEY${suffix}`;
+    const secret = process.env[secretVar];
+    if (!secret) {
+      throw new Error(`Missing environment variable: ${secretVar}`);
+    }
+    return secret;
+  };
+
+  const getRegion = () => {
+    const regionVar = `NEXT_PRIVATE_UPLOAD_REGION${suffix}`;
+    return process.env[regionVar] || (isUS ? "us-east-2" : "eu-central-1");
+  };
+
+  return {
+    bucket: getBucket(),
+    advancedBucket: process.env[`NEXT_PRIVATE_ADVANCED_UPLOAD_BUCKET${suffix}`],
+    region: getRegion(),
+    accessKeyId: getAccessKeyId(),
+    secretAccessKey: getSecretAccessKey(),
+    endpoint: process.env[`NEXT_PRIVATE_UPLOAD_ENDPOINT${suffix}`],
+    distributionHost:
+      process.env[`NEXT_PRIVATE_UPLOAD_DISTRIBUTION_HOST${suffix}`],
+    advancedDistributionHost:
+      process.env[`NEXT_PRIVATE_ADVANCED_UPLOAD_DISTRIBUTION_HOST${suffix}`],
+    distributionKeyId:
+      process.env[`NEXT_PRIVATE_UPLOAD_DISTRIBUTION_KEY_ID${suffix}`],
+    distributionKeyContents:
+      process.env[`NEXT_PRIVATE_UPLOAD_DISTRIBUTION_KEY_CONTENTS${suffix}`],
+  };
+}
+
+/**
+ * Gets storage configuration for a team using feature flags.
+ * This is the main function that should be used by file operations.
+ *
+ * @param teamId - The team ID to get storage configuration for
+ * @returns Promise<StorageConfig> - The storage configuration for the team
+ */
+export async function getTeamStorageConfigById(
+  teamId: string,
+): Promise<StorageConfig> {
+  try {
+    const features = await getFeatureFlags({ teamId });
+
+    // If team has usStorage feature flag enabled, use US region
+    const storageRegion = features.usStorage ? "us-east-2" : undefined;
+
+    return getStorageConfig(storageRegion);
+  } catch (error) {
+    console.warn(`Failed to resolve storage region for team ${teamId}:`, error);
+    return getStorageConfig(); // Default to EU region on error
+  }
+}

--- a/ee/features/storage/s3-store.ts
+++ b/ee/features/storage/s3-store.ts
@@ -1,0 +1,196 @@
+import {
+  type StorageConfig,
+  getStorageConfig,
+} from "@/ee/features/storage/config";
+import { S3 } from "@aws-sdk/client-s3";
+import { S3Store } from "@tus/s3-store";
+import type { Upload } from "@tus/server";
+import type { Readable } from "stream";
+
+import { getFeatureFlags } from "@/lib/featureFlags";
+
+/**
+ * Team-aware S3Store that routes uploads to different S3 buckets
+ * based on team storage preferences. Extends S3Store and dynamically
+ * switches the S3 client and bucket based on team feature flags.
+ */
+export class MultiRegionS3Store extends S3Store {
+  private euConfig: StorageConfig;
+  private usConfig: StorageConfig;
+  private euClient: S3;
+  private usClient: S3;
+  private teamStorageCache = new Map<string, boolean>(); // teamId -> useUSStorage
+
+  constructor() {
+    // Initialize with EU config as default
+    const euConfig = getStorageConfig();
+
+    // Create S3 client config for super() call (omit endpoint if empty/undefined)
+    const superS3Config: any = {
+      bucket: euConfig.bucket,
+      region: euConfig.region,
+      credentials: {
+        accessKeyId: euConfig.accessKeyId,
+        secretAccessKey: euConfig.secretAccessKey,
+      },
+    };
+
+    super({
+      partSize: 8 * 1024 * 1024, // 8MiB parts
+      s3ClientConfig: superS3Config,
+    });
+
+    // Store configurations
+    this.euConfig = euConfig;
+
+    // Create EU S3 client configuration (omit endpoint if empty/undefined)
+    const euS3Config: any = {
+      bucket: euConfig.bucket,
+      region: euConfig.region,
+      credentials: {
+        accessKeyId: euConfig.accessKeyId,
+        secretAccessKey: euConfig.secretAccessKey,
+      },
+    };
+
+    this.euClient = new S3(euS3Config);
+
+    // Initialize US configuration and client
+    try {
+      this.usConfig = getStorageConfig("us-east-2");
+
+      // Create US S3 client configuration (omit endpoint if empty/undefined)
+      const usS3Config: any = {
+        bucket: this.usConfig.bucket,
+        region: this.usConfig.region,
+        credentials: {
+          accessKeyId: this.usConfig.accessKeyId,
+          secretAccessKey: this.usConfig.secretAccessKey,
+        },
+      };
+
+      this.usClient = new S3(usS3Config);
+    } catch (error) {
+      this.usConfig = euConfig;
+      this.usClient = this.euClient;
+    }
+  }
+
+  /**
+   * Extracts teamId from upload ID (format: teamId/docId/filename)
+   */
+  private extractTeamIdFromUploadId(uploadId: string): string | null {
+    const parts = uploadId.split("/");
+    return parts.length > 0 ? parts[0] : null;
+  }
+
+  /**
+   * Determines if team should use US storage, with caching
+   */
+  private async shouldUseUSStorage(teamId: string): Promise<boolean> {
+    // Check cache first
+    if (this.teamStorageCache.has(teamId)) {
+      const cached = this.teamStorageCache.get(teamId)!;
+
+      return cached;
+    }
+
+    try {
+      const features = await getFeatureFlags({ teamId });
+      const useUS = features.usStorage || false;
+
+      // Cache the result for 5 minutes
+      this.teamStorageCache.set(teamId, useUS);
+      setTimeout(() => this.teamStorageCache.delete(teamId), 5 * 60 * 1000);
+
+      return useUS;
+    } catch (error) {
+      return false; // Default to EU
+    }
+  }
+
+  /**
+   * Sets the S3 client and bucket for the appropriate region
+   */
+  private async ensureCorrectRegion(uploadId: string): Promise<void> {
+    const teamId = this.extractTeamIdFromUploadId(uploadId);
+
+    if (!teamId) {
+      // Default to EU - ensure we're using EU client and bucket
+      this.client = this.euClient;
+      this.bucket = this.euConfig.bucket;
+      return;
+    }
+
+    const useUS = await this.shouldUseUSStorage(teamId);
+    if (useUS) {
+      // Switch to US client and bucket
+      this.client = this.usClient;
+      this.bucket = this.usConfig.bucket;
+    } else {
+      // Use EU client and bucket
+      this.client = this.euClient;
+      this.bucket = this.euConfig.bucket;
+    }
+  }
+
+  // Override key S3Store methods to ensure correct region
+  async create(upload: Upload): Promise<Upload> {
+    try {
+      await this.ensureCorrectRegion(upload.id);
+      return await super.create(upload);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async write(stream: Readable, id: string, offset: number): Promise<number> {
+    try {
+      await this.ensureCorrectRegion(id);
+      return await super.write(stream, id, offset);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async getUpload(id: string): Promise<Upload> {
+    try {
+      await this.ensureCorrectRegion(id);
+      return await super.getUpload(id);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async remove(id: string): Promise<void> {
+    try {
+      await this.ensureCorrectRegion(id);
+      // Clean up cache entry
+      const teamId = this.extractTeamIdFromUploadId(id);
+      if (teamId) {
+        this.teamStorageCache.delete(teamId);
+      }
+      await super.remove(id);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async declareUploadLength(id: string, length: number): Promise<void> {
+    try {
+      await this.ensureCorrectRegion(id);
+      await super.declareUploadLength(id, length);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async read(id: string): Promise<Readable> {
+    try {
+      await this.ensureCorrectRegion(id);
+      return await super.read(id);
+    } catch (error) {
+      throw error;
+    }
+  }
+}

--- a/lib/api/documents/process-document.ts
+++ b/lib/api/documents/process-document.ts
@@ -206,6 +206,7 @@ export const processDocument = async ({
     await copyFileToBucketServer({
       filePath: document.versions[0].file,
       storageType: document.versions[0].storageType,
+      teamId,
     });
 
     await prisma.documentVersion.update({

--- a/lib/featureFlags/index.ts
+++ b/lib/featureFlags/index.ts
@@ -8,7 +8,8 @@ export type BetaFeatures =
   | "webhooks"
   | "conversations"
   | "dataroomUpload"
-  | "inDocumentLinks";
+  | "inDocumentLinks"
+  | "usStorage";
 type BetaFeaturesRecord = Record<BetaFeatures, string[]>;
 
 export const getFeatureFlags = async ({ teamId }: { teamId?: string }) => {
@@ -21,6 +22,7 @@ export const getFeatureFlags = async ({ teamId }: { teamId?: string }) => {
     conversations: false,
     dataroomUpload: false,
     inDocumentLinks: false,
+    usStorage: false,
   };
 
   // Return all features as true if edge config is not available

--- a/lib/files/aws-client.ts
+++ b/lib/files/aws-client.ts
@@ -1,45 +1,109 @@
+import {
+  type StorageConfig,
+  getStorageConfig,
+  getTeamStorageConfigById,
+} from "@/ee/features/storage/config";
 import { LambdaClient } from "@aws-sdk/client-lambda";
 import { S3Client } from "@aws-sdk/client-s3";
 
-export const getS3Client = () => {
+export const getS3Client = (storageRegion?: string) => {
   const NEXT_PUBLIC_UPLOAD_TRANSPORT = process.env.NEXT_PUBLIC_UPLOAD_TRANSPORT;
 
   if (NEXT_PUBLIC_UPLOAD_TRANSPORT !== "s3") {
     throw new Error("Invalid upload transport");
   }
 
-  const hasCredentials =
-    process.env.NEXT_PRIVATE_UPLOAD_ACCESS_KEY_ID &&
-    process.env.NEXT_PRIVATE_UPLOAD_SECRET_ACCESS_KEY;
+  const config = getStorageConfig(storageRegion);
 
   return new S3Client({
-    endpoint: process.env.NEXT_PRIVATE_UPLOAD_ENDPOINT || undefined,
-    region: process.env.NEXT_PRIVATE_UPLOAD_REGION || "eu-central-1",
-    credentials: hasCredentials
-      ? {
-          accessKeyId: String(process.env.NEXT_PRIVATE_UPLOAD_ACCESS_KEY_ID),
-          secretAccessKey: String(
-            process.env.NEXT_PRIVATE_UPLOAD_SECRET_ACCESS_KEY,
-          ),
-        }
-      : undefined,
+    endpoint: config.endpoint || undefined,
+    region: config.region,
+    credentials: {
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
+    },
   });
 };
 
-export const getLambdaClient = () => {
+export const getS3ClientForTeam = async (teamId: string) => {
   const NEXT_PUBLIC_UPLOAD_TRANSPORT = process.env.NEXT_PUBLIC_UPLOAD_TRANSPORT;
 
   if (NEXT_PUBLIC_UPLOAD_TRANSPORT !== "s3") {
     throw new Error("Invalid upload transport");
   }
 
-  return new LambdaClient({
-    region: process.env.NEXT_PRIVATE_UPLOAD_REGION || "eu-central-1",
+  const config = await getTeamStorageConfigById(teamId);
+
+  return new S3Client({
+    endpoint: config.endpoint || undefined,
+    region: config.region,
     credentials: {
-      accessKeyId: String(process.env.NEXT_PRIVATE_UPLOAD_ACCESS_KEY_ID),
-      secretAccessKey: String(
-        process.env.NEXT_PRIVATE_UPLOAD_SECRET_ACCESS_KEY,
-      ),
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
     },
   });
+};
+
+export const getLambdaClient = (storageRegion?: string) => {
+  const NEXT_PUBLIC_UPLOAD_TRANSPORT = process.env.NEXT_PUBLIC_UPLOAD_TRANSPORT;
+
+  if (NEXT_PUBLIC_UPLOAD_TRANSPORT !== "s3") {
+    throw new Error("Invalid upload transport");
+  }
+
+  const config = getStorageConfig(storageRegion);
+
+  return new LambdaClient({
+    region: config.region,
+    credentials: {
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
+    },
+  });
+};
+
+export const getLambdaClientForTeam = async (teamId: string) => {
+  const NEXT_PUBLIC_UPLOAD_TRANSPORT = process.env.NEXT_PUBLIC_UPLOAD_TRANSPORT;
+
+  if (NEXT_PUBLIC_UPLOAD_TRANSPORT !== "s3") {
+    throw new Error("Invalid upload transport");
+  }
+
+  const config = await getTeamStorageConfigById(teamId);
+
+  return new LambdaClient({
+    region: config.region,
+    credentials: {
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
+    },
+  });
+};
+
+/**
+ * Gets both S3 client and storage config for a team in a single call.
+ * This is more efficient than calling getS3ClientForTeam and getTeamStorageConfigById separately.
+ *
+ * @param teamId - The team ID
+ * @returns Promise<{ client: S3Client, config: StorageConfig }> - Both client and config
+ */
+export const getTeamS3ClientAndConfig = async (teamId: string) => {
+  const NEXT_PUBLIC_UPLOAD_TRANSPORT = process.env.NEXT_PUBLIC_UPLOAD_TRANSPORT;
+
+  if (NEXT_PUBLIC_UPLOAD_TRANSPORT !== "s3") {
+    throw new Error("Invalid upload transport");
+  }
+
+  const config = await getTeamStorageConfigById(teamId);
+
+  const client = new S3Client({
+    endpoint: config.endpoint || undefined,
+    region: config.region,
+    credentials: {
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
+    },
+  });
+
+  return { client, config };
 };

--- a/lib/files/delete-file-server.ts
+++ b/lib/files/delete-file-server.ts
@@ -3,17 +3,18 @@ import { DocumentStorageType } from "@prisma/client";
 import { del } from "@vercel/blob";
 import { match } from "ts-pattern";
 
-import { getS3Client } from "./aws-client";
+import { getTeamS3ClientAndConfig } from "./aws-client";
 
 export type DeleteFileOptions = {
   type: DocumentStorageType;
   data: string; // url for vercel, folderpath for s3
+  teamId: string; // needed to resolve storage region
 };
 
-export const deleteFile = async ({ type, data }: DeleteFileOptions) => {
+export const deleteFile = async ({ type, data, teamId }: DeleteFileOptions) => {
   return await match(type)
     .with(DocumentStorageType.S3_PATH, async () =>
-      deleteAllFilesFromS3Server(data),
+      deleteAllFilesFromS3Server(data, teamId),
     )
     .with(DocumentStorageType.VERCEL_BLOB, async () =>
       deleteFileFromVercelServer(data),
@@ -27,17 +28,17 @@ const deleteFileFromVercelServer = async (url: string) => {
   await del(url);
 };
 
-const deleteAllFilesFromS3Server = async (data: string) => {
+const deleteAllFilesFromS3Server = async (data: string, teamId: string) => {
   // get docId from url with starts with "doc_" with regex
   const dataMatch = data.match(/^(.*doc_[^\/]+)\//);
   const folderPath = dataMatch ? dataMatch[1] : data;
 
-  const client = getS3Client();
+  const { client, config } = await getTeamS3ClientAndConfig(teamId);
 
   try {
     // List all objects in the folder
     const listParams = {
-      Bucket: process.env.NEXT_PRIVATE_UPLOAD_BUCKET,
+      Bucket: config.bucket,
       Prefix: `${folderPath}/`, // Ensure this ends with a slash if it's a folder
     };
     const listedObjects = await client.send(
@@ -49,7 +50,7 @@ const deleteAllFilesFromS3Server = async (data: string) => {
 
     // Prepare delete parameters
     const deleteParams = {
-      Bucket: process.env.NEXT_PRIVATE_UPLOAD_BUCKET,
+      Bucket: config.bucket,
       Delete: {
         Objects: listedObjects.Contents.map((file) => ({ Key: file.Key })),
       },
@@ -60,7 +61,7 @@ const deleteAllFilesFromS3Server = async (data: string) => {
 
     if (listedObjects.IsTruncated) {
       // If there are more files than returned in a single request, recurse
-      await deleteAllFilesFromS3Server(folderPath);
+      await deleteAllFilesFromS3Server(folderPath, teamId);
     }
   } catch (error) {
     console.error("Error deleting files:", error);

--- a/lib/files/delete-team-files-server.ts
+++ b/lib/files/delete-team-files-server.ts
@@ -1,7 +1,7 @@
 import { DeleteObjectsCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
 import { del } from "@vercel/blob";
 
-import { getS3Client } from "./aws-client";
+import { getTeamS3ClientAndConfig } from "./aws-client";
 
 export type DeleteFilesOptions = {
   teamId: string;
@@ -25,12 +25,12 @@ const deleteAllFilesFromS3Server = async (teamId: string) => {
   // the teamId is the first prefix in the folder path
   const folderPath = teamId;
 
-  const client = getS3Client();
+  const { client, config } = await getTeamS3ClientAndConfig(teamId);
 
   try {
     // List all objects in the folder
     const listParams = {
-      Bucket: process.env.NEXT_PRIVATE_UPLOAD_BUCKET,
+      Bucket: config.bucket,
       Prefix: `${folderPath}/`, // Ensure this ends with a slash if it's a folder
     };
     const listedObjects = await client.send(
@@ -42,7 +42,7 @@ const deleteAllFilesFromS3Server = async (teamId: string) => {
 
     // Prepare delete parameters
     const deleteParams = {
-      Bucket: process.env.NEXT_PRIVATE_UPLOAD_BUCKET,
+      Bucket: config.bucket,
       Delete: {
         Objects: listedObjects.Contents.map((file) => ({ Key: file.Key })),
       },

--- a/lib/files/put-file-server.ts
+++ b/lib/files/put-file-server.ts
@@ -8,7 +8,7 @@ import { match } from "ts-pattern";
 import { newId } from "@/lib/id-helper";
 
 import { SUPPORTED_DOCUMENT_MIME_TYPES } from "../constants";
-import { getS3Client } from "./aws-client";
+import { getTeamS3ClientAndConfig } from "./aws-client";
 
 // `File` is a web API type and not available server-side, so we need to define our own type
 type File = {
@@ -87,7 +87,7 @@ const putFileInS3Server = async ({
     throw new Error("Unsupported file type");
   }
 
-  const client = getS3Client();
+  const { client, config } = await getTeamS3ClientAndConfig(teamId);
 
   // Get the basename and extension for the file
   const { name, ext } = path.parse(file.name);
@@ -95,7 +95,7 @@ const putFileInS3Server = async ({
   const key = `${teamId}/${docId}/${slugify(name)}${ext}`;
 
   const params = {
-    Bucket: process.env.NEXT_PRIVATE_UPLOAD_BUCKET,
+    Bucket: config.bucket,
     Key: key,
     Body: file.buffer,
     ContentType: file.type,

--- a/lib/files/stream-file-server.ts
+++ b/lib/files/stream-file-server.ts
@@ -4,7 +4,7 @@ import slugify from "@sindresorhus/slugify";
 import path from "node:path";
 import { Readable } from "stream";
 
-import { getS3Client } from "./aws-client";
+import { getTeamS3ClientAndConfig } from "./aws-client";
 
 type StreamFile = {
   name: string;
@@ -21,7 +21,7 @@ export const streamFileServer = async ({
   teamId: string;
   docId: string;
 }) => {
-  const client = getS3Client();
+  const { client, config } = await getTeamS3ClientAndConfig(teamId);
 
   // Get the basename and extension for the file
   const { name, ext } = path.parse(file.name);
@@ -31,7 +31,7 @@ export const streamFileServer = async ({
   const params = {
     client,
     params: {
-      Bucket: process.env.NEXT_PRIVATE_UPLOAD_BUCKET,
+      Bucket: config.bucket,
       Key: key,
       Body: file.stream,
       ContentType: file.type,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -181,8 +181,11 @@ function prepareRemotePatterns() {
     { protocol: "https", hostname: "faisalman.github.io" },
     // special document pages
     { protocol: "https", hostname: "d36r2enbzam0iu.cloudfront.net" },
+    // us special storage
+    { protocol: "https", hostname: "d35vw2hoyyl88.cloudfront.net" },
   ];
 
+  // Default region patterns
   if (process.env.NEXT_PRIVATE_UPLOAD_DISTRIBUTION_HOST) {
     patterns.push({
       protocol: "https",
@@ -194,6 +197,21 @@ function prepareRemotePatterns() {
     patterns.push({
       protocol: "https",
       hostname: process.env.NEXT_PRIVATE_ADVANCED_UPLOAD_DISTRIBUTION_HOST,
+    });
+  }
+
+  // US region patterns
+  if (process.env.NEXT_PRIVATE_UPLOAD_DISTRIBUTION_HOST_US) {
+    patterns.push({
+      protocol: "https",
+      hostname: process.env.NEXT_PRIVATE_UPLOAD_DISTRIBUTION_HOST_US,
+    });
+  }
+
+  if (process.env.NEXT_PRIVATE_ADVANCED_UPLOAD_DISTRIBUTION_HOST_US) {
+    patterns.push({
+      protocol: "https",
+      hostname: process.env.NEXT_PRIVATE_ADVANCED_UPLOAD_DISTRIBUTION_HOST_US,
     });
   }
 

--- a/pages/api/file/s3/get-presigned-post-url.ts
+++ b/pages/api/file/s3/get-presigned-post-url.ts
@@ -7,13 +7,11 @@ import { getServerSession } from "next-auth";
 import path from "node:path";
 
 import { ONE_HOUR, ONE_SECOND } from "@/lib/constants";
-import { getS3Client } from "@/lib/files/aws-client";
+import { getTeamS3ClientAndConfig } from "@/lib/files/aws-client";
 import prisma from "@/lib/prisma";
 import { CustomUser } from "@/lib/types";
 
 import { authOptions } from "../../auth/[...nextauth]";
-
-const client = getS3Client();
 
 export default async function handler(
   req: NextApiRequest,
@@ -58,8 +56,10 @@ export default async function handler(
     const slugifiedName = slugify(name) + ext;
     const key = `${team.id}/${docId}/${slugifiedName}`;
 
+    const { client, config } = await getTeamS3ClientAndConfig(team.id);
+
     const putObjectCommand = new PutObjectCommand({
-      Bucket: process.env.NEXT_PRIVATE_UPLOAD_BUCKET,
+      Bucket: config.bucket,
       Key: key,
       ContentType: contentType,
       ContentDisposition: `attachment; filename="${slugifiedName}"`,

--- a/pages/api/file/tus/[[...file]].ts
+++ b/pages/api/file/tus/[[...file]].ts
@@ -1,13 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { MultiRegionS3Store } from "@/ee/features/storage/s3-store";
 import { CopyObjectCommand } from "@aws-sdk/client-s3";
 import slugify from "@sindresorhus/slugify";
-import { S3Store } from "@tus/s3-store";
 import { Server } from "@tus/server";
 import { getServerSession } from "next-auth/next";
 import path from "node:path";
 
-import { getS3Client } from "@/lib/files/aws-client";
+import { getTeamS3ClientAndConfig } from "@/lib/files/aws-client";
 import { RedisLocker } from "@/lib/files/tus-redis-locker";
 import { newId } from "@/lib/id-helper";
 import { lockerRedisClient } from "@/lib/redis";
@@ -25,28 +25,13 @@ const locker = new RedisLocker({
   redisClient: lockerRedisClient,
 });
 
-const client = getS3Client();
-
 const tusServer = new Server({
   // `path` needs to match the route declared by the next file router
   path: "/api/file/tus",
   maxSize: 1024 * 1024 * 1024 * 2, // 2 GiB
   respectForwardedHeaders: true,
   locker,
-  datastore: new S3Store({
-    partSize: 8 * 1024 * 1024, // each uploaded part will have ~8MiB,
-    // TODO: expirationPeriodInMilliseconds is not working due to a permissions issue
-    // expirationPeriodInMilliseconds: 1000 * 60 * 60 * 3, // 3 hours
-    s3ClientConfig: {
-      bucket: process.env.NEXT_PRIVATE_UPLOAD_BUCKET as string,
-      region: process.env.NEXT_PRIVATE_UPLOAD_REGION as string,
-      credentials: {
-        accessKeyId: process.env.NEXT_PRIVATE_UPLOAD_ACCESS_KEY_ID as string,
-        secretAccessKey: process.env
-          .NEXT_PRIVATE_UPLOAD_SECRET_ACCESS_KEY as string,
-      },
-    },
-  }),
+  datastore: new MultiRegionS3Store(),
   namingFunction(req, metadata) {
     const { teamId, fileName } = metadata as {
       teamId: string;
@@ -84,10 +69,19 @@ const tusServer = new Server({
       // The Key (object path) where the file was uploaded
       const objectKey = upload.id;
 
+      // Extract teamId from the object key (format: teamId/docId/filename)
+      const teamId = objectKey.split("/")[0];
+      if (!teamId) {
+        throw { status_code: 500, body: "Invalid object key format" };
+      }
+
+      // Get team-specific S3 client and config
+      const { client, config } = await getTeamS3ClientAndConfig(teamId);
+
       // Copy the object onto itself, replacing the metadata
       const params = {
-        Bucket: process.env.NEXT_PRIVATE_UPLOAD_BUCKET,
-        CopySource: `${process.env.NEXT_PRIVATE_UPLOAD_BUCKET}/${objectKey}`,
+        Bucket: config.bucket,
+        CopySource: `${config.bucket}/${objectKey}`,
         Key: objectKey,
         ContentType: contentType,
         ContentDisposition: contentDisposition,

--- a/pages/api/teams/[teamId]/documents/[id]/advanced-mode.ts
+++ b/pages/api/teams/[teamId]/documents/[id]/advanced-mode.ts
@@ -63,13 +63,15 @@ export default async function handle(
 
       if (!supportsAdvancedExcelMode(documentVersion.contentType)) {
         return res.status(400).json({
-          message: "Advanced mode is only available for Excel files (.xls, .xlsx, .xlsm).",
+          message:
+            "Advanced mode is only available for Excel files (.xls, .xlsx, .xlsm).",
         });
       }
 
       await copyFileToBucketServer({
         filePath: documentVersion.file,
         storageType: documentVersion.storageType,
+        teamId,
       });
 
       const documentPromise = prisma.document.update({

--- a/pages/api/teams/[teamId]/documents/[id]/index.ts
+++ b/pages/api/teams/[teamId]/documents/[id]/index.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import { getServerSession } from "next-auth/next";
 
-import { errorhandler, TeamError } from "@/lib/errorHandler";
+import { TeamError, errorhandler } from "@/lib/errorHandler";
 import { deleteFile } from "@/lib/files/delete-file-server";
 import prisma from "@/lib/prisma";
 import { getTeamWithUsersAndDocument } from "@/lib/team/helper";
@@ -197,7 +197,11 @@ export default async function handle(
       if (documentVersions.type !== "notion") {
         // delete the files from storage
         for (const version of documentVersions.versions) {
-          await deleteFile({ type: version.storageType, data: version.file });
+          await deleteFile({
+            type: version.storageType,
+            data: version.file,
+            teamId,
+          });
         }
       }
 

--- a/pages/api/teams/[teamId]/documents/[id]/versions/index.ts
+++ b/pages/api/teams/[teamId]/documents/[id]/versions/index.ts
@@ -172,6 +172,7 @@ export default async function handle(
         await copyFileToBucketServer({
           filePath: version.file,
           storageType: version.storageType,
+          teamId,
         });
       }
 

--- a/pages/api/teams/[teamId]/enable-advanced-mode.ts
+++ b/pages/api/teams/[teamId]/enable-advanced-mode.ts
@@ -82,9 +82,12 @@ export default async function handle(
         },
       });
 
-      const eligibleDocuments = documents.filter(doc => {
+      const eligibleDocuments = documents.filter((doc) => {
         const primaryVersion = doc.versions[0];
-        return primaryVersion && supportsAdvancedExcelMode(primaryVersion.contentType);
+        return (
+          primaryVersion &&
+          supportsAdvancedExcelMode(primaryVersion.contentType)
+        );
       });
 
       // Update all documents and their versions
@@ -97,6 +100,7 @@ export default async function handle(
           await copyFileToBucketServer({
             filePath: primaryVersion.file,
             storageType: primaryVersion.storageType,
+            teamId: teamId as string,
           });
 
           // Update document and version when enabling

--- a/pages/api/teams/[teamId]/folders/manage/[folderId]/index.ts
+++ b/pages/api/teams/[teamId]/folders/manage/[folderId]/index.ts
@@ -64,7 +64,7 @@ export default async function handle(
       }
 
       // Delete the folder and its contents
-      await deleteFolderAndContents(folderId);
+      await deleteFolderAndContents(folderId, teamId);
 
       return res.status(204).end(); // 204 No Content response for successful deletes
     } catch (error) {
@@ -77,7 +77,7 @@ export default async function handle(
   }
 }
 
-async function deleteFolderAndContents(folderId: string) {
+async function deleteFolderAndContents(folderId: string, teamId: string) {
   const childFoldersToDelete = await prisma.folder.findMany({
     where: {
       parentId: folderId,
@@ -85,7 +85,7 @@ async function deleteFolderAndContents(folderId: string) {
   });
 
   for (const childFolder of childFoldersToDelete) {
-    await deleteFolderAndContents(childFolder.id);
+    await deleteFolderAndContents(childFolder.id, teamId);
   }
 
   // Delete all documents in the folder
@@ -110,7 +110,11 @@ async function deleteFolderAndContents(folderId: string) {
 
   documents.map(async (documentVersions: { versions: any }) => {
     for (const version of documentVersions.versions) {
-      await deleteFile({ type: version.storageType, data: version.file });
+      await deleteFile({
+        type: version.storageType,
+        data: version.file,
+        teamId,
+      });
     }
   });
 


### PR DESCRIPTION
Introduces team-specific S3 storage configuration and multi-region support, allowing teams to use either EU or US S3 buckets based on feature flags. Refactors file operations (upload, copy, delete, presigned URLs, Lambda invocations) to resolve storage region and credentials per team. Adds new storage config and multi-region S3Store, updates API routes and utility functions to use team-aware clients, and extends feature flags with 'usStorage'.