### PR TITLE
Added redirection to permissions tab in data rooms after creating link

### DIFF
--- a/ee/features/permissions/components/dataroom-link-sheet.tsx
+++ b/ee/features/permissions/components/dataroom-link-sheet.tsx
@@ -544,6 +544,10 @@ export function DataroomLinkSheet({
         setShowPermissionsSheet(false);
         setPendingLinkData(null);
         toast.success("Link created successfully");
+        const isOnPermissionsPage = router.asPath.includes("/permissions");
+        if (linkType === LinkType.DATAROOM_LINK && !isOnPermissionsPage) {
+          router.push(`/datarooms/${targetId}/permissions`);
+        }
       }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users are now automatically redirected to the dataroom permissions page after creating a new dataroom link, when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->