### PR TITLE
Fix dataroom last updated timestamp logic

### DIFF
--- a/pages/view/[linkId]/index.tsx
+++ b/pages/view/[linkId]/index.tsx
@@ -185,12 +185,32 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
 
       const { teamId } = link.dataroom;
 
-      const lastUpdatedAt = link.dataroom.documents.reduce((max, doc) => {
-        return Math.max(
-          max,
-          new Date(doc.document.versions[0].updatedAt).getTime(),
-        );
-      }, 0);
+      // Calculate lastUpdatedAt based on documents and folders
+      let lastUpdatedAt;
+      const allTimestamps = [];
+      
+      // Collect timestamps from documents
+      link.dataroom.documents.forEach(doc => {
+        if (doc.document.versions && doc.document.versions.length > 0) {
+          allTimestamps.push(new Date(doc.document.versions[0].updatedAt).getTime());
+        }
+      });
+      
+      // Collect timestamps from folders
+      if (link.dataroom.folders) {
+        link.dataroom.folders.forEach(folder => {
+          if (folder.updatedAt) {
+            allTimestamps.push(new Date(folder.updatedAt).getTime());
+          }
+        });
+      }
+      
+      // If no documents or folders, use dataroom's updatedAt; otherwise use latest timestamp
+      if (allTimestamps.length === 0) {
+        lastUpdatedAt = new Date(link.dataroom.updatedAt).getTime();
+      } else {
+        lastUpdatedAt = Math.max(...allTimestamps);
+      }
 
       return {
         props: {

--- a/pages/view/domains/[domain]/[slug]/index.tsx
+++ b/pages/view/domains/[domain]/[slug]/index.tsx
@@ -167,12 +167,32 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
 
       const { teamId } = link.dataroom;
 
-      const lastUpdatedAt = link.dataroom.documents.reduce((max, doc) => {
-        return Math.max(
-          max,
-          new Date(doc.document.versions[0].updatedAt).getTime(),
-        );
-      }, 0);
+      // Calculate lastUpdatedAt based on documents and folders
+      let lastUpdatedAt;
+      const allTimestamps = [];
+      
+      // Collect timestamps from documents
+      link.dataroom.documents.forEach(doc => {
+        if (doc.document.versions && doc.document.versions.length > 0) {
+          allTimestamps.push(new Date(doc.document.versions[0].updatedAt).getTime());
+        }
+      });
+      
+      // Collect timestamps from folders
+      if (link.dataroom.folders) {
+        link.dataroom.folders.forEach(folder => {
+          if (folder.updatedAt) {
+            allTimestamps.push(new Date(folder.updatedAt).getTime());
+          }
+        });
+      }
+      
+      // If no documents or folders, use dataroom's updatedAt; otherwise use latest timestamp
+      if (allTimestamps.length === 0) {
+        lastUpdatedAt = new Date(link.dataroom.updatedAt).getTime();
+      } else {
+        lastUpdatedAt = Math.max(...allTimestamps);
+      }
 
       return {
         props: {


### PR DESCRIPTION
Fix dataroom `lastUpdatedAt` showing 1.1.1970 by correctly calculating the latest timestamp from documents, folders, or the dataroom itself.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1756201604972909?thread_ts=1756201604.972909&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-67b30cf6-cbfa-48cd-98d8-77d23045d2cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-67b30cf6-cbfa-48cd-98d8-77d23045d2cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

