### PR TITLE
feat: remove internal response headers

### DIFF
--- a/lib/middleware/posthog.ts
+++ b/lib/middleware/posthog.ts
@@ -5,8 +5,6 @@ export default async function PostHogMiddleware(req: NextRequest) {
   const hostname = url.pathname.startsWith("/ingest/static/")
     ? "eu-assets.i.posthog.com"
     : "eu.i.posthog.com";
-  const requestHeaders = new Headers(req.headers);
-  requestHeaders.set("host", hostname);
 
   // Handle OPTIONS method for CORS preflight
   if (req.method === "OPTIONS") {
@@ -15,12 +13,52 @@ export default async function PostHogMiddleware(req: NextRequest) {
     });
   }
 
+  // Create clean headers object with only necessary headers
+  const forwardHeaders = new Headers();
+
+  // Headers that PostHog needs
+  const allowedHeaders = [
+    "accept",
+    "accept-encoding",
+    "accept-language",
+    "authorization",
+    "content-type",
+    "content-length",
+    "user-agent",
+    "referer",
+    "origin",
+    "forwarded",
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-real-ip",
+  ];
+
+  // Copy allowed headers from the original request
+  for (const [key, value] of req.headers.entries()) {
+    const lowerKey = key.toLowerCase();
+
+    // Check if header is allowed
+    if (
+      allowedHeaders.some((allowed) =>
+        allowed.endsWith("*")
+          ? lowerKey.startsWith(allowed.slice(0, -1))
+          : lowerKey === allowed,
+      )
+    ) {
+      forwardHeaders.set(key, value);
+    }
+  }
+
+  // Set the correct host for PostHog
+  forwardHeaders.set("host", hostname);
+
   url.protocol = "https";
   url.hostname = hostname;
   url.port = "443";
   url.pathname = url.pathname.replace(/^\/ingest/, "");
 
   return NextResponse.rewrite(url, {
-    headers: requestHeaders,
+    headers: forwardHeaders,
   });
 }

--- a/lib/middleware/posthog.ts
+++ b/lib/middleware/posthog.ts
@@ -32,6 +32,8 @@ export default async function PostHogMiddleware(req: NextRequest) {
     "x-forwarded-host",
     "x-forwarded-proto",
     "x-real-ip",
+    // PostHog specific headers
+    "x-posthog-*",
   ];
 
   // Copy allowed headers from the original request
@@ -59,6 +61,8 @@ export default async function PostHogMiddleware(req: NextRequest) {
   url.pathname = url.pathname.replace(/^\/ingest/, "");
 
   return NextResponse.rewrite(url, {
-    headers: forwardHeaders,
+    request: {
+      headers: forwardHeaders,
+    },
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Header forwarding when proxying analytics is now limited to a curated whitelist, reducing exposed request data.
  - Host is set explicitly for proxied requests while existing URL rewrite and CORS preflight behavior are preserved.
  - No changes to public APIs or app functionality; improves privacy and reliability.
  - No user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->