### PR TITLE
feat: keep original name for watermarked document

### DIFF
--- a/components/view/nav.tsx
+++ b/components/view/nav.tsx
@@ -135,10 +135,24 @@ export default function Nav({
         const pdfBlob = await response.blob();
         const blobUrl = window.URL.createObjectURL(pdfBlob);
 
+        // Extract filename from Content-Disposition header
+        const contentDisposition = response.headers.get("content-disposition");
+        let filename = "document.pdf";
+        if (contentDisposition) {
+          const filenameMatch = contentDisposition.match(
+            /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/,
+          );
+          if (filenameMatch && filenameMatch[1]) {
+            filename = decodeURIComponent(
+              filenameMatch[1].replace(/['"]/g, ""),
+            );
+          }
+        }
+
         const link = document.createElement("a");
         link.href = blobUrl;
         link.rel = "noopener noreferrer";
-        link.download = "watermarked_document.pdf";
+        link.download = filename;
         document.body.appendChild(link);
         link.click();
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -29,6 +29,18 @@ export function getExtension(url: string) {
   return url.split(/[#?]/)[0].split(".").pop().trim();
 }
 
+/**
+ * Ensures a filename has a .pdf extension for watermarked documents
+ * Removes any existing extension and adds .pdf
+ */
+export function getFileNameWithPdfExtension(filename?: string): string {
+  if (!filename) return "document.pdf";
+
+  // Remove existing extension and add .pdf
+  const nameWithoutExt = filename.replace(/\.[^/.]+$/, "");
+  return `${nameWithoutExt}.pdf`;
+}
+
 interface SWRError extends Error {
   status: number;
 }

--- a/pages/api/links/download/dataroom-document.ts
+++ b/pages/api/links/download/dataroom-document.ts
@@ -4,6 +4,7 @@ import { ItemType, ViewType } from "@prisma/client";
 
 import { getFile } from "@/lib/files/get-file";
 import prisma from "@/lib/prisma";
+import { getFileNameWithPdfExtension } from "@/lib/utils";
 import { getIpAddress } from "@/lib/utils/ip";
 
 export const config = {
@@ -194,6 +195,7 @@ export default async function handle(
               url: downloadUrl,
               numPages: downloadDocuments[0].document!.versions[0].numPages,
               watermarkConfig: view.link.watermarkConfig,
+              originalFileName: downloadDocuments[0].document!.name,
               viewerData: {
                 email: view.viewerEmail,
                 date: new Date(view.viewedAt).toLocaleDateString(),
@@ -215,7 +217,7 @@ export default async function handle(
         res.setHeader("Content-Type", "application/pdf");
         res.setHeader(
           "Content-Disposition",
-          'attachment; filename="watermarked.pdf"',
+          `attachment; filename="${encodeURIComponent(getFileNameWithPdfExtension(downloadDocuments[0].document!.name))}"`,
         );
         res.setHeader("Content-Length", Buffer.from(pdfBuffer).length);
 

--- a/pages/api/links/download/index.ts
+++ b/pages/api/links/download/index.ts
@@ -4,6 +4,7 @@ import { LinkType } from "@prisma/client";
 
 import { getFile } from "@/lib/files/get-file";
 import prisma from "@/lib/prisma";
+import { getFileNameWithPdfExtension } from "@/lib/utils";
 import { getIpAddress } from "@/lib/utils/ip";
 
 export default async function handle(
@@ -39,6 +40,7 @@ export default async function handle(
             select: {
               teamId: true,
               downloadOnly: true,
+              name: true,
               versions: {
                 where: { isPrimary: true },
                 select: {
@@ -128,6 +130,7 @@ export default async function handle(
               url: downloadUrl,
               numPages: view.document!.versions[0].numPages,
               watermarkConfig: view.link.watermarkConfig,
+              originalFileName: view.document!.name,
               viewerData: {
                 email: view.viewerEmail,
                 date: new Date(view.viewedAt).toLocaleDateString(),
@@ -163,7 +166,7 @@ export default async function handle(
         res.setHeader("Content-Type", "application/pdf");
         res.setHeader(
           "Content-Disposition",
-          'attachment; filename="watermarked.pdf"',
+          `attachment; filename="${encodeURIComponent(getFileNameWithPdfExtension(view.document!.name))}"`,
         );
         res.setHeader("Content-Length", Buffer.from(pdfBuffer).length);
 

--- a/pages/api/mupdf/annotate-document.ts
+++ b/pages/api/mupdf/annotate-document.ts
@@ -3,7 +3,12 @@ import { NextApiRequest, NextApiResponse } from "next";
 import fontkit from "@pdf-lib/fontkit";
 import { PDFDocument, StandardFonts, degrees, rgb } from "pdf-lib";
 
-import { hexToRgb, log, safeTemplateReplace } from "@/lib/utils";
+import {
+  getFileNameWithPdfExtension,
+  hexToRgb,
+  log,
+  safeTemplateReplace,
+} from "@/lib/utils";
 
 // This function can run for a maximum of 120 seconds
 export const config = {
@@ -252,12 +257,14 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     return;
   }
 
-  const { url, watermarkConfig, viewerData, numPages } = req.body as {
-    url: string;
-    watermarkConfig: WatermarkConfig;
-    viewerData: ViewerData;
-    numPages: number;
-  };
+  const { url, watermarkConfig, viewerData, numPages, originalFileName } =
+    req.body as {
+      url: string;
+      watermarkConfig: WatermarkConfig;
+      viewerData: ViewerData;
+      numPages: number;
+      originalFileName?: string;
+    };
 
   try {
     // Fetch the PDF data
@@ -294,7 +301,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     res.setHeader("Content-Type", "application/pdf");
     res.setHeader(
       "Content-Disposition",
-      'attachment; filename="watermarked.pdf"',
+      `attachment; filename="${encodeURIComponent(getFileNameWithPdfExtension(originalFileName))}"`,
     );
 
     res.status(200).send(Buffer.from(pdfBytes));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Downloaded watermarked PDF files now use the original document name with a .pdf extension, improving file identification.
* **Bug Fixes**
  * Ensured downloaded PDF filenames always have the correct .pdf extension, even if the original name lacked one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->