### PR TITLE
fix: either allow discount or promo codes

### DIFF
--- a/pages/api/teams/[teamId]/billing/upgrade.ts
+++ b/pages/api/teams/[teamId]/billing/upgrade.ts
@@ -6,7 +6,7 @@ import { waitUntil } from "@vercel/functions";
 import { getServerSession } from "next-auth/next";
 
 import { identifyUser, trackAnalytics } from "@/lib/analytics";
-import { dub, getDubDiscountForExternalUserId } from "@/lib/dub";
+import { getDubDiscountForExternalUserId } from "@/lib/dub";
 import prisma from "@/lib/prisma";
 import { CustomUser } from "@/lib/types";
 
@@ -114,9 +114,8 @@ export default async function handle(
           enabled: true,
         },
         mode: "subscription",
-        allow_promotion_codes: true,
         client_reference_id: teamId,
-        ...(dubDiscount ?? {}),
+        ...(dubDiscount ?? { allow_promotion_codes: true }),
         metadata: {
           dubCustomerId: userId,
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Promotion codes are now enabled by default during team plan upgrades for both new and existing customers, fixing cases where codes were unintentionally unavailable at checkout.
  * Discount handling is more consistent: custom discounts still apply when present, while allowing promo codes when no discount is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->