### PR TITLE
feat: add toggle to disallow bulk download

### DIFF
--- a/components/datarooms/settings/bulk-download-settings.tsx
+++ b/components/datarooms/settings/bulk-download-settings.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+
+import { useTeam } from "@/context/team-context";
+import { toast } from "sonner";
+import useSWR from "swr";
+
+import { fetcher } from "@/lib/utils";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+interface BulkDownloadSettingsProps {
+  dataroomId: string;
+}
+
+export default function BulkDownloadSettings({
+  dataroomId,
+}: BulkDownloadSettingsProps) {
+  const teamInfo = useTeam();
+  const teamId = teamInfo?.currentTeam?.id;
+
+  const { data: dataroomData, mutate: mutateDataroom } = useSWR<{
+    id: string;
+    name: string;
+    pId: string;
+    allowBulkDownload: boolean;
+  }>(
+    dataroomId ? `/api/teams/${teamId}/datarooms/${dataroomId}` : null,
+    fetcher,
+  );
+
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const handleBulkDownloadToggle = async (checked: boolean) => {
+    if (!dataroomId || !teamId || isUpdating) return;
+
+    setIsUpdating(true);
+
+    toast.promise(
+      fetch(`/api/teams/${teamId}/datarooms/${dataroomId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          allowBulkDownload: checked,
+        }),
+      }).then(async (res) => {
+        if (!res.ok) {
+          throw new Error("Failed to update bulk download settings");
+        }
+        await mutateDataroom();
+      }),
+      {
+        loading: "Updating bulk download settings...",
+        success: "Bulk download settings updated successfully",
+        error: "Failed to update bulk download settings",
+      },
+    );
+
+    setIsUpdating(false);
+  };
+
+  return (
+    <Card className="bg-transparent">
+      <CardHeader>
+        <CardTitle className="flex items-center">Dataroom Download</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <Label
+              htmlFor="bulk-download-toggle"
+              className="text-sm font-medium"
+            >
+              Allow bulk download of entire dataroom
+            </Label>
+          </div>
+          <Switch
+            id="bulk-download-toggle"
+            checked={dataroomData?.allowBulkDownload ?? true}
+            onCheckedChange={handleBulkDownloadToggle}
+            disabled={isUpdating}
+          />
+        </div>
+      </CardContent>
+      <CardFooter className="flex items-center justify-between rounded-b-lg border-t bg-muted px-6 py-6">
+        <p className="text-sm text-muted-foreground transition-colors">
+          When enabled, visitors can download all dataroom contents as a single
+          ZIP file. Individual document and folder downloads will still work
+          regardless of this setting.
+        </p>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/components/datarooms/settings/settings-tabs.tsx
+++ b/components/datarooms/settings/settings-tabs.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 
-import { BellIcon, CogIcon, ShieldIcon } from "lucide-react";
+import { BellIcon, CogIcon, DownloadIcon, ShieldIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -38,6 +38,18 @@ export default function SettingsTabs({ dataroomId }: SettingsTabsProps) {
       >
         <BellIcon className="h-4 w-4" />
         Notifications
+      </Link>
+      <Link
+        href={`/datarooms/${dataroomId}/settings/downloads`}
+        className={cn(
+          "flex items-center gap-x-2 rounded-md p-2 text-primary hover:bg-muted",
+          {
+            "bg-muted font-medium": router.pathname.includes("downloads"),
+          },
+        )}
+      >
+        <DownloadIcon className="h-4 w-4" />
+        Downloads
       </Link>
       <Link
         href={`/datarooms/${dataroomId}/settings/file-permissions`}

--- a/components/view/dataroom/nav-dataroom.tsx
+++ b/components/view/dataroom/nav-dataroom.tsx
@@ -23,6 +23,7 @@ const DEFAULT_BANNER_IMAGE = "/_static/papermark-banner.png";
 
 export default function DataroomNav({
   allowDownload,
+  allowBulkDownload,
   brand,
   viewId,
   linkId,
@@ -34,6 +35,7 @@ export default function DataroomNav({
   isTeamMember,
 }: {
   allowDownload?: boolean;
+  allowBulkDownload?: boolean;
   brand?: Partial<DataroomBrand>;
   viewId?: string;
   linkId?: string;
@@ -187,7 +189,7 @@ export default function DataroomNav({
                 </Tooltip>
               </TooltipProvider>
             )}
-            {allowDownload ? (
+            {allowDownload && allowBulkDownload ? (
               <ButtonTooltip content="Download Dataroom">
                 <Button
                   onClick={downloadDataroom}

--- a/components/view/viewer/dataroom-viewer.tsx
+++ b/components/view/viewer/dataroom-viewer.tsx
@@ -113,9 +113,10 @@ export default function DataroomViewer({
   isEmbedded?: boolean;
   viewerEmail?: string;
 }) {
-  const { documents, folders } = dataroom as {
+  const { documents, folders, allowBulkDownload } = dataroom as {
     documents: DataroomDocument[];
     folders: DataroomFolder[];
+    allowBulkDownload: boolean;
   };
 
   const searchParams = useSearchParams();
@@ -329,6 +330,7 @@ export default function DataroomViewer({
         viewId={viewId}
         dataroom={dataroom}
         allowDownload={allDocumentsCanDownload}
+        allowBulkDownload={allowBulkDownload}
         isPreview={isPreview}
         dataroomId={dataroom?.id}
         viewerId={viewerId}

--- a/lib/api/links/link-data.ts
+++ b/lib/api/links/link-data.ts
@@ -110,6 +110,7 @@ export async function fetchDataroomLinkData({
           id: true,
           name: true,
           teamId: true,
+          allowBulkDownload: true,
           documents: {
             where:
               groupPermissions.length > 0 || effectiveGroupId
@@ -280,6 +281,7 @@ export async function fetchDataroomDocumentLinkData({
         select: {
           id: true,
           name: true,
+          allowBulkDownload: true,
           documents: {
             where: { id: dataroomDocumentId },
             select: {

--- a/pages/api/links/download/bulk.ts
+++ b/pages/api/links/download/bulk.ts
@@ -47,6 +47,7 @@ export default async function handle(
           dataroom: {
             select: {
               teamId: true,
+              allowBulkDownload: true,
               folders: {
                 select: {
                   id: true,
@@ -105,6 +106,11 @@ export default async function handle(
       // if dataroom does not exist, we should not allow the download
       if (!view.dataroom) {
         return res.status(404).json({ error: "Error downloading" });
+      }
+
+      // if dataroom does not allow bulk download, we should not allow the download
+      if (!view.dataroom.allowBulkDownload) {
+        return res.status(403).json({ error: "Bulk download is disabled for this dataroom" });
       }
 
       // if viewedAt is longer than 23 hours ago, we should not allow the download

--- a/pages/api/teams/[teamId]/datarooms/[id]/index.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/index.ts
@@ -100,11 +100,12 @@ export default async function handle(
         return res.status(401).end("Unauthorized");
       }
 
-      const { name, enableChangeNotifications, defaultPermissionStrategy } =
+      const { name, enableChangeNotifications, defaultPermissionStrategy, allowBulkDownload } =
         req.body as {
           name?: string;
           enableChangeNotifications?: boolean;
           defaultPermissionStrategy?: DefaultPermissionStrategy;
+          allowBulkDownload?: boolean;
         };
 
       const featureFlags = await getFeatureFlags({ teamId: team.id });
@@ -132,6 +133,9 @@ export default async function handle(
             enableChangeNotifications,
           }),
           ...(defaultPermissionStrategy && { defaultPermissionStrategy }),
+          ...(typeof allowBulkDownload === "boolean" && {
+            allowBulkDownload,
+          }),
         },
       });
 

--- a/pages/datarooms/[id]/settings/downloads.tsx
+++ b/pages/datarooms/[id]/settings/downloads.tsx
@@ -1,0 +1,42 @@
+import { useDataroom } from "@/lib/swr/use-dataroom";
+
+import { DataroomHeader } from "@/components/datarooms/dataroom-header";
+import { DataroomNavigation } from "@/components/datarooms/dataroom-navigation";
+import BulkDownloadSettings from "@/components/datarooms/settings/bulk-download-settings";
+import SettingsTabs from "@/components/datarooms/settings/settings-tabs";
+import AppLayout from "@/components/layouts/app";
+
+export default function Downloads() {
+  const { dataroom } = useDataroom();
+
+  if (!dataroom) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <AppLayout>
+      <main className="relative mx-2 mb-10 mt-4 space-y-8 overflow-hidden px-1 sm:mx-3 md:mx-5 md:mt-5 lg:mx-7 lg:mt-8 xl:mx-10">
+        <header>
+          <DataroomHeader
+            title={dataroom.name}
+            description={dataroom.pId}
+            actions={[]}
+          />
+
+          <DataroomNavigation dataroomId={dataroom.id} />
+        </header>
+
+        {/* Settings */}
+        <div className="mx-auto grid w-full gap-2">
+          <h1 className="text-2xl font-semibold">Settings</h1>
+        </div>
+        <div className="mx-auto grid w-full items-start gap-6 md:grid-cols-[180px_1fr] lg:grid-cols-[250px_1fr]">
+          <SettingsTabs dataroomId={dataroom.id} />
+          <div className="grid gap-6">
+            <BulkDownloadSettings dataroomId={dataroom.id} />
+          </div>
+        </div>
+      </main>
+    </AppLayout>
+  );
+}

--- a/prisma/migrations/20241231_add_dataroom_allow_bulk_download/migration.sql
+++ b/prisma/migrations/20241231_add_dataroom_allow_bulk_download/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Dataroom" ADD COLUMN "allowBulkDownload" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema/dataroom.prisma
+++ b/prisma/schema/dataroom.prisma
@@ -31,6 +31,9 @@ model Dataroom {
   // unified permission strategy
   defaultPermissionStrategy DefaultPermissionStrategy @default(INHERIT_FROM_PARENT)
 
+  // bulk download setting
+  allowBulkDownload Boolean @default(true) // Allow bulk download of entire dataroom
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Downloads settings page with a toggle to allow bulk download of the entire dataroom.
  * Introduced a Downloads tab in dataroom settings for easy access.
  * Navigation now shows the “Download Dataroom” button only when bulk download is enabled.
* **Bug Fixes**
  * Bulk downloads are blocked when disabled in settings, ensuring availability matches the configured preference across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->