### PR TITLE
fix: persist RadioGroup selection in report form

### DIFF
--- a/components/view/report-form.tsx
+++ b/components/view/report-form.tsx
@@ -101,7 +101,7 @@ export default function ReportForm({
               </p>
             </div>
             <div className="flex flex-col space-y-4">
-              <RadioGroup onValueChange={setAbuseType} className="grid gap-2">
+              <RadioGroup value={abuseType} onValueChange={setAbuseType} className="grid gap-2">
                 <div className="flex items-center space-x-2">
                   <RadioGroupItem value="spam" id="spam" />
                   <Label htmlFor="spam" className="font-normal">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization between the selected radio button and the displayed value in the report form, ensuring the correct option is always shown as selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->