### PR TITLE
Fix email validation for university domains

### DIFF
--- a/lib/utils/validate-email.ts
+++ b/lib/utils/validate-email.ts
@@ -2,9 +2,9 @@
 export const fullyCompliantEmailRegex =
   /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
 
-// Simple email regex
+// Simple email regex - supports university domains with subdomains and hyphens
 export const simpleEmailRegex =
-  /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z]{2,})+$/;
+  /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/;
 
 export const validateEmail = (email: string) => {
   return simpleEmailRegex.test(email.toLowerCase().trim());


### PR DESCRIPTION
Update `simpleEmailRegex` to correctly validate email addresses with hyphens in subdomains, which are common in university email schemas.

The previous regex `(?:\.[a-zA-Z]{2,})+$` was too restrictive, disallowing hyphens in subdomain parts (e.g., `example-university.de`) and failing for multi-level subdomains like `medical.uni-hamburg.de`. The updated regex now correctly handles these patterns.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1756990814289529?thread_ts=1756990814.289529&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-7a8eb54b-f27d-4123-ac61-7bd74fe304fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7a8eb54b-f27d-4123-ac61-7bd74fe304fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated basic email validation to accept addresses with multiple subdomains and hyphens (e.g., university and departmental domains), reducing false rejections.
  * Maintains behavior of the fully compliant validator; only the simpler check was broadened.
  * No UI changes; forms that previously flagged some valid emails should now pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->