### PR TITLE
Improvement: Enable features in 7 day trial(and show correct popups)

### DIFF
--- a/components/datarooms/settings/notification-settings.tsx
+++ b/components/datarooms/settings/notification-settings.tsx
@@ -27,7 +27,7 @@ export default function NotificationSettings({
 }: NotificationSettingsProps) {
   const teamInfo = useTeam();
   const teamId = teamInfo?.currentTeam?.id;
-  const { isDataroomsPlus } = usePlan();
+  const { isDataroomsPlus, isTrial } = usePlan();
 
   const { data: dataroomData, mutate: mutateDataroom } = useSWR<{
     id: string;
@@ -49,7 +49,7 @@ export default function NotificationSettings({
   const handleNotificationToggle = async (checked: boolean) => {
     if (!dataroomId || !teamId) return;
 
-    if (!isDataroomsPlus && !features?.roomChangeNotifications) {
+    if (!isDataroomsPlus && !isTrial && !features?.roomChangeNotifications) {
       toast.error("This feature is not available in your plan");
       return;
     }

--- a/components/documents/document-header.tsx
+++ b/components/documents/document-header.tsx
@@ -931,7 +931,7 @@ export default function DocumentHeader({
 
       {prismaDocument.type === "sheet" &&
         supportsAdvancedExcelMode(primaryVersion.contentType) &&
-        (isFree || isPro) && (
+        (isFree || isPro) && !isTrial && (
           <AlertBanner
             id="advanced-excel-alert"
             variant="default"

--- a/components/folders/add-folder-modal.tsx
+++ b/components/folders/add-folder-modal.tsx
@@ -136,7 +136,7 @@ export function AddFolderModal({
   };
 
   // If the team is on a free plan, show the upgrade modal
-  if (isFree && (!isDataroom || !isTrial)) {
+  if (isFree && !isTrial) {
     if (children) {
       return (
         <UpgradePlanModal

--- a/components/links/link-sheet/index-file-section.tsx
+++ b/components/links/link-sheet/index-file-section.tsx
@@ -40,7 +40,7 @@ export default function IndexFileSection({
         link="https://www.papermark.com/help/article/link-settings"
         action={handleEnableIndexFile}
         isAllowed={isAllowed}
-        requiredPlan="Data Rooms Plus"
+        requiredPlan="data rooms plus"
         upgradeAction={() =>
           handleUpgradeStateChange({
             state: true,

--- a/components/links/link-sheet/index.tsx
+++ b/components/links/link-sheet/index.tsx
@@ -175,6 +175,7 @@ export default function LinkSheet({
   const [currentPreset, setCurrentPreset] = useState<LinkPreset | null>(null);
 
   const isPresetsAllowed =
+    isTrial ||
     (isPro && limits?.advancedLinkControlsOnPro) ||
     isBusiness ||
     isDatarooms ||

--- a/components/links/link-sheet/link-item.tsx
+++ b/components/links/link-sheet/link-item.tsx
@@ -1,11 +1,16 @@
 import { CircleHelpIcon, RotateCcwIcon } from "lucide-react";
 
+
+
+import { usePlan } from "@/lib/swr/use-billing";
+import { cn } from "@/lib/utils";
+
+
+
 import PlanBadge from "@/components/billing/plan-badge";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { BadgeTooltip, ButtonTooltip } from "@/components/ui/tooltip";
-
-import { cn } from "@/lib/utils";
 
 export default function LinkItem({
   title,
@@ -28,6 +33,10 @@ export default function LinkItem({
   resetAction?: () => void;
   tooltipContent?: string;
 }) {
+  const { isTrial } = usePlan();
+  const showBadge =
+    isTrial && requiredPlan?.toLowerCase() === "data rooms plus";
+
   return (
     <div className="flex items-center justify-between gap-x-2">
       <div className="flex w-full items-center justify-between space-x-2">
@@ -48,7 +57,9 @@ export default function LinkItem({
               <CircleHelpIcon className="h-4 w-4 shrink-0 text-muted-foreground hover:text-foreground" />
             </BadgeTooltip>
           )}
-          {!isAllowed && requiredPlan && <PlanBadge plan={requiredPlan} />}
+          {(!isAllowed && requiredPlan) || showBadge ? (
+            <PlanBadge plan={requiredPlan} />
+          ) : null}
         </h2>
         {enabled && resetAction && (
           <ButtonTooltip content="Reset to defaults">

--- a/components/links/link-sheet/upload-section/index.tsx
+++ b/components/links/link-sheet/upload-section/index.tsx
@@ -19,7 +19,6 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import { BadgeTooltip } from "@/components/ui/tooltip";
 
 import { DEFAULT_LINK_TYPE } from "..";

--- a/components/links/links-table.tsx
+++ b/components/links/links-table.tsx
@@ -95,7 +95,7 @@ export default function LinksTable({
 
   const now = Date.now();
   const router = useRouter();
-  const { isFree } = usePlan();
+  const { isFree, isTrial } = usePlan();
   const teamInfo = useTeam();
   const { id: targetId, groupId } = router.query as {
     id: string;
@@ -444,7 +444,10 @@ export default function LinksTable({
   const AddLinkButton = () => {
     if (!canAddLinks) {
       return (
-        <UpgradePlanModal clickedPlan={PlanEnum.Pro} trigger={"limit_add_link"}>
+        <UpgradePlanModal
+          clickedPlan={isTrial ? PlanEnum.Business : PlanEnum.Pro}
+          trigger={"limit_add_link"}
+        >
           <Button>Upgrade to Create Link</Button>
         </UpgradePlanModal>
       );

--- a/components/sidebar/team-switcher.tsx
+++ b/components/sidebar/team-switcher.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { useLimits } from "@/ee/limits/swr-handler";
 import { PlanEnum } from "@/ee/stripe/constants";
 import { ChevronsUpDown, UserRoundPlusIcon } from "lucide-react";
+import { usePlan } from "@/lib/swr/use-billing";
 import { Team } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -43,6 +44,7 @@ export function TeamSwitcher({
     React.useState<boolean>(false);
   const { isMobile } = useSidebar();
   const { canAddUsers, showUpgradePlanModal } = useLimits();
+  const { isTrial } = usePlan();
 
   const switchTeam = (team: Team) => {
     localStorage.setItem("currentTeamId", team.id);
@@ -115,7 +117,7 @@ export function TeamSwitcher({
       <SidebarMenuItem>
         {showUpgradePlanModal ? (
           <UpgradePlanModal
-            clickedPlan={PlanEnum.Pro}
+            clickedPlan={isTrial ? PlanEnum.Business : PlanEnum.Pro}
             trigger={"invite_team_members"}
           >
             <SidebarMenuButton

--- a/components/tags/add-tag-modal.tsx
+++ b/components/tags/add-tag-modal.tsx
@@ -54,7 +54,7 @@ export function AddTagsModal({
   >;
   handleSubmit: FormEventHandler<HTMLFormElement> | undefined;
 }) {
-  const { isFree } = usePlan();
+  const { isFree, isTrial } = usePlan();
   const initialValues = useRef(tagForm);
 
   useMemo(() => {
@@ -75,7 +75,10 @@ export function AddTagsModal({
   if (isFree && tagCount >= 5) {
     if (children) {
       return (
-        <UpgradePlanModal clickedPlan={PlanEnum.Pro} trigger={"create_tag"}>
+        <UpgradePlanModal
+          clickedPlan={isTrial ? PlanEnum.Business : PlanEnum.Pro}
+          trigger={"create_tag"}
+        >
           <Button>Upgrade to Create Tags</Button>
         </UpgradePlanModal>
       );

--- a/components/visitors/visitors-table.tsx
+++ b/components/visitors/visitors-table.tsx
@@ -77,7 +77,7 @@ export default function VisitorsTable({
     currentPage,
     pageSize,
   );
-  const { plan } = usePlan();
+  const { plan, isTrial } = usePlan();
   const isFreePlan = plan === "free";
 
   const [isLoading, setIsLoading] = useState(false);
@@ -479,7 +479,10 @@ export default function VisitorsTable({
                         Some older visits may not be shown because your document
                         has more than 20 views.{" "}
                       </span>
-                      <UpgradePlanModal clickedPlan={PlanEnum.Pro} trigger="">
+                      <UpgradePlanModal
+                        clickedPlan={isTrial ? PlanEnum.Business : PlanEnum.Pro}
+                        trigger=""
+                      >
                         <button className="underline hover:text-gray-800">
                           Upgrade to see full history
                         </button>

--- a/ee/features/permissions/components/dataroom-link-sheet.tsx
+++ b/ee/features/permissions/components/dataroom-link-sheet.tsx
@@ -120,6 +120,7 @@ export function DataroomLinkSheet({
     useState<boolean>(false);
 
   const isPresetsAllowed =
+    isTrial ||
     (isPro && limits?.advancedLinkControlsOnPro) ||
     isBusiness ||
     isDatarooms ||

--- a/ee/limits/handler.ts
+++ b/ee/limits/handler.ts
@@ -3,6 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { getLimits } from "@/ee/limits/server";
 import { authOptions } from "@/pages/api/auth/[...nextauth]";
 import { getServerSession } from "next-auth/next";
+import prisma from "@/lib/prisma";
 
 import { getFeatureFlags } from "@/lib/featureFlags";
 import { CustomUser } from "@/lib/types";
@@ -22,16 +23,31 @@ export default async function handle(
     const userId = (session.user as CustomUser).id;
 
     try {
-      const limits = await getLimits({ teamId, userId });
+      const team = await prisma.team.findUnique({
+        where: {
+          id: teamId,
+          users: {
+            some: {
+              userId: userId,
+            },
+          },
+        },
+        select: {
+          plan: true,
+        },
+      });
 
+      const limits = await getLimits({ teamId, userId });
+      const isTrial = team?.plan.includes("drtrial");
       const featureFlags = await getFeatureFlags({ teamId });
       const conversationsInDataroom =
-        featureFlags.conversations || limits.conversationsInDataroom;
+        featureFlags.conversations || limits.conversationsInDataroom || isTrial;
+      const dataroomUpload = featureFlags.dataroomUpload || isTrial;
 
       return res.status(200).json({
         ...limits,
         conversationsInDataroom,
-        dataroomUpload: featureFlags.dataroomUpload,
+        dataroomUpload,
       });
     } catch (error) {
       return res.status(500).json((error as Error).message);

--- a/ee/limits/handler.ts
+++ b/ee/limits/handler.ts
@@ -3,9 +3,9 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { getLimits } from "@/ee/limits/server";
 import { authOptions } from "@/pages/api/auth/[...nextauth]";
 import { getServerSession } from "next-auth/next";
-import prisma from "@/lib/prisma";
 
 import { getFeatureFlags } from "@/lib/featureFlags";
+import prisma from "@/lib/prisma";
 import { CustomUser } from "@/lib/types";
 
 export default async function handle(
@@ -23,6 +23,7 @@ export default async function handle(
     const userId = (session.user as CustomUser).id;
 
     try {
+      // TODO: move this to a cache layer
       const team = await prisma.team.findUnique({
         where: {
           id: teamId,

--- a/lib/webhook/triggers/document-created.ts
+++ b/lib/webhook/triggers/document-created.ts
@@ -24,8 +24,7 @@ export async function sendDocumentCreatedWebhook({
 
     if (
       team?.plan === "free" ||
-      team?.plan === "pro" ||
-      team?.plan.includes("trial")
+      team?.plan === "pro"
     ) {
       // team is not on paid plan, so we don't need to send webhooks
       return;

--- a/pages/api/teams/[teamId]/datarooms/[id]/folders/manage/[folderId]/dataroom-to-dataroom.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/folders/manage/[folderId]/dataroom-to-dataroom.ts
@@ -134,7 +134,7 @@ export default async function handle(
         return res.status(401).end("Unauthorized");
       }
 
-      if (team.plan === "free" || team.plan === "pro") {
+      if (team.plan === "free" || (team.plan === "pro" && !team.plan.includes("drtrial"))) {
         return res.status(403).json({
           message: "Upgrade your plan to use datarooms.",
         });

--- a/pages/api/teams/[teamId]/datarooms/[id]/folders/manage/[folderId]/dataroom-to-dataroom.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/folders/manage/[folderId]/dataroom-to-dataroom.ts
@@ -134,7 +134,10 @@ export default async function handle(
         return res.status(401).end("Unauthorized");
       }
 
-      if (team.plan === "free" || (team.plan === "pro" && !team.plan.includes("drtrial"))) {
+      if (
+        (team.plan === "free" || team.plan === "pro") &&
+        !team.plan.includes("drtrial")
+      ) {
         return res.status(403).json({
           message: "Upgrade your plan to use datarooms.",
         });

--- a/pages/api/teams/[teamId]/datarooms/[id]/index.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/index.ts
@@ -103,10 +103,12 @@ export default async function handle(
 
       const featureFlags = await getFeatureFlags({ teamId: team.id });
       const isDataroomsPlus = team.plan.includes("datarooms-plus");
+      const isTrial = team.plan.includes("drtrial");
 
       if (
         enableChangeNotifications !== undefined &&
         !isDataroomsPlus &&
+        !isTrial &&
         !featureFlags.roomChangeNotifications
       ) {
         return res.status(403).json({

--- a/pages/api/teams/[teamId]/datarooms/create-from-folder.ts
+++ b/pages/api/teams/[teamId]/datarooms/create-from-folder.ts
@@ -173,7 +173,7 @@ export default async function handle(
           .json({ message: "Trial data room already exists" });
       }
 
-      if (["free", "pro"].includes(team.plan)) {
+      if (["free", "pro"].includes(team.plan) && !team.plan.includes("drtrial")) {
         return res
           .status(400)
           .json({ message: "You need a Business plan to create a data room" });

--- a/pages/api/teams/[teamId]/documents/[id]/add-to-dataroom.ts
+++ b/pages/api/teams/[teamId]/documents/[id]/add-to-dataroom.ts
@@ -50,7 +50,10 @@ export default async function handle(
         return res.status(401).end("Unauthorized");
       }
 
-      if (team.plan === "free" || (team.plan === "pro" && !team.plan.includes("drtrial"))) {
+      if (
+        (team.plan === "free" || team.plan === "pro") &&
+        !team.plan.includes("drtrial")
+      ) {
         return res.status(403).json({
           message: "Upgrade your plan to use datarooms.",
         });

--- a/pages/api/teams/[teamId]/documents/[id]/add-to-dataroom.ts
+++ b/pages/api/teams/[teamId]/documents/[id]/add-to-dataroom.ts
@@ -50,7 +50,7 @@ export default async function handle(
         return res.status(401).end("Unauthorized");
       }
 
-      if (team.plan === "free" || team.plan === "pro") {
+      if (team.plan === "free" || (team.plan === "pro" && !team.plan.includes("drtrial"))) {
         return res.status(403).json({
           message: "Upgrade your plan to use datarooms.",
         });

--- a/pages/api/teams/[teamId]/update-advanced-mode.ts
+++ b/pages/api/teams/[teamId]/update-advanced-mode.ts
@@ -42,7 +42,7 @@ export default async function handle(
           },
         },
       });
-      if (!team || team.plan.includes("free")) {
+      if (!team || (team.plan.includes("free") && !team.plan.includes("trial"))) {
         return res.status(401).json({ error: "Unauthorized" });
       }
 

--- a/pages/datarooms/[id]/analytics/index.tsx
+++ b/pages/datarooms/[id]/analytics/index.tsx
@@ -31,7 +31,7 @@ export default function DataroomAnalyticsPage() {
   const defaultTab =
     isTrial || isDatarooms || isDataroomsPlus ? "analytics" : "audit-log";
   // Check if user has access to analytics features
-  const hasAnalyticsAccess = isDatarooms || isDataroomsPlus;
+  const hasAnalyticsAccess = isDatarooms || isDataroomsPlus || isTrial;
 
   if (!dataroom) {
     return <div>Loading...</div>;

--- a/pages/documents/[id]/index.tsx
+++ b/pages/documents/[id]/index.tsx
@@ -5,6 +5,10 @@ import { useState } from "react";
 import { useTeam } from "@/context/team-context";
 import { PlanEnum } from "@/ee/stripe/constants";
 
+import { usePlan } from "@/lib/swr/use-billing";
+import { useDocument, useDocumentLinks } from "@/lib/swr/use-document";
+import useLimits from "@/lib/swr/use-limits";
+
 import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import DocumentHeader from "@/components/documents/document-header";
 import { StatsComponent } from "@/components/documents/stats";
@@ -12,13 +16,9 @@ import VideoAnalytics from "@/components/documents/video-analytics";
 import AppLayout from "@/components/layouts/app";
 import LinkSheet from "@/components/links/link-sheet";
 import LinksTable from "@/components/links/links-table";
-import { NavMenu } from "@/components/navigation-menu";
 import { Button } from "@/components/ui/button";
 import LoadingSpinner from "@/components/ui/loading-spinner";
 import VisitorsTable from "@/components/visitors/visitors-table";
-
-import { useDocument, useDocumentLinks } from "@/lib/swr/use-document";
-import useLimits from "@/lib/swr/use-limits";
 
 export default function DocumentPage() {
   const {
@@ -29,6 +29,7 @@ export default function DocumentPage() {
   } = useDocument();
   const { links } = useDocumentLinks();
   const teamInfo = useTeam();
+  const { isTrial } = usePlan();
 
   const { canAddLinks } = useLimits();
 
@@ -41,7 +42,10 @@ export default function DocumentPage() {
   const AddLinkButton = () => {
     if (!canAddLinks) {
       return (
-        <UpgradePlanModal clickedPlan={PlanEnum.Pro} trigger={"limit_add_link"}>
+        <UpgradePlanModal
+          clickedPlan={isTrial ? PlanEnum.Business : PlanEnum.Pro}
+          trigger={"limit_add_link"}
+        >
           <Button className="flex h-8 whitespace-nowrap text-xs lg:h-9 lg:text-sm">
             Upgrade to Create Link
           </Button>

--- a/pages/settings/agreements.tsx
+++ b/pages/settings/agreements.tsx
@@ -15,12 +15,11 @@ import AgreementSheet from "@/components/links/link-sheet/agreement-panel";
 import { SettingsHeader } from "@/components/settings/settings-header";
 import { Button } from "@/components/ui/button";
 import { BadgeTooltip } from "@/components/ui/tooltip";
-
 export default function NdaAgreements() {
   const { agreements, loading, error } = useAgreements();
   const teamInfo = useTeam();
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
-  const { isBusiness, isDatarooms, isDataroomsPlus } = usePlan();
+  const { isBusiness, isDatarooms, isDataroomsPlus, isTrial } = usePlan();
 
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
@@ -60,7 +59,7 @@ export default function NdaAgreements() {
               </p>
             </div>
             <ul className="flex items-center justify-between gap-4">
-              {isBusiness || isDatarooms || isDataroomsPlus ? (
+              {isTrial || isBusiness || isDatarooms || isDataroomsPlus ? (
                 <Button variant="outline" onClick={() => setIsOpen(true)}>
                   <FileTextIcon className="h-4 w-4" />
                   Create agreement
@@ -118,7 +117,7 @@ export default function NdaAgreements() {
                   Create your first NDA agreement to get started
                 </p>
               </div>
-              {isBusiness || isDatarooms || isDataroomsPlus ? (
+              {isTrial || isBusiness || isDatarooms || isDataroomsPlus ? (
                 <Button variant="outline" onClick={() => setIsOpen(true)}>
                   <FileTextIcon className="h-4 w-4" />
                   Create NDA agreement

--- a/pages/settings/general.tsx
+++ b/pages/settings/general.tsx
@@ -32,7 +32,7 @@ export default function General() {
   const handleExcelAdvancedModeChange = async (data: {
     enableExcelAdvancedMode: string;
   }) => {
-    if (isFree && data.enableExcelAdvancedMode === "true") {
+    if (isFree && !isTrial && data.enableExcelAdvancedMode === "true") {
       showUpgradeModal(PlanEnum.Business, "advanced-excel-mode");
       return;
     }

--- a/pages/settings/people.tsx
+++ b/pages/settings/people.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import { mutate } from "swr";
 
 import { useAnalytics } from "@/lib/analytics";
+import { usePlan } from "@/lib/swr/use-billing";
 import { useInvitations } from "@/lib/swr/use-invitations";
 import useLimits from "@/lib/swr/use-limits";
 import { useGetTeam } from "@/lib/swr/use-team";
@@ -41,6 +42,7 @@ export default function Billing() {
   const { data: session } = useSession();
   const { team, loading } = useGetTeam()!;
   const teamInfo = useTeam();
+  const { isTrial } = usePlan();
   const { canAddUsers, showUpgradePlanModal } = useLimits();
   const { teams } = useTeams();
   const analytics = useAnalytics();
@@ -240,7 +242,7 @@ export default function Billing() {
               </div>
               {showUpgradePlanModal ? (
                 <UpgradePlanModal
-                  clickedPlan={PlanEnum.Pro}
+                  clickedPlan={isTrial ? PlanEnum.Business : PlanEnum.Pro}
                   trigger={"invite_team_members"}
                 >
                   <Button className="whitespace-nowrap px-1 text-xs sm:px-4 sm:text-sm">

--- a/pages/settings/presets/index.tsx
+++ b/pages/settings/presets/index.tsx
@@ -24,7 +24,7 @@ export default function Presets() {
   const router = useRouter();
   const teamInfo = useTeam();
 
-  const { isBusiness, isDatarooms, isDataroomsPlus } = usePlan();
+  const { isBusiness, isDatarooms, isDataroomsPlus, isTrial } = usePlan();
 
   const {
     data: presets,
@@ -56,7 +56,7 @@ export default function Presets() {
                 </BadgeTooltip>
               </p>
             </div>
-            {isBusiness || isDatarooms || isDataroomsPlus ? (
+            {isTrial || isBusiness || isDatarooms || isDataroomsPlus ? (
               <Button onClick={() => router.push("/settings/presets/new")}>
                 <PlusIcon className="mr-1.5 h-4 w-4" />
                 Create Preset
@@ -86,7 +86,7 @@ export default function Presets() {
                   when creating links.
                 </p>
               </div>
-              {isBusiness || isDatarooms || isDataroomsPlus ? (
+              {isTrial || isBusiness || isDatarooms || isDataroomsPlus ? (
                 <Button
                   variant="outline"
                   onClick={() => router.push("/settings/presets/new")}

--- a/pages/settings/webhooks/[id]/index.tsx
+++ b/pages/settings/webhooks/[id]/index.tsx
@@ -32,7 +32,7 @@ export default function WebhookDetail() {
   const router = useRouter();
   const { id } = router.query;
   const teamInfo = useTeam();
-  const { isFree, isPro } = usePlan();
+  const { isFree, isPro, isTrial } = usePlan();
   const teamId = teamInfo?.currentTeam?.id;
   const [isEditing, setIsEditing] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
@@ -64,7 +64,7 @@ export default function WebhookDetail() {
   }, [webhook]);
 
   const handleUpdate = async () => {
-    if (isFree || isPro) {
+    if ((isFree || isPro) && !isTrial) {
       toast.error("This feature is not available on your plan");
       return;
     }
@@ -359,7 +359,7 @@ export default function WebhookDetail() {
                         onClick={(e) => {
                           e.preventDefault();
                           e.stopPropagation();
-                          if (isFree || isPro) {
+                          if ((isFree || isPro) && !isTrial) {
                             toast.error(
                               "This feature is not available on your plan",
                             );

--- a/pages/settings/webhooks/index.tsx
+++ b/pages/settings/webhooks/index.tsx
@@ -22,7 +22,7 @@ interface Webhook {
 
 export default function WebhookSettings() {
   const teamInfo = useTeam();
-  const { isFree, isPro } = usePlan();
+  const { isFree, isPro, isTrial } = usePlan();
   const teamId = teamInfo?.currentTeam?.id;
 
   const { data: webhooks } = useSWR<Webhook[]>(
@@ -39,7 +39,9 @@ export default function WebhookSettings() {
             <div className="space-y-1">
               <h3 className="flex items-center gap-2 text-2xl font-semibold tracking-tight text-foreground">
                 Webhooks{" "}
-                {isFree || isPro ? <PlanBadge plan="Business" /> : null}
+                {(isFree || isPro) && !isTrial ? (
+                  <PlanBadge plan="Business" />
+                ) : null}
               </h3>
               <p className="flex flex-row items-center gap-2 text-sm text-muted-foreground">
                 Send data to external services when events happen in Papermark

--- a/pages/settings/webhooks/new.tsx
+++ b/pages/settings/webhooks/new.tsx
@@ -74,7 +74,7 @@ const formSchema = z.object({
 export default function NewWebhook() {
   const router = useRouter();
   const teamInfo = useTeam();
-  const { isFree, isPro } = usePlan();
+  const { isFree, isPro, isTrial } = usePlan();
   const teamId = teamInfo?.currentTeam?.id;
 
   const [isLoading, setIsLoading] = useState(false);
@@ -92,7 +92,7 @@ export default function NewWebhook() {
   }, []);
 
   const createWebhook = async () => {
-    if (isFree || isPro) {
+    if ((isFree || isPro) && !isTrial) {
       return;
     }
 
@@ -337,7 +337,7 @@ export default function NewWebhook() {
             </div>
 
             <div className="flex space-x-4">
-              {isFree || isPro ? (
+              {(isFree || isPro) && !isTrial ? (
                 <UpgradePlanModal
                   key="create-webhook"
                   clickedPlan={PlanEnum.Business}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trial users now have expanded access to features such as analytics, agreement creation, presets, and webhooks, previously limited to higher-tier plans.
  * Upgrade prompts and plan badges are now tailored based on trial status, providing more relevant upgrade options for trial users.
  * Trial users can bypass some plan restrictions, including notifications and link presets availability.

* **Bug Fixes**
  * Improved conditional logic ensures that trial users are not unnecessarily restricted from accessing premium features or shown upgrade prompts meant for non-trial users.
  * Access control refined to allow certain "pro" plans with trial status to use dataroom and related features.

* **Style**
  * Minor updates to badge display and plan naming for consistency.

* **Chores**
  * Internal logic updated to consistently recognize and handle trial plan status across the app.
  * Removed deprecated UI elements related to file request mode toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->