### PR TITLE
Disable preview buttons when document processes

### DIFF
--- a/components/links/link-sheet/index.tsx
+++ b/components/links/link-sheet/index.tsx
@@ -14,12 +14,14 @@ import useSWR from "swr";
 import { useAnalytics } from "@/lib/analytics";
 import { usePlan } from "@/lib/swr/use-billing";
 import useDataroomGroups from "@/lib/swr/use-dataroom-groups";
+import { useDocument } from "@/lib/swr/use-document";
 import { useDomains } from "@/lib/swr/use-domains";
 import useLimits from "@/lib/swr/use-limits";
 import { LinkWithViews, WatermarkConfig } from "@/lib/types";
 import { convertDataUrlToFile, fetcher, uploadImage } from "@/lib/utils";
 
 import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
+import { isDocumentProcessing } from "@/components/documents/document-preview-button";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -173,6 +175,12 @@ export default function LinkSheet({
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [currentPreset, setCurrentPreset] = useState<LinkPreset | null>(null);
+
+  // Check if document is processing (only for document links)
+  const { document, primaryVersion } = useDocument();
+  const isDocumentCurrentlyProcessing = 
+    linkType === LinkType.DOCUMENT_LINK && 
+    isDocumentProcessing(primaryVersion);
 
   const isPresetsAllowed =
     isTrial ||
@@ -762,6 +770,7 @@ export default function LinkSheet({
                 type="button"
                 variant="outline"
                 loading={isLoading}
+                disabled={isDocumentCurrentlyProcessing}
                 onClick={(e) => handleSubmit(e, true)}
               >
                 {currentLink ? "Update & Preview" : "Save & Preview"}

--- a/ee/features/permissions/components/dataroom-link-sheet.tsx
+++ b/ee/features/permissions/components/dataroom-link-sheet.tsx
@@ -19,6 +19,7 @@ import z from "zod";
 import { useAnalytics } from "@/lib/analytics";
 import { usePlan } from "@/lib/swr/use-billing";
 import useDataroomGroups from "@/lib/swr/use-dataroom-groups";
+import { useDocument } from "@/lib/swr/use-document";
 import { useDomains } from "@/lib/swr/use-domains";
 import useLimits from "@/lib/swr/use-limits";
 import { LinkWithViews } from "@/lib/types";
@@ -32,6 +33,7 @@ import DomainSection from "@/components/links/link-sheet/domain-section";
 import { LinkOptions } from "@/components/links/link-sheet/link-options";
 import LinkSuccessSheet from "@/components/links/link-sheet/link-success-sheet";
 import TagSection from "@/components/links/link-sheet/tags/tag-section";
+import { isDocumentProcessing } from "@/components/documents/document-preview-button";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -119,6 +121,12 @@ export function DataroomLinkSheet({
   const [createdLink, setCreatedLink] = useState<LinkWithViews | null>(null);
   const [hasCustomPermissions, setHasCustomPermissions] =
     useState<boolean>(false);
+
+  // Check if document is processing (only for document links)
+  const { document, primaryVersion } = useDocument();
+  const isDocumentCurrentlyProcessing = 
+    linkType === LinkType.DOCUMENT_LINK && 
+    isDocumentProcessing(primaryVersion);
 
   const isPresetsAllowed =
     isTrial ||
@@ -1009,6 +1017,7 @@ export function DataroomLinkSheet({
                     type="button"
                     variant="link"
                     loading={isLoading}
+                    disabled={isDocumentCurrentlyProcessing}
                     onClick={(e) => handleSubmit(e, true)}
                     className="flex items-center gap-2"
                   >


### PR DESCRIPTION
Disable "Save & Preview" and "Update & Preview" buttons for document links while the document is processing, keeping regular save/update buttons active.

---
Linear Issue: [PM-437](https://linear.app/papermark/issue/PM-437/disable-the-save-and-preview-button-on-the-link-sheet-if-the-document)

<a href="https://cursor.com/background-agent?bcId=bc-ff4dc3ee-0cfe-4a57-8bd8-9e43a582d285">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff4dc3ee-0cfe-4a57-8bd8-9e43a582d285">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

