### PR TITLE
Rename Q&A conversations to Q&A

### DIFF
--- a/components/datarooms/dataroom-navigation.tsx
+++ b/components/datarooms/dataroom-navigation.tsx
@@ -26,7 +26,7 @@ export const DataroomNavigation = ({ dataroomId }: { dataroomId?: string }) => {
           segment: "analytics",
         },
         {
-          label: "Q&A Conversations",
+          label: "Q&A",
           href: `/datarooms/${dataroomId}/conversations`,
           segment: "conversations",
           limited: !limits?.conversationsInDataroom,


### PR DESCRIPTION
Rename "Q&A Conversations" to "Q&A" on the dataroom settings tab to shorten the label.

---

[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1752597769028349?thread_ts=1752597769.028349&cid=C095YUQAYRJ)