### PR TITLE
fix: dataroom without documents show timestamp 0

### DIFF
--- a/lib/api/links/link-data.ts
+++ b/lib/api/links/link-data.ts
@@ -111,6 +111,7 @@ export async function fetchDataroomLinkData({
           name: true,
           teamId: true,
           allowBulkDownload: true,
+          createdAt: true,
           documents: {
             where:
               groupPermissions.length > 0 || effectiveGroupId

--- a/pages/view/[linkId]/index.tsx
+++ b/pages/view/[linkId]/index.tsx
@@ -190,7 +190,7 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
           max,
           new Date(doc.document.versions[0].updatedAt).getTime(),
         );
-      }, 0);
+      }, new Date(link.dataroom.createdAt).getTime());
 
       return {
         props: {

--- a/pages/view/domains/[domain]/[slug]/index.tsx
+++ b/pages/view/domains/[domain]/[slug]/index.tsx
@@ -172,7 +172,7 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
           max,
           new Date(doc.document.versions[0].updatedAt).getTime(),
         );
-      }, 0);
+      }, new Date(link.dataroom.createdAt).getTime());
 
       return {
         props: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * “Last updated” on dataroom pages now considers the dataroom’s creation time, providing a more accurate baseline even when no documents exist.
* **Bug Fixes**
  * Fixed cases where “Last updated” could appear as 0 or be missing by ensuring it’s at least the dataroom creation time across dataroom link views and domain-based routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->