### PR TITLE
Rename people tab to team

### DIFF
--- a/components/layouts/breadcrumb.tsx
+++ b/components/layouts/breadcrumb.tsx
@@ -207,7 +207,7 @@ const SettingsBreadcrumb = () => {
       case "/settings/general":
         return "General";
       case "/settings/people":
-        return "People";
+        return "Team";
       case "/settings/domains":
         return "Domains";
       case "/settings/presets":

--- a/components/settings/settings-header.tsx
+++ b/components/settings/settings-header.tsx
@@ -38,7 +38,7 @@ export function SettingsHeader() {
             segment: `general`,
           },
           {
-            label: "People",
+            label: "Team",
             href: `/settings/people`,
             segment: "people",
           },

--- a/components/sidebar/app-sidebar.tsx
+++ b/components/sidebar/app-sidebar.tsx
@@ -136,7 +136,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
             current: router.pathname.includes("settings/general"),
           },
           {
-            title: "People",
+            title: "Team",
             url: "/settings/people",
             current: router.pathname.includes("settings/people"),
           },

--- a/pages/settings/people.tsx
+++ b/pages/settings/people.tsx
@@ -235,7 +235,7 @@ export default function Billing() {
           <div>
             <div className="flex items-center justify-between gap-x-1 rounded-lg border border-border bg-secondary p-4 sm:p-10">
               <div className="flex flex-col space-y-1 sm:space-y-3">
-                <h2 className="text-xl font-medium">People</h2>
+                <h2 className="text-xl font-medium">Team</h2>
                 <p className="text-sm text-secondary-foreground">
                   Teammates that have access to this project.
                 </p>


### PR DESCRIPTION
Rename "People" tab to "Team" in general settings.

---

[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1752598283439139?thread_ts=1752598283.439139&cid=C095YUQAYRJ)