### PR TITLE
Fix: prevent long document names from overflowing modal dialog

### DIFF
--- a/components/datarooms/move-dataroom-folder-modal.tsx
+++ b/components/datarooms/move-dataroom-folder-modal.tsx
@@ -5,6 +5,9 @@ import { useState } from "react";
 import { useTeam } from "@/context/team-context";
 import { toast } from "sonner";
 
+import { moveDataroomDocumentToFolder } from "@/lib/documents/move-dataroom-documents";
+import { moveDataroomFolderToFolder } from "@/lib/documents/move-dataroom-folders";
+
 import { SidebarFolderTreeSelection } from "@/components/datarooms/folders";
 import { Button } from "@/components/ui/button";
 import {
@@ -15,9 +18,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-
-import { moveDataroomDocumentToFolder } from "@/lib/documents/move-dataroom-documents";
-import { moveDataroomFolderToFolder } from "@/lib/documents/move-dataroom-folders";
 
 import { TSelectedFolder } from "../documents/move-folder-modal";
 
@@ -110,7 +110,7 @@ export function MoveToDataroomFolderModal({
           <DialogDescription>Move your item to a folder.</DialogDescription>
         </DialogHeader>
         <form>
-          <div className="mb-2 max-h-[75vh] overflow-y-scroll">
+          <div className="mb-2 max-h-[75vh] overflow-x-hidden overflow-y-scroll">
             <SidebarFolderTreeSelection
               dataroomId={dataroomId}
               selectedFolder={selectedFolder}
@@ -133,7 +133,9 @@ export function MoveToDataroomFolderModal({
               ) : (
                 <>
                   Move to{" "}
-                  <span className="font-medium">{selectedFolder.name}</span>
+                  <span className="max-w-[200px] truncate font-medium">
+                    {selectedFolder.name}
+                  </span>
                 </>
               )}
             </Button>

--- a/components/documents/add-document-to-dataroom-modal.tsx
+++ b/components/documents/add-document-to-dataroom-modal.tsx
@@ -87,31 +87,32 @@ export function AddToDataroomModal({
   };
 
   return (
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="sm:max-w-[425px] max-w-[90vw]">
-          <DialogHeader className="text-start">
-            <DialogTitle className="break-words max-w-full">
-              <span className="font-bold break-words line-clamp-2">
-                {documentName}
-              </span>
-            </DialogTitle>
-            <DialogDescription>
-              Add your document to a dataroom.
-            </DialogDescription>
-          </DialogHeader>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-[90vw] sm:max-w-[425px]">
+        <DialogHeader className="text-start">
+          <DialogTitle>
+            <span className="font-bold">{documentName}</span>
+          </DialogTitle>
+          <DialogDescription>
+            Add your document to a dataroom.
+          </DialogDescription>
+        </DialogHeader>
         <Select onValueChange={(value) => setSelectedDataroom(value)}>
-          <SelectTrigger className="min-w-fit">
+          <SelectTrigger className="w-[380px] max-w-full [&>span]:max-w-full [&>span]:overflow-hidden [&>span]:truncate [&>span]:text-ellipsis [&>span]:whitespace-nowrap">
             <SelectValue placeholder="Select a dataroom" />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent className="w-[380px] max-w-[90vw]">
             {datarooms?.map((dataroom) => (
               <SelectItem
                 key={dataroom.id}
                 value={dataroom.id}
                 disabled={dataroom.id === dataroomId}
+                className="break-words"
               >
-                {dataroom.name}
-                {dataroom.id === dataroomId ? " (current)" : ""}
+                <span className="line-clamp-1 break-words">
+                  {dataroom.name}
+                  {dataroom.id === dataroomId ? " (current)" : ""}
+                </span>
               </SelectItem>
             ))}
           </SelectContent>
@@ -129,15 +130,15 @@ export function AddToDataroomModal({
               {!selectedDataroom ? (
                 "Select a dataroom"
               ) : (
-                <>
-                  Add to{" "}
-                  <span className="font-medium">
+                <span className="flex w-full max-w-[350px] items-center justify-center truncate">
+                  Add to
+                  <span className="ml-1 line-clamp-1 truncate font-medium">
                     {
                       datarooms?.filter((d) => d.id === selectedDataroom)[0]
                         .name
                     }
                   </span>
-                </>
+                </span>
               )}
             </Button>
           </DialogFooter>

--- a/components/documents/add-document-to-dataroom-modal.tsx
+++ b/components/documents/add-document-to-dataroom-modal.tsx
@@ -87,16 +87,18 @@ export function AddToDataroomModal({
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader className="text-start">
-          <DialogTitle>
-            <span className="font-bold">{documentName}</span>
-          </DialogTitle>
-          <DialogDescription>
-            Add your document to a dataroom.
-          </DialogDescription>
-        </DialogHeader>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-[425px] max-w-[90vw]">
+          <DialogHeader className="text-start">
+            <DialogTitle className="break-words max-w-full">
+              <span className="font-bold break-words line-clamp-2">
+                {documentName}
+              </span>
+            </DialogTitle>
+            <DialogDescription>
+              Add your document to a dataroom.
+            </DialogDescription>
+          </DialogHeader>
         <Select onValueChange={(value) => setSelectedDataroom(value)}>
           <SelectTrigger className="min-w-fit">
             <SelectValue placeholder="Select a dataroom" />

--- a/components/documents/add-folder-to-dataroom-modal.tsx
+++ b/components/documents/add-folder-to-dataroom-modal.tsx
@@ -114,18 +114,21 @@ export function AddFolderToDataroomModal({
           <DialogDescription>Add your folder to a dataroom.</DialogDescription>
         </DialogHeader>
         <Select onValueChange={(value) => setSelectedDataroom(value)}>
-          <SelectTrigger className="min-w-fit">
+          <SelectTrigger className="w-[380px] max-w-full [&>span]:truncate [&>span]:max-w-full [&>span]:overflow-hidden [&>span]:text-ellipsis [&>span]:whitespace-nowrap">
             <SelectValue placeholder="Select a dataroom" />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent className="w-[380px] max-w-[90vw]">
             {datarooms?.map((dataroom) => (
               <SelectItem
                 key={dataroom.id}
                 value={dataroom.id}
                 disabled={dataroom.id === dataroomId}
+                className="break-words"
               >
-                {dataroom.name}
-                {dataroom.id === dataroomId ? " (current)" : ""}
+                <span className="break-words line-clamp-1">
+                  {dataroom.name}
+                  {dataroom.id === dataroomId ? " (current)" : ""}
+                </span>
               </SelectItem>
             ))}
           </SelectContent>
@@ -143,15 +146,15 @@ export function AddFolderToDataroomModal({
               {!selectedDataroom ? (
                 "Select a dataroom"
               ) : (
-                <>
-                  Add to{" "}
-                  <span className="font-medium">
+                <span className="flex items-center justify-center w-full max-w-[350px] truncate">
+                  Add to
+                  <span className="font-medium truncate line-clamp-1 ml-1">
                     {
                       datarooms?.filter((d) => d.id === selectedDataroom)[0]
                         .name
                     }
                   </span>
-                </>
+                </span>
               )}
             </Button>
           </DialogFooter>

--- a/components/documents/move-folder-modal.tsx
+++ b/components/documents/move-folder-modal.tsx
@@ -5,6 +5,9 @@ import { useState } from "react";
 import { useTeam } from "@/context/team-context";
 import { toast } from "sonner";
 
+import { moveDocumentToFolder } from "@/lib/documents/move-documents";
+import { moveFolderToFolder } from "@/lib/documents/move-folder";
+
 import { SidebarFolderTreeSelection } from "@/components/sidebar-folders";
 import { Button } from "@/components/ui/button";
 import {
@@ -15,9 +18,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-
-import { moveDocumentToFolder } from "@/lib/documents/move-documents";
-import { moveFolderToFolder } from "@/lib/documents/move-folder";
 
 export type TSelectedFolder = {
   id: string | null;
@@ -104,14 +104,14 @@ export function MoveToFolderModal({
         <DialogHeader className="text-start">
           <DialogTitle>
             Move
-            <div className="w-[376px] truncate font-bold">
+            <div className="truncate font-bold">
               {`${(documentIds?.length ?? 0) + (folderIds?.length ?? 0)} items`}
             </div>
           </DialogTitle>
           <DialogDescription>Move your item to a folder.</DialogDescription>
         </DialogHeader>
         <form>
-          <div className="mb-2 max-h-[75vh] overflow-y-scroll">
+          <div className="mb-2 max-h-[75vh] overflow-x-hidden overflow-y-scroll">
             <SidebarFolderTreeSelection
               selectedFolder={selectedFolder}
               setSelectedFolder={setSelectedFolder}
@@ -133,7 +133,9 @@ export function MoveToFolderModal({
               ) : (
                 <>
                   Move to{" "}
-                  <span className="font-medium">{selectedFolder.name}</span>
+                  <span className="max-w-[200px] truncate font-medium">
+                    {selectedFolder.name}
+                  </span>
                 </>
               )}
             </Button>

--- a/components/links/link-sheet/upload-section/index.tsx
+++ b/components/links/link-sheet/upload-section/index.tsx
@@ -89,7 +89,7 @@ function FolderSelectionModal({
           </DialogDescription>
         </DialogHeader>
         <form>
-          <div className="mb-2 max-h-[75vh] overflow-y-scroll">
+          <div className="mb-2 max-h-[75vh] overflow-x-hidden overflow-y-scroll">
             {dataroomId && dataroomId !== "all_documents" ? (
               <DataroomFolderTree
                 dataroomId={dataroomId}
@@ -115,7 +115,9 @@ function FolderSelectionModal({
               ) : (
                 <>
                   Select{" "}
-                  <span className="font-medium">{selectedFolder.name}</span>
+                  <span className="max-w-[200px] truncate font-medium">
+                    {selectedFolder.name}
+                  </span>
                 </>
               )}
             </Button>

--- a/components/ui/nextra-filetree.tsx
+++ b/components/ui/nextra-filetree.tsx
@@ -120,7 +120,7 @@ const Folder = memo<FolderProps>(
         <div
           title={name}
           className={cn(
-            "inline-flex w-full cursor-pointer items-center",
+            "inline-flex w-full cursor-pointer items-center overflow-hidden",
             "rounded-md text-foreground duration-100 hover:bg-gray-100 hover:dark:bg-muted",
             "px-3 py-1.5 leading-6",
             active && "bg-gray-100 font-semibold dark:bg-muted",
@@ -147,7 +147,10 @@ const Folder = memo<FolderProps>(
             <FolderIcon className="h-5 w-5 shrink-0" aria-hidden="true" />
           )}
           <span
-            className="ml-2 w-fit truncate"
+            className="ml-2 truncate whitespace-nowrap"
+            style={{
+              maxWidth: `${Math.max(150, 300 - indent * 30)}px`,
+            }}
             title={(label ?? name) as string}
           >
             {label ?? name}
@@ -165,6 +168,7 @@ const Folder = memo<FolderProps>(
 Folder.displayName = "Folder";
 
 const File = memo<FileProps>(({ label, name, active, onToggle }) => {
+  const indent = useIndent();
   const toggle = useCallback(() => {
     onToggle?.(!active);
   }, [onToggle]);
@@ -179,12 +183,18 @@ const File = memo<FileProps>(({ label, name, active, onToggle }) => {
       )}
     >
       <span
-        className="ml-5 inline-flex cursor-default items-center"
+        className="ml-5 inline-flex w-full cursor-default items-center overflow-hidden"
         onClick={toggle}
       >
         <Ident />
         <FileIcon className="h-5 w-5 shrink-0" aria-hidden="true" />
-        <span className="ml-2 w-fit truncate" title={(label ?? name) as string}>
+        <span
+          className="ml-2 truncate whitespace-nowrap"
+          style={{
+            maxWidth: `${Math.max(150, 280 - indent * 30)}px`,
+          }}
+          title={(label ?? name) as string}
+        >
           {label ?? name}
         </span>
       </span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved modal dialog appearance on smaller screens by increasing maximum width.
  * Enhanced title text wrapping and limited long document names to two lines for better readability.
  * Updated dropdown and button label styles to ensure consistent text truncation and prevent overflow in dataroom selection modals.
  * Added horizontal overflow restrictions and text truncation to folder and file name displays in folder trees and selection modals.
  * Dynamically adjusted folder and file name widths in file trees based on indentation level for better layout consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->