### PR TITLE
fix: ignore allowlist/denylist from group links via presets

### DIFF
--- a/components/links/link-sheet/index.tsx
+++ b/components/links/link-sheet/index.tsx
@@ -235,6 +235,8 @@ export default function LinkSheet({
     if (!preset) return;
 
     setData((prev) => {
+      const isGroupLink = prev.audienceType === LinkAudienceType.GROUP;
+
       return {
         ...prev,
         name: prev.name, // Keep existing name
@@ -243,8 +245,13 @@ export default function LinkSheet({
         emailProtected: preset.emailProtected ?? prev.emailProtected,
         emailAuthenticated:
           preset.emailAuthenticated ?? prev.emailAuthenticated,
-        allowList: preset.allowList || prev.allowList,
-        denyList: preset.denyList || prev.denyList,
+        // For group links, ignore allow/deny lists from presets as access is controlled by group membership
+        allowList: isGroupLink
+          ? prev.allowList
+          : preset.allowList || prev.allowList,
+        denyList: isGroupLink
+          ? prev.denyList
+          : preset.denyList || prev.denyList,
         password: preset.password || prev.password,
         enableCustomMetatag:
           preset.enableCustomMetaTag ?? prev.enableCustomMetatag,

--- a/ee/features/permissions/components/dataroom-link-sheet.tsx
+++ b/ee/features/permissions/components/dataroom-link-sheet.tsx
@@ -187,6 +187,8 @@ export function DataroomLinkSheet({
     if (!preset) return;
 
     setData((prev) => {
+      const isGroupLink = prev.audienceType === LinkAudienceType.GROUP;
+
       return {
         ...prev,
         name: prev.name, // Keep existing name
@@ -195,8 +197,13 @@ export function DataroomLinkSheet({
         emailProtected: preset.emailProtected ?? prev.emailProtected,
         emailAuthenticated:
           preset.emailAuthenticated ?? prev.emailAuthenticated,
-        allowList: preset.allowList || prev.allowList,
-        denyList: preset.denyList || prev.denyList,
+        // For group links, ignore allow/deny lists from presets as access is controlled by group membership
+        allowList: isGroupLink
+          ? prev.allowList
+          : preset.allowList || prev.allowList,
+        denyList: isGroupLink
+          ? prev.denyList
+          : preset.denyList || prev.denyList,
         password: preset.password || prev.password,
         enableCustomMetatag:
           preset.enableCustomMetaTag ?? prev.enableCustomMetatag,

--- a/pages/api/webhooks/services/[...path]/index.ts
+++ b/pages/api/webhooks/services/[...path]/index.ts
@@ -446,8 +446,13 @@ async function handleDocumentCreate(
         enableScreenshotProtection: link.enableScreenshotProtection,
         audienceType: link.audienceType,
         groupId: isGroupAudience ? link.groupId : null,
-        allowList: link.allowList || preset?.allowList,
-        denyList: link.denyList || preset?.denyList,
+        // For group links, ignore allow/deny lists from presets as access is controlled by group membership
+        allowList: isGroupAudience
+          ? link.allowList
+          : link.allowList || preset?.allowList,
+        denyList: isGroupAudience
+          ? link.denyList
+          : link.denyList || preset?.denyList,
         ...(preset?.enableCustomMetaTag && {
           enableCustomMetatag: preset?.enableCustomMetaTag,
           metaTitle: preset?.metaTitle,
@@ -652,8 +657,13 @@ async function handleLinkCreate(
         enableScreenshotProtection: link.enableScreenshotProtection,
         audienceType: link.audienceType,
         groupId: isGroupAudience ? link.groupId : null,
-        allowList: link.allowList || preset?.allowList,
-        denyList: link.denyList || preset?.denyList,
+        // For group links, ignore allow/deny lists from presets as access is controlled by group membership
+        allowList: isGroupAudience
+          ? link.allowList
+          : link.allowList || preset?.allowList,
+        denyList: isGroupAudience
+          ? link.denyList
+          : link.denyList || preset?.denyList,
         ...(preset?.enableCustomMetaTag && {
           enableCustomMetatag: preset?.enableCustomMetaTag,
           metaTitle: preset?.metaTitle,

--- a/pages/api/webhooks/services/[...path]/index.ts
+++ b/pages/api/webhooks/services/[...path]/index.ts
@@ -449,10 +449,10 @@ async function handleDocumentCreate(
         // For group links, ignore allow/deny lists from presets as access is controlled by group membership
         allowList: isGroupAudience
           ? link.allowList
-          : link.allowList || preset?.allowList,
+          : (link.allowList ?? preset?.allowList),
         denyList: isGroupAudience
           ? link.denyList
-          : link.denyList || preset?.denyList,
+          : (link.denyList ?? preset?.denyList),
         ...(preset?.enableCustomMetaTag && {
           enableCustomMetatag: preset?.enableCustomMetaTag,
           metaTitle: preset?.metaTitle,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Applying presets to group-audience links no longer overrides existing allow/deny access lists; group links retain their current access settings.
  - Preset behavior for non-group links remains unchanged.
  - Access-list handling is now consistent across creation and update flows for documents, links, and datarooms, preventing unintended access changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->