### PR TITLE
Disable buttons while document processes

### DIFF
--- a/components/links/link-sheet/index.tsx
+++ b/components/links/link-sheet/index.tsx
@@ -13,12 +13,14 @@ import useSWR from "swr";
 
 import { useAnalytics } from "@/lib/analytics";
 import { usePlan } from "@/lib/swr/use-billing";
+import { useDocument } from "@/lib/swr/use-document";
 import useDataroomGroups from "@/lib/swr/use-dataroom-groups";
 import { useDomains } from "@/lib/swr/use-domains";
 import useLimits from "@/lib/swr/use-limits";
 import { LinkWithViews, WatermarkConfig } from "@/lib/types";
 import { convertDataUrlToFile, fetcher, uploadImage } from "@/lib/utils";
 
+import { isDocumentProcessing } from "@/components/documents/document-preview-button";
 import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -191,6 +193,15 @@ export default function LinkSheet({
       dedupingInterval: 10000,
     },
   );
+
+  // Document data for processing status check
+  const { document: documentData, primaryVersion } = useDocument();
+
+  // Check if document is processing (only for DOCUMENT_LINK)
+  const isDocumentCurrentlyProcessing = 
+    linkType === LinkType.DOCUMENT_LINK && primaryVersion 
+      ? isDocumentProcessing(primaryVersion)
+      : false;
 
   useEffect(() => {
     setData(currentLink || DEFAULT_LINK_PROPS(linkType, groupId, !isDatarooms));
@@ -754,6 +765,7 @@ export default function LinkSheet({
               <Button
                 type="submit"
                 loading={isSaving}
+                disabled={isDocumentCurrentlyProcessing}
                 onClick={(e) => handleSubmit(e, false)}
               >
                 {currentLink ? "Update Link" : "Save Link"}
@@ -762,6 +774,7 @@ export default function LinkSheet({
                 type="button"
                 variant="outline"
                 loading={isLoading}
+                disabled={isDocumentCurrentlyProcessing}
                 onClick={(e) => handleSubmit(e, true)}
               >
                 {currentLink ? "Update & Preview" : "Save & Preview"}

--- a/ee/features/permissions/components/dataroom-link-sheet.tsx
+++ b/ee/features/permissions/components/dataroom-link-sheet.tsx
@@ -18,12 +18,14 @@ import z from "zod";
 
 import { useAnalytics } from "@/lib/analytics";
 import { usePlan } from "@/lib/swr/use-billing";
+import { useDocument } from "@/lib/swr/use-document";
 import useDataroomGroups from "@/lib/swr/use-dataroom-groups";
 import { useDomains } from "@/lib/swr/use-domains";
 import useLimits from "@/lib/swr/use-limits";
 import { LinkWithViews } from "@/lib/types";
 import { convertDataUrlToFile, fetcher, uploadImage } from "@/lib/utils";
 
+import { isDocumentProcessing } from "@/components/documents/document-preview-button";
 import {
   DEFAULT_LINK_PROPS as BASE_DEFAULT_LINK_PROPS,
   DEFAULT_LINK_TYPE as BASE_DEFAULT_LINK_TYPE,
@@ -135,6 +137,15 @@ export function DataroomLinkSheet({
       dedupingInterval: 10000,
     },
   );
+
+  // Document data for processing status check
+  const { document: documentData, primaryVersion } = useDocument();
+
+  // Check if document is processing (only for DOCUMENT_LINK)
+  const isDocumentCurrentlyProcessing = 
+    linkType === LinkType.DOCUMENT_LINK && primaryVersion 
+      ? isDocumentProcessing(primaryVersion)
+      : false;
 
   useEffect(() => {
     setData(currentLink || DEFAULT_LINK_PROPS(linkType, groupId, !isDatarooms));
@@ -998,6 +1009,7 @@ export function DataroomLinkSheet({
                       : "outline"
                   }
                   loading={isSaving}
+                  disabled={isDocumentCurrentlyProcessing}
                   onClick={(e) => handleSubmit(e, false)}
                 >
                   {currentLink ? "Update Link" : "Save Link"}
@@ -1009,6 +1021,7 @@ export function DataroomLinkSheet({
                     type="button"
                     variant="link"
                     loading={isLoading}
+                    disabled={isDocumentCurrentlyProcessing}
                     onClick={(e) => handleSubmit(e, true)}
                     className="flex items-center gap-2"
                   >


### PR DESCRIPTION
Disable save and preview buttons on link sheets when the associated document is still processing to prevent issues with incomplete document data.

---
Linear Issue: [PM-437](https://linear.app/papermark/issue/PM-437/disable-the-save-and-preview-button-on-the-link-sheet-if-the-document)

<a href="https://cursor.com/background-agent?bcId=bc-16302def-e1bb-41dd-a7ce-c4ceb90e76fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16302def-e1bb-41dd-a7ce-c4ceb90e76fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

