### PR TITLE
Allow managers to update ignored domains

### DIFF
--- a/pages/api/teams/[teamId]/global-block-list.ts
+++ b/pages/api/teams/[teamId]/global-block-list.ts
@@ -38,12 +38,12 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(404).json({ error: "Team not found" });
   }
 
-  const isUserAdmin = team.users.some(
+  const isUserAdminOrManager = team.users.some(
     (user) =>
-      user.role === "ADMIN" && user.userId === (session.user as CustomUser).id,
+      (user.role === "ADMIN" || user.role === "MANAGER") && user.userId === (session.user as CustomUser).id,
   );
 
-  if (!isUserAdmin) {
+  if (!isUserAdminOrManager) {
     return res.status(403).json({ error: "Forbidden" });
   }
 

--- a/pages/api/teams/[teamId]/ignored-domains.ts
+++ b/pages/api/teams/[teamId]/ignored-domains.ts
@@ -38,12 +38,12 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(404).json({ error: "Team not found" });
   }
 
-  const isUserAdmin = team.users.some(
+  const isUserAdminOrManager = team.users.some(
     (user) =>
-      user.role === "ADMIN" && user.userId === (session.user as CustomUser).id,
+      (user.role === "ADMIN" || user.role === "MANAGER") && user.userId === (session.user as CustomUser).id,
   );
 
-  if (!isUserAdmin) {
+  if (!isUserAdminOrManager) {
     return res.status(403).json({ error: "Forbidden" });
   }
 


### PR DESCRIPTION
Enable managers to update the ignored domains and global block lists to fulfill user requirements.

---

[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1752608818350509?thread_ts=1752608818.350509&cid=C095YUQAYRJ)