### PR TITLE
Increase dataroom name max length from 34 to 156

### DIFF
--- a/components/datarooms/add-dataroom-modal.tsx
+++ b/components/datarooms/add-dataroom-modal.tsx
@@ -44,7 +44,7 @@ export function AddDataroomModal({
   const { isFree, isPro } = usePlan();
   const analytics = useAnalytics();
   const dataroomSchema = z.object({
-    name: z.string().min(3, {
+    name: z.string().trim().min(3, {
       message: "Please provide a dataroom name with at least 3 characters.",
     }),
   });
@@ -140,7 +140,7 @@ export function AddDataroomModal({
             id="dataroom-name"
             placeholder="ACME Aquisition"
             className="mb-4 mt-1 w-full"
-            onChange={(e) => setDataroomName(e.target.value.trim())}
+            onChange={(e) => setDataroomName(e.target.value)}
           />
           <DialogFooter>
             <Button type="submit" className="h-9 w-full" loading={loading}>

--- a/components/datarooms/dataroom-breadcrumb.tsx
+++ b/components/datarooms/dataroom-breadcrumb.tsx
@@ -4,6 +4,11 @@ import { useRouter } from "next/router";
 import React, { useMemo } from "react";
 
 import {
+  useDataroom,
+  useDataroomFolderWithParents,
+} from "@/lib/swr/use-dataroom";
+
+import {
   Breadcrumb,
   BreadcrumbEllipsis,
   BreadcrumbItem,
@@ -19,11 +24,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-import {
-  useDataroom,
-  useDataroomFolderWithParents,
-} from "@/lib/swr/use-dataroom";
-
+import { TruncatedBreadcrumbLink } from "../layouts/breadcrumb";
 function BreadcrumbComponentBase({
   name,
   dataroomId,
@@ -47,11 +48,10 @@ function BreadcrumbComponentBase({
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
-          <BreadcrumbLink asChild>
-            <Link href={`/datarooms/${dataroomId}/documents`}>
-              {dataroom?.name || "Loading..."}
-            </Link>
-          </BreadcrumbLink>
+          <TruncatedBreadcrumbLink
+            href={`/datarooms/${dataroomId}/documents`}
+            text={dataroom?.name}
+          />
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>

--- a/pages/datarooms/[id]/settings/index.tsx
+++ b/pages/datarooms/[id]/settings/index.tsx
@@ -64,10 +64,10 @@ export default function Settings() {
               inputAttrs={{
                 name: "name",
                 placeholder: "My Dataroom",
-                maxLength: 32,
+                maxLength: 156,
               }}
               defaultValue={dataroom.name}
-              helpText="Max 32 characters"
+              helpText="Max 156 characters"
               handleSubmit={(updateData) =>
                 fetch(`/api/teams/${teamId}/datarooms/${dataroom.id}`, {
                   method: "PATCH",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a breadcrumb link that automatically truncates long text and displays a tooltip when the text overflows.

* **Improvements**
  * Increased the maximum allowed length for dataroom names from 32 to 156 characters.
  * Enhanced dataroom name validation to ignore leading and trailing spaces when checking minimum length.
  * Improved breadcrumb navigation by simplifying how dataroom names are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->