### PR TITLE
feat: add automatic hierarchical index for dataroom items

### DIFF
--- a/components/datarooms/dataroom-breadcrumb.tsx
+++ b/components/datarooms/dataroom-breadcrumb.tsx
@@ -7,6 +7,10 @@ import {
   useDataroom,
   useDataroomFolderWithParents,
 } from "@/lib/swr/use-dataroom";
+import {
+  HIERARCHICAL_DISPLAY_STYLE,
+  useHierarchicalDisplayName,
+} from "@/lib/utils/hierarchical-display";
 
 import {
   Breadcrumb,
@@ -25,6 +29,70 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 import { TruncatedBreadcrumbLink } from "../layouts/breadcrumb";
+
+const BreadcrumbFolderItem = ({
+  folder,
+  dataroomId,
+  isLast,
+}: {
+  folder: any;
+  dataroomId: string;
+  isLast: boolean;
+}) => {
+  const displayName = useHierarchicalDisplayName(
+    folder.name,
+    folder.hierarchicalIndex,
+  );
+
+  if (isLast) {
+    return (
+      <BreadcrumbPage
+        className="max-w-[200px] truncate"
+        style={HIERARCHICAL_DISPLAY_STYLE}
+      >
+        {displayName}
+      </BreadcrumbPage>
+    );
+  }
+
+  return (
+    <BreadcrumbLink asChild>
+      <Link
+        href={`/datarooms/${dataroomId}/documents${folder.path}`}
+        className="max-w-[200px] truncate"
+        style={HIERARCHICAL_DISPLAY_STYLE}
+      >
+        {displayName}
+      </Link>
+    </BreadcrumbLink>
+  );
+};
+
+const BreadcrumbDropdownItem = ({
+  folder,
+  dataroomId,
+}: {
+  folder: any;
+  dataroomId: string;
+}) => {
+  const displayName = useHierarchicalDisplayName(
+    folder.name,
+    folder.hierarchicalIndex,
+  );
+
+  return (
+    <DropdownMenuItem>
+      <Link
+        href={`/datarooms/${dataroomId}/documents${folder.path}`}
+        className="w-full"
+        style={HIERARCHICAL_DISPLAY_STYLE}
+      >
+        {displayName}
+      </Link>
+    </DropdownMenuItem>
+  );
+};
+
 function BreadcrumbComponentBase({
   name,
   dataroomId,
@@ -69,54 +137,41 @@ function BreadcrumbComponentBase({
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start">
                   {folders.slice(0, -2).map((folder, index) => (
-                    <DropdownMenuItem key={index}>
-                      <Link
-                        href={`/datarooms/${dataroomId}/documents${folder.path}`}
-                        className="w-full"
-                      >
-                        {folder.name}
-                      </Link>
-                    </DropdownMenuItem>
+                    <BreadcrumbDropdownItem
+                      key={index}
+                      folder={folder}
+                      dataroomId={dataroomId}
+                    />
                   ))}
                 </DropdownMenuContent>
               </DropdownMenu>
             </BreadcrumbItem>
             <BreadcrumbSeparator />
             <BreadcrumbItem>
-              <BreadcrumbLink asChild>
-                <Link
-                  href={`/datarooms/${dataroomId}/documents${folders[folders.length - 2].path}`}
-                  className="max-w-[200px] truncate"
-                >
-                  {folders[folders.length - 2].name}
-                </Link>
-              </BreadcrumbLink>
+              <BreadcrumbFolderItem
+                folder={folders[folders.length - 2]}
+                dataroomId={dataroomId}
+                isLast={false}
+              />
             </BreadcrumbItem>
             <BreadcrumbSeparator />
             <BreadcrumbItem>
-              <BreadcrumbPage className="max-w-[200px] truncate">
-                {folders[folders.length - 1].name}
-              </BreadcrumbPage>
+              <BreadcrumbFolderItem
+                folder={folders[folders.length - 1]}
+                dataroomId={dataroomId}
+                isLast={true}
+              />
             </BreadcrumbItem>
           </>
         ) : (
           folders?.map((folder, index) => (
             <React.Fragment key={index}>
               <BreadcrumbItem>
-                {index === folders.length - 1 ? (
-                  <BreadcrumbPage className="max-w-[200px] truncate">
-                    {folder.name}
-                  </BreadcrumbPage>
-                ) : (
-                  <BreadcrumbLink asChild>
-                    <Link
-                      href={`/datarooms/${dataroomId}/documents${folder.path}`}
-                      className="max-w-[200px] truncate"
-                    >
-                      {folder.name}
-                    </Link>
-                  </BreadcrumbLink>
-                )}
+                <BreadcrumbFolderItem
+                  folder={folder}
+                  dataroomId={dataroomId}
+                  isLast={index === folders.length - 1}
+                />
               </BreadcrumbItem>
               {index < folders.length - 1 && <BreadcrumbSeparator />}
             </React.Fragment>

--- a/components/datarooms/dataroom-document-card.tsx
+++ b/components/datarooms/dataroom-document-card.tsx
@@ -20,6 +20,10 @@ import { type DataroomFolderDocument } from "@/lib/swr/use-dataroom";
 import { type DocumentWithLinksAndLinkCountAndViewCount } from "@/lib/types";
 import { cn, nFormatter, timeAgo } from "@/lib/utils";
 import { fileIcon } from "@/lib/utils/get-file-icon";
+import {
+  HIERARCHICAL_DISPLAY_STYLE,
+  useHierarchicalDisplayName,
+} from "@/lib/utils/hierarchical-display";
 
 import BarChart from "@/components/shared/icons/bar-chart";
 import { Button } from "@/components/ui/button";
@@ -60,6 +64,12 @@ export default function DataroomDocumentCard({
   const isLight =
     theme === "light" || (theme === "system" && systemTheme === "light");
   const router = useRouter();
+
+  // Get hierarchical display name
+  const displayName = useHierarchicalDisplayName(
+    dataroomDocument.document.name,
+    dataroomDocument.hierarchicalIndex,
+  );
 
   const [isFirstClick, setIsFirstClick] = useState<boolean>(false);
   const [menuOpen, setMenuOpen] = useState<boolean>(false);
@@ -205,8 +215,11 @@ export default function DataroomDocumentCard({
 
             <div className="flex-col">
               <div className="flex items-center">
-                <h2 className="min-w-0 max-w-[150px] truncate text-sm font-semibold leading-6 text-foreground sm:max-w-md">
-                  {dataroomDocument.document.name}
+                <h2
+                  className="min-w-0 max-w-[150px] truncate text-sm font-semibold leading-6 text-foreground sm:max-w-md"
+                  style={HIERARCHICAL_DISPLAY_STYLE}
+                >
+                  {displayName}
                 </h2>
               </div>
               <div className="mt-1 flex items-center space-x-1 text-xs leading-5 text-muted-foreground">

--- a/components/datarooms/folders/sidebar-tree.tsx
+++ b/components/datarooms/folders/sidebar-tree.tsx
@@ -9,6 +9,10 @@ import {
   useDataroomFoldersTree,
 } from "@/lib/swr/use-dataroom";
 import { cn } from "@/lib/utils";
+import {
+  HIERARCHICAL_DISPLAY_STYLE,
+  useHierarchicalDisplayName,
+} from "@/lib/utils/hierarchical-display";
 import { sortByIndexThenName } from "@/lib/utils/sort-items-by-index-name";
 
 import { FileTree } from "@/components/ui/nextra-filetree";
@@ -19,6 +23,31 @@ type MixedItem =
   | (DataroomFolderWithDocuments & { itemType: "folder" })
   | (DataroomFolderWithDocuments["documents"][0] & { itemType: "document" });
 
+const DocumentFileItem = memo(
+  ({
+    document,
+    router,
+  }: {
+    document: DataroomFolderWithDocuments["documents"][0] & {
+      itemType: "document";
+    };
+    router: any;
+  }) => {
+    const documentDisplayName = useHierarchicalDisplayName(
+      document.document.name,
+      document.hierarchicalIndex,
+    );
+
+    return (
+      <FileTree.File
+        name={documentDisplayName}
+        onToggle={() => router.push(`/documents/${document.document.id}`)}
+      />
+    );
+  },
+);
+DocumentFileItem.displayName = "DocumentFileItem";
+
 const FolderComponent = memo(
   ({
     dataroomId,
@@ -28,6 +57,12 @@ const FolderComponent = memo(
     folder: DataroomFolderWithDocuments;
   }) => {
     const router = useRouter();
+
+    // Get hierarchical display names
+    const folderDisplayName = useHierarchicalDisplayName(
+      folder.name,
+      folder.hierarchicalIndex,
+    );
 
     const mixedItems = useMemo(() => {
       const allItems: MixedItem[] = [
@@ -57,11 +92,7 @@ const FolderComponent = memo(
             );
           } else {
             return (
-              <FileTree.File
-                key={item.id}
-                name={item.document.name}
-                onToggle={() => router.push(`/documents/${item.document.id}`)}
-              />
+              <DocumentFileItem key={item.id} document={item} router={router} />
             );
           }
         }),
@@ -87,7 +118,7 @@ const FolderComponent = memo(
 
     return (
       <FileTree.Folder
-        name={folder.name}
+        name={folderDisplayName}
         key={folder.id}
         active={isActive}
         childActive={isChildActive}

--- a/components/datarooms/folders/utils.ts
+++ b/components/datarooms/folders/utils.ts
@@ -61,6 +61,7 @@ type DataroomDocumentWithVersion = {
   folderId: string | null;
   id: string;
   name: string;
+  hierarchicalIndex: string | null;
   versions: {
     id: string;
     versionNumber: number;
@@ -75,6 +76,7 @@ type DataroomFolderWithDocumentsNew = DataroomFolder & {
     folderId: string | null;
     id: string;
     name: string;
+    hierarchicalIndex: string | null;
   }[];
 };
 

--- a/components/datarooms/rebuild-index-button.tsx
+++ b/components/datarooms/rebuild-index-button.tsx
@@ -1,0 +1,135 @@
+import { useState } from "react";
+
+import { Hash, ListOrderedIcon, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+
+import { useFeatureFlags } from "@/lib/hooks/use-feature-flags";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { ResponsiveButton } from "@/components/ui/responsive-button";
+
+interface RebuildIndexButtonProps {
+  teamId: string;
+  dataroomId: string;
+  disabled?: boolean;
+}
+
+export default function RebuildIndexButton({
+  teamId,
+  dataroomId,
+  disabled = false,
+}: RebuildIndexButtonProps) {
+  const { isFeatureEnabled } = useFeatureFlags();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const isDataroomIndexEnabled = isFeatureEnabled("dataroomIndex");
+
+  // Don't render if feature is not enabled
+  if (!isDataroomIndexEnabled) {
+    return null;
+  }
+
+  const handleRebuildIndex = async () => {
+    try {
+      setIsLoading(true);
+
+      const response = await fetch(
+        `/api/teams/${teamId}/datarooms/${dataroomId}/calculate-indexes`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to rebuild indexes");
+      }
+
+      const result = await response.json();
+
+      toast.success(
+        `Hierarchical indexes rebuilt successfully! Updated ${result.totalUpdated} items (${result.foldersUpdated} folders, ${result.documentsUpdated} documents).`,
+      );
+
+      setIsOpen(false);
+
+      // Trigger a page refresh to show updated indexes
+      window.location.reload();
+    } catch (error) {
+      console.error("Error rebuilding indexes:", error);
+      toast.error(
+        error instanceof Error ? error.message : "Failed to rebuild indexes",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <ResponsiveButton
+          icon={<ListOrderedIcon className="h-4 w-4" />}
+          text="Rebuild Index"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+        />
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center">
+            Rebuild Hierarchical Index
+          </DialogTitle>
+          <DialogDescription>
+            Recalculate the hierarchical numbering based on the dataroom items'
+            current order.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          <div className="rounded-lg bg-muted p-4">
+            <div className="flex items-start gap-3">
+              <div className="text-sm text-muted-foreground">
+                <p className="mb-1 font-medium">What this does:</p>
+                <ul className="list-inside list-disc space-y-1">
+                  <li>
+                    Analyzes the current folder structure and document order
+                  </li>
+                  <li>
+                    Assigns hierarchical numbers (1, 1.1, 1.1.1, 2, 2.1, etc.)
+                  </li>
+                  <li>
+                    Updates the display to show these numbers alongside names
+                  </li>
+                  <li>Maintains the existing order and hierarchy</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setIsOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleRebuildIndex} loading={isLoading}>
+            <ListOrderedIcon className="h-4 w-4" />
+            Rebuild Index
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/datarooms/rebuild-index-button.tsx
+++ b/components/datarooms/rebuild-index-button.tsx
@@ -95,8 +95,8 @@ export default function RebuildIndexButton({
             Rebuild Hierarchical Index
           </DialogTitle>
           <DialogDescription>
-            Recalculate the hierarchical numbering based on the dataroom items'
-            current order.
+            Recalculate the hierarchical numbering based on the dataroom
+            items&apos; current order.
           </DialogDescription>
         </DialogHeader>
         <div className="py-4">

--- a/components/datarooms/sortable/sortable-list.tsx
+++ b/components/datarooms/sortable/sortable-list.tsx
@@ -155,10 +155,10 @@ export function DataroomSortableList({
       mutate(`${baseKey}/folders`);
       mutate(`${baseKey}/folders?include_documents=true`);
       setIsReordering(false);
-      toast.success("Index saved successfully");
+      toast.success("Folder order saved successfully");
     } catch (error) {
       console.error("Failed to save new order:", error);
-      toast.error("Failed to save index");
+      toast.error("Failed to save order");
       // Optionally, show an error message to the user
     } finally {
       setIsReordering(false);
@@ -247,7 +247,7 @@ export function DataroomSortableList({
           className="gap-x-1"
         >
           <CheckIcon className="size-4" />
-          Save index
+          Save order
         </Button>
       </Portal>
       <DeleteFolderModal />

--- a/components/documents/folder-card.tsx
+++ b/components/documents/folder-card.tsx
@@ -20,6 +20,10 @@ import { mutate } from "swr";
 import { DataroomFolderWithCount } from "@/lib/swr/use-dataroom";
 import { FolderWithCount } from "@/lib/swr/use-documents";
 import { timeAgo } from "@/lib/utils";
+import {
+  HIERARCHICAL_DISPLAY_STYLE,
+  useHierarchicalDisplayName,
+} from "@/lib/utils/hierarchical-display";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -66,6 +70,14 @@ export default function FolderCard({
   const [addDataroomOpen, setAddDataroomOpen] = useState<boolean>(false);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
 
+  // Get hierarchical display name for dataroom folders
+  const displayName = useHierarchicalDisplayName(
+    folder.name,
+    isDataroom && "hierarchicalIndex" in folder
+      ? folder.hierarchicalIndex
+      : undefined,
+  );
+
   const folderPath =
     isDataroom && dataroomId
       ? `/datarooms/${dataroomId}/documents${folder.path}`
@@ -83,8 +95,6 @@ export default function FolderCard({
       });
     }
   }, [openFolder, addDataroomOpen]);
-
-
 
   const handleCreateDataroom = (e: any, folderId: string) => {
     e.stopPropagation();
@@ -160,8 +170,11 @@ export default function FolderCard({
 
           <div className="flex-col">
             <div className="flex items-center">
-              <h2 className="min-w-0 max-w-[150px] truncate text-sm font-semibold leading-6 text-foreground sm:max-w-md">
-                {folder.name}
+              <h2
+                className="min-w-0 max-w-[150px] truncate text-sm font-semibold leading-6 text-foreground sm:max-w-md"
+                style={HIERARCHICAL_DISPLAY_STYLE}
+              >
+                {displayName}
               </h2>
             </div>
             <div className="mt-1 flex items-center space-x-1 text-xs leading-5 text-muted-foreground">

--- a/components/view/dataroom/document-card.tsx
+++ b/components/view/dataroom/document-card.tsx
@@ -9,6 +9,10 @@ import { toast } from "sonner";
 import { timeAgo } from "@/lib/utils";
 import { cn } from "@/lib/utils";
 import { fileIcon } from "@/lib/utils/get-file-icon";
+import {
+  HIERARCHICAL_DISPLAY_STYLE,
+  useHierarchicalDisplayName,
+} from "@/lib/utils/hierarchical-display";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -53,6 +57,12 @@ export default function DocumentCard({
   const isLight =
     theme === "light" || (theme === "system" && systemTheme === "light");
   const router = useRouter();
+
+  // Get hierarchical display name
+  const displayName = useHierarchicalDisplayName(
+    document.name,
+    document.hierarchicalIndex,
+  );
   const { previewToken, domain, slug } = router.query as {
     previewToken?: string;
     domain?: string;
@@ -183,13 +193,16 @@ export default function DocumentCard({
 
         <div className="flex-col">
           <div className="flex items-center">
-            <h2 className="min-w-0 max-w-[300px] truncate text-sm font-semibold leading-6 text-foreground sm:max-w-lg">
+            <h2
+              className="min-w-0 max-w-[300px] truncate text-sm font-semibold leading-6 text-foreground sm:max-w-lg"
+              style={HIERARCHICAL_DISPLAY_STYLE}
+            >
               <button
                 onClick={handleDocumentClick}
                 className="w-full truncate"
                 disabled={isProcessing}
               >
-                <span>{document.name}</span>
+                <span>{displayName}</span>
                 {isProcessing && (
                   <span className="ml-2 text-xs text-muted-foreground">
                     (Processing...)

--- a/components/view/dataroom/document-card.tsx
+++ b/components/view/dataroom/document-card.tsx
@@ -32,6 +32,7 @@ type DRDocument = {
   downloadOnly: boolean;
   versions: DocumentVersion[];
   canDownload: boolean;
+  hierarchicalIndex: string | null;
 };
 
 type DocumentsCardProps = {

--- a/components/view/dataroom/folder-card.tsx
+++ b/components/view/dataroom/folder-card.tsx
@@ -5,6 +5,10 @@ import { Download, FolderIcon, MoreVerticalIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import { timeAgo } from "@/lib/utils";
+import {
+  HIERARCHICAL_DISPLAY_STYLE,
+  useHierarchicalDisplayName,
+} from "@/lib/utils/hierarchical-display";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -34,6 +38,12 @@ export default function FolderCard({
   allowDownload,
 }: FolderCardProps) {
   const [open, setOpen] = useState(false);
+
+  // Get hierarchical display name
+  const displayName = useHierarchicalDisplayName(
+    folder.name,
+    folder.hierarchicalIndex,
+  );
   const downloadDocument = async () => {
     if (!allowDownload) {
       toast.error("Downloading folders is not allowed.");
@@ -95,12 +105,15 @@ export default function FolderCard({
 
         <div className="flex-col">
           <div className="flex items-center">
-            <h2 className="min-w-0 max-w-[300px] truncate text-sm font-semibold leading-6 text-foreground sm:max-w-lg">
+            <h2
+              className="min-w-0 max-w-[300px] truncate text-sm font-semibold leading-6 text-foreground sm:max-w-lg"
+              style={HIERARCHICAL_DISPLAY_STYLE}
+            >
               <div
                 onClick={() => setFolderId(folder.id)}
                 className="w-full truncate"
               >
-                <span>{folder.name}</span>
+                <span>{displayName}</span>
                 <span className="absolute inset-0" />
               </div>
             </h2>

--- a/components/view/viewer/dataroom-viewer.tsx
+++ b/components/view/viewer/dataroom-viewer.tsx
@@ -13,6 +13,10 @@ import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { PanelLeftIcon, XIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import {
+  HIERARCHICAL_DISPLAY_STYLE,
+  useHierarchicalDisplayName,
+} from "@/lib/utils/hierarchical-display";
 import { sortByIndexThenName } from "@/lib/utils/sort-items-by-index-name";
 
 import { ViewFolderTree } from "@/components/datarooms/folders";
@@ -39,6 +43,39 @@ import { DocumentUploadModal } from "../dataroom/document-upload-modal";
 import FolderCard from "../dataroom/folder-card";
 import IndexFileDialog from "../dataroom/index-file-dialog";
 import DataroomNav from "../dataroom/nav-dataroom";
+
+const ViewerBreadcrumbItem = ({
+  folder,
+  setFolderId,
+  isLast,
+}: {
+  folder: any;
+  setFolderId: (id: string | null) => void;
+  isLast: boolean;
+}) => {
+  const displayName = useHierarchicalDisplayName(
+    folder.name,
+    folder.hierarchicalIndex,
+  );
+
+  if (isLast) {
+    return (
+      <BreadcrumbPage className="capitalize" style={HIERARCHICAL_DISPLAY_STYLE}>
+        {displayName}
+      </BreadcrumbPage>
+    );
+  }
+
+  return (
+    <BreadcrumbLink
+      onClick={() => setFolderId(folder.id)}
+      className="cursor-pointer capitalize"
+      style={HIERARCHICAL_DISPLAY_STYLE}
+    >
+      {displayName}
+    </BreadcrumbLink>
+  );
+};
 
 type FolderOrDocument =
   | (DataroomFolder & { allowDownload: boolean })
@@ -410,18 +447,11 @@ export default function DataroomViewer({
                         <React.Fragment key={folder.id}>
                           <BreadcrumbSeparator />
                           <BreadcrumbItem>
-                            {index === breadcrumbFolders.length - 1 ? (
-                              <BreadcrumbPage className="capitalize">
-                                {folder.name}
-                              </BreadcrumbPage>
-                            ) : (
-                              <BreadcrumbLink
-                                onClick={() => setFolderId(folder.id)}
-                                className="cursor-pointer capitalize"
-                              >
-                                {folder.name}
-                              </BreadcrumbLink>
-                            )}
+                            <ViewerBreadcrumbItem
+                              folder={folder}
+                              setFolderId={setFolderId}
+                              isLast={index === breadcrumbFolders.length - 1}
+                            />
                           </BreadcrumbItem>
                         </React.Fragment>
                       ))}

--- a/components/view/viewer/dataroom-viewer.tsx
+++ b/components/view/viewer/dataroom-viewer.tsx
@@ -100,6 +100,7 @@ type DataroomDocument = {
   versions: DocumentVersion[];
   canDownload: boolean;
   canView: boolean;
+  hierarchicalIndex: string | null;
 };
 
 const getParentFolders = (

--- a/lib/api/links/link-data.ts
+++ b/lib/api/links/link-data.ts
@@ -122,6 +122,7 @@ export async function fetchDataroomLinkData({
               folderId: true,
               updatedAt: true,
               orderIndex: true,
+              hierarchicalIndex: true,
               document: {
                 select: {
                   id: true,
@@ -156,6 +157,17 @@ export async function fetchDataroomLinkData({
               groupPermissions.length > 0 || effectiveGroupId
                 ? { id: { in: allRequiredFolderIds } }
                 : undefined,
+            select: {
+              id: true,
+              name: true,
+              path: true,
+              parentId: true,
+              dataroomId: true,
+              orderIndex: true,
+              hierarchicalIndex: true,
+              createdAt: true,
+              updatedAt: true,
+            },
             orderBy: [{ orderIndex: "asc" }, { name: "asc" }],
           },
         },
@@ -289,6 +301,7 @@ export async function fetchDataroomDocumentLinkData({
               id: true,
               updatedAt: true,
               orderIndex: true,
+              hierarchicalIndex: true,
               document: {
                 select: {
                   id: true,

--- a/lib/featureFlags/index.ts
+++ b/lib/featureFlags/index.ts
@@ -8,7 +8,8 @@ export type BetaFeatures =
   | "conversations"
   | "dataroomUpload"
   | "inDocumentLinks"
-  | "usStorage";
+  | "usStorage"
+  | "dataroomIndex";
 
 type BetaFeaturesRecord = Record<BetaFeatures, string[]>;
 
@@ -22,6 +23,7 @@ export const getFeatureFlags = async ({ teamId }: { teamId?: string }) => {
     dataroomUpload: false,
     inDocumentLinks: false,
     usStorage: false,
+    dataroomIndex: false,
   };
 
   // Return all features as true if edge config is not available

--- a/lib/hooks/use-feature-flags.ts
+++ b/lib/hooks/use-feature-flags.ts
@@ -1,0 +1,31 @@
+import { useTeam } from "@/context/team-context";
+import useSWR from "swr";
+
+import { BetaFeatures } from "@/lib/featureFlags";
+import { fetcher } from "@/lib/utils";
+
+/**
+ * Hook to fetch and use feature flags for the current team
+ */
+export function useFeatureFlags() {
+  const teamInfo = useTeam();
+
+  const {
+    data: features,
+    error,
+    isLoading,
+  } = useSWR<Record<BetaFeatures, boolean>>(
+    teamInfo?.currentTeam?.id
+      ? `/api/feature-flags?teamId=${teamInfo.currentTeam.id}`
+      : null,
+    fetcher,
+  );
+
+  return {
+    features,
+    isLoading,
+    error,
+    // Helper function to check if a specific feature is enabled
+    isFeatureEnabled: (feature: BetaFeatures) => features?.[feature] || false,
+  };
+}

--- a/lib/swr/use-dataroom.ts
+++ b/lib/swr/use-dataroom.ts
@@ -213,6 +213,7 @@ export type DataroomFolderWithDocuments = DataroomFolder & {
     orderIndex: number | null;
     id: string;
     folderId: string;
+    hierarchicalIndex: string | null;
     document: {
       id: string;
       name: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -132,6 +132,7 @@ export interface LinkWithDataroom extends Link {
       folderId: string | null;
       updatedAt: Date;
       orderIndex: number | null;
+      hierarchicalIndex: string | null;
       document: {
         id: string;
         name: string;

--- a/lib/types/index-file.ts
+++ b/lib/types/index-file.ts
@@ -1,4 +1,5 @@
 export interface DataroomIndexEntry {
+  hierarchicalIndex: string | null | undefined;
   name: string;
   type: "File" | "Folder" | "Root Folder";
   path: string;

--- a/lib/utils/calculate-hierarchical-indexes.ts
+++ b/lib/utils/calculate-hierarchical-indexes.ts
@@ -1,0 +1,211 @@
+import prisma from "@/lib/prisma";
+
+interface DataroomItem {
+  id: string;
+  name: string;
+  orderIndex: number | null;
+  parentId?: string | null;
+  folderId?: string | null;
+  type: "folder" | "document";
+}
+
+interface HierarchicalItem extends DataroomItem {
+  hierarchicalIndex: string;
+  children: HierarchicalItem[];
+}
+
+/**
+ * Sorts items by orderIndex first (nulls last), then by name
+ */
+function sortItems(items: DataroomItem[]): DataroomItem[] {
+  return items.sort((a, b) => {
+    // First sort by orderIndex (nulls go to the end)
+    if (a.orderIndex !== null && b.orderIndex !== null) {
+      if (a.orderIndex !== b.orderIndex) {
+        return a.orderIndex - b.orderIndex;
+      }
+    } else if (a.orderIndex !== null) {
+      return -1; // a comes first
+    } else if (b.orderIndex !== null) {
+      return 1; // b comes first
+    }
+
+    // Then sort by name
+    return a.name.localeCompare(b.name);
+  });
+}
+
+/**
+ * Builds a hierarchical tree structure from flat items
+ */
+function buildHierarchy(
+  items: DataroomItem[],
+  parentId: string | null = null,
+): HierarchicalItem[] {
+  const children = items.filter((item) => {
+    if (item.type === "folder") {
+      return item.parentId === parentId;
+    } else {
+      return item.folderId === parentId;
+    }
+  });
+
+  const sortedChildren = sortItems(children);
+
+  return sortedChildren.map((item, index) => {
+    const hierarchicalItem: HierarchicalItem = {
+      ...item,
+      hierarchicalIndex: "", // Will be set later
+      children: buildHierarchy(items, item.id),
+    };
+
+    return hierarchicalItem;
+  });
+}
+
+/**
+ * Assigns hierarchical indexes to items recursively
+ */
+function assignHierarchicalIndexes(
+  items: HierarchicalItem[],
+  prefix: string = "",
+): void {
+  items.forEach((item, index) => {
+    const currentIndex = index + 1;
+    item.hierarchicalIndex = prefix
+      ? `${prefix}.${currentIndex}`
+      : `${currentIndex}`;
+
+    if (item.children.length > 0) {
+      assignHierarchicalIndexes(item.children, item.hierarchicalIndex);
+    }
+  });
+}
+
+/**
+ * Flattens the hierarchical tree back to a flat array with hierarchical indexes
+ */
+function flattenHierarchy(items: HierarchicalItem[]): Array<{
+  id: string;
+  hierarchicalIndex: string;
+  type: "folder" | "document";
+}> {
+  const result: Array<{
+    id: string;
+    hierarchicalIndex: string;
+    type: "folder" | "document";
+  }> = [];
+
+  items.forEach((item) => {
+    result.push({
+      id: item.id,
+      hierarchicalIndex: item.hierarchicalIndex,
+      type: item.type,
+    });
+
+    if (item.children.length > 0) {
+      result.push(...flattenHierarchy(item.children));
+    }
+  });
+
+  return result;
+}
+
+/**
+ * Calculates and updates hierarchical indexes for all folders and documents in a dataroom
+ */
+export async function calculateAndUpdateHierarchicalIndexes(
+  dataroomId: string,
+): Promise<{ foldersUpdated: number; documentsUpdated: number }> {
+  try {
+    // Fetch all folders and documents for the dataroom
+    const [folders, documents] = await Promise.all([
+      prisma.dataroomFolder.findMany({
+        where: { dataroomId },
+        select: {
+          id: true,
+          name: true,
+          parentId: true,
+          orderIndex: true,
+        },
+      }),
+      prisma.dataroomDocument.findMany({
+        where: { dataroomId },
+        select: {
+          id: true,
+          folderId: true,
+          orderIndex: true,
+          document: {
+            select: {
+              name: true,
+            },
+          },
+        },
+      }),
+    ]);
+
+    // Convert to unified format
+    const allItems: DataroomItem[] = [
+      ...folders.map((folder) => ({
+        id: folder.id,
+        name: folder.name,
+        orderIndex: folder.orderIndex,
+        parentId: folder.parentId,
+        type: "folder" as const,
+      })),
+      ...documents.map((doc) => ({
+        id: doc.id,
+        name: doc.document.name,
+        orderIndex: doc.orderIndex,
+        folderId: doc.folderId,
+        type: "document" as const,
+      })),
+    ];
+
+    // Build hierarchy starting from root items (no parent)
+    const hierarchy = buildHierarchy(allItems, null);
+
+    // Assign hierarchical indexes
+    assignHierarchicalIndexes(hierarchy);
+
+    // Flatten back to get all items with their indexes
+    const flattenedItems = flattenHierarchy(hierarchy);
+
+    // Separate folders and documents for batch updates
+    const folderUpdates = flattenedItems.filter(
+      (item) => item.type === "folder",
+    );
+    const documentUpdates = flattenedItems.filter(
+      (item) => item.type === "document",
+    );
+
+    // Use Prisma transaction to batch update all hierarchicalIndex fields
+    await prisma.$transaction(async (tx) => {
+      // Update folders
+      const folderPromises = folderUpdates.map((folder) =>
+        tx.dataroomFolder.update({
+          where: { id: folder.id },
+          data: { hierarchicalIndex: folder.hierarchicalIndex },
+        }),
+      );
+
+      // Update documents
+      const documentPromises = documentUpdates.map((document) =>
+        tx.dataroomDocument.update({
+          where: { id: document.id },
+          data: { hierarchicalIndex: document.hierarchicalIndex },
+        }),
+      );
+
+      await Promise.all([...folderPromises, ...documentPromises]);
+    });
+
+    return {
+      foldersUpdated: folderUpdates.length,
+      documentsUpdated: documentUpdates.length,
+    };
+  } catch (error) {
+    console.error("Error calculating hierarchical indexes:", error);
+    throw new Error("Failed to calculate and update hierarchical indexes");
+  }
+}

--- a/lib/utils/hierarchical-display.ts
+++ b/lib/utils/hierarchical-display.ts
@@ -1,0 +1,40 @@
+import { useFeatureFlags } from "@/lib/hooks/use-feature-flags";
+
+/**
+ * Returns the display name with hierarchical index if enabled
+ */
+export function useHierarchicalDisplayName(
+  name: string,
+  hierarchicalIndex?: string | null,
+): string {
+  const { isFeatureEnabled } = useFeatureFlags();
+  const isDataroomIndexEnabled = isFeatureEnabled("dataroomIndex");
+
+  if (isDataroomIndexEnabled && hierarchicalIndex) {
+    return `${hierarchicalIndex} ${name}`;
+  }
+
+  return name;
+}
+
+/**
+ * Non-hook version for use in non-React contexts
+ */
+export function getHierarchicalDisplayName(
+  name: string,
+  hierarchicalIndex?: string | null,
+  isFeatureEnabled: boolean = false,
+): string {
+  if (isFeatureEnabled && hierarchicalIndex) {
+    return `${hierarchicalIndex} ${name}`;
+  }
+
+  return name;
+}
+
+/**
+ * CSS class for tabular numbers styling
+ */
+export const HIERARCHICAL_DISPLAY_STYLE = {
+  fontVariantNumeric: "tabular-nums" as const,
+};

--- a/pages/api/links/generate-index.ts
+++ b/pages/api/links/generate-index.ts
@@ -3,6 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { ItemType } from "@prisma/client";
 
 import { generateDataroomIndex } from "@/lib/dataroom/index-generator";
+import { getFeatureFlags } from "@/lib/featureFlags";
 import prisma from "@/lib/prisma";
 import { LinkWithDataroom } from "@/lib/types";
 import { IndexFileFormat } from "@/lib/types/index-file";
@@ -185,6 +186,7 @@ export default async function handle(
           orderIndex: doc.orderIndex,
           updatedAt: doc.updatedAt,
           createdAt: doc.createdAt,
+          hierarchicalIndex: doc.hierarchicalIndex,
           document: {
             id: doc.document.id,
             name: doc.document.name,
@@ -207,6 +209,10 @@ export default async function handle(
       },
     };
 
+    const { dataroomIndex } = await getFeatureFlags({
+      teamId: link.dataroom.teamId,
+    });
+
     // Generate the index file using the appropriate generator
     const { data, filename, mimeType } = await generateDataroomIndex(
       linkWithDataroom,
@@ -215,6 +221,7 @@ export default async function handle(
         baseUrl: link.domainId
           ? `${link.domainSlug}/${link.slug}`
           : `${process.env.NEXT_PUBLIC_MARKETING_URL}/view/${link.id}`,
+        showHierarchicalIndex: dataroomIndex,
       },
     );
 

--- a/pages/api/teams/[teamId]/datarooms/[id]/calculate-indexes.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/calculate-indexes.ts
@@ -1,0 +1,88 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { authOptions } from "@/pages/api/auth/[...nextauth]";
+import { getServerSession } from "next-auth/next";
+
+import { getFeatureFlags } from "@/lib/featureFlags";
+import prisma from "@/lib/prisma";
+import { CustomUser } from "@/lib/types";
+import { calculateAndUpdateHierarchicalIndexes } from "@/lib/utils/calculate-hierarchical-indexes";
+
+export const config = {
+  maxDuration: 300,
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ message: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).end("Unauthorized");
+  }
+
+  const { teamId, id: dataroomId } = req.query as {
+    teamId: string;
+    id: string;
+  };
+  const userId = (session.user as CustomUser).id;
+
+  if (!dataroomId || typeof dataroomId !== "string") {
+    return res.status(400).json({ message: "Invalid dataroom ID" });
+  }
+
+  if (!teamId || typeof teamId !== "string") {
+    return res.status(400).json({ message: "Invalid team ID" });
+  }
+
+  try {
+    // Check if dataroomIndex feature flag is enabled
+    const featureFlags = await getFeatureFlags({ teamId });
+    if (!featureFlags.dataroomIndex) {
+      return res.status(403).json({ message: "Feature not enabled" });
+    }
+
+    // Verify user has access to this dataroom
+    const dataroom = await prisma.dataroom.findUnique({
+      where: {
+        id: dataroomId,
+        teamId,
+        team: {
+          users: {
+            some: {
+              userId: userId,
+            },
+          },
+        },
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+    });
+
+    if (!dataroom) {
+      return res.status(404).json({ message: "Dataroom not found" });
+    }
+
+    // Calculate and update hierarchical indexes
+    const result = await calculateAndUpdateHierarchicalIndexes(dataroomId);
+
+    res.status(200).json({
+      message: "Hierarchical indexes calculated successfully",
+      foldersUpdated: result.foldersUpdated,
+      documentsUpdated: result.documentsUpdated,
+      totalUpdated: result.foldersUpdated + result.documentsUpdated,
+    });
+  } catch (error) {
+    console.error("Error calculating hierarchical indexes:", error);
+    res.status(500).json({
+      message: "Error calculating hierarchical indexes",
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+}

--- a/pages/api/teams/[teamId]/datarooms/[id]/documents/index.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/documents/index.ts
@@ -65,7 +65,14 @@ export default async function handle(
             },
           },
         ],
-        include: {
+        select: {
+          id: true,
+          dataroomId: true,
+          folderId: true,
+          orderIndex: true,
+          hierarchicalIndex: true,
+          createdAt: true,
+          updatedAt: true,
           document: {
             select: {
               id: true,
@@ -160,7 +167,9 @@ export default async function handle(
                 orderBy: { createdAt: "desc" },
                 take: 1,
               },
-              _count: { select: { viewerGroups: true, permissionGroups: true } },
+              _count: {
+                select: { viewerGroups: true, permissionGroups: true },
+              },
             },
           },
         },

--- a/pages/api/teams/[teamId]/datarooms/[id]/folders/[...name].ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/folders/[...name].ts
@@ -79,7 +79,16 @@ export default async function handle(
         orderBy: {
           name: "asc",
         },
-        include: {
+        select: {
+          id: true,
+          name: true,
+          path: true,
+          parentId: true,
+          dataroomId: true,
+          orderIndex: true,
+          hierarchicalIndex: true,
+          createdAt: true,
+          updatedAt: true,
           _count: {
             select: { documents: true, childFolders: true },
           },

--- a/pages/api/teams/[teamId]/datarooms/[id]/folders/documents/[...name].ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/folders/documents/[...name].ts
@@ -92,6 +92,7 @@ export default async function handle(
           createdAt: true,
           updatedAt: true,
           orderIndex: true,
+          hierarchicalIndex: true,
           document: {
             select: {
               id: true,

--- a/pages/api/teams/[teamId]/datarooms/[id]/folders/index.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/folders/index.ts
@@ -259,7 +259,16 @@ export default async function handle(
             parentId: null,
           },
           orderBy: [{ orderIndex: "asc" }, { name: "asc" }],
-          include: {
+          select: {
+            id: true,
+            name: true,
+            path: true,
+            parentId: true,
+            dataroomId: true,
+            orderIndex: true,
+            hierarchicalIndex: true,
+            createdAt: true,
+            updatedAt: true,
             _count: {
               select: { documents: true, childFolders: true },
             },
@@ -281,6 +290,7 @@ export default async function handle(
               select: {
                 id: true,
                 folderId: true,
+                hierarchicalIndex: true,
                 document: {
                   select: {
                     id: true,
@@ -291,11 +301,21 @@ export default async function handle(
               },
             },
             folders: {
-              include: {
+              select: {
+                id: true,
+                name: true,
+                path: true,
+                parentId: true,
+                dataroomId: true,
+                orderIndex: true,
+                hierarchicalIndex: true,
+                createdAt: true,
+                updatedAt: true,
                 documents: {
                   select: {
                     id: true,
                     folderId: true,
+                    hierarchicalIndex: true,
                     document: {
                       select: {
                         id: true,
@@ -333,12 +353,22 @@ export default async function handle(
             name: "asc",
           },
         ],
-        include: {
+        select: {
+          id: true,
+          name: true,
+          path: true,
+          parentId: true,
+          dataroomId: true,
+          orderIndex: true,
+          hierarchicalIndex: true,
+          createdAt: true,
+          updatedAt: true,
           documents: {
             select: {
               orderIndex: true,
               id: true,
               folderId: true,
+              hierarchicalIndex: true,
               document: {
                 select: {
                   id: true,

--- a/pages/api/teams/[teamId]/datarooms/[id]/folders/parents/[...name].ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/folders/parents/[...name].ts
@@ -69,6 +69,7 @@ export default async function handle(
             id: true,
             parentId: true,
             name: true,
+            hierarchicalIndex: true,
           },
         });
 
@@ -76,7 +77,11 @@ export default async function handle(
           return res.status(404).end("Parent Folder not found");
         }
 
-        folderNames.push({ name: folder.name, path: path });
+        folderNames.push({
+          name: folder.name,
+          path: path,
+          hierarchicalIndex: folder.hierarchicalIndex,
+        });
       }
 
       return res.status(200).json(folderNames);

--- a/pages/api/teams/[teamId]/datarooms/[id]/generate-index.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/generate-index.ts
@@ -5,6 +5,7 @@ import { ItemType } from "@prisma/client";
 import { getServerSession } from "next-auth/next";
 
 import { generateDataroomIndex } from "@/lib/dataroom/index-generator";
+import { getFeatureFlags } from "@/lib/featureFlags";
 import prisma from "@/lib/prisma";
 import { CustomUser, LinkWithDataroom } from "@/lib/types";
 import { IndexFileFormat } from "@/lib/types/index-file";
@@ -183,6 +184,7 @@ export default async function handle(
           orderIndex: doc.orderIndex,
           updatedAt: doc.updatedAt,
           createdAt: doc.createdAt,
+          hierarchicalIndex: doc.hierarchicalIndex,
           document: {
             id: doc.document.id,
             name: doc.document.name,
@@ -205,6 +207,12 @@ export default async function handle(
       },
     };
 
+    const { dataroomIndex } = await getFeatureFlags({
+      teamId: link.dataroom.teamId,
+    });
+
+    console.log("dataroomIndex", dataroomIndex);
+
     // Generate the index file using the appropriate generator
     const { data, filename, mimeType } = await generateDataroomIndex(
       linkWithDataroom,
@@ -213,6 +221,7 @@ export default async function handle(
         baseUrl: link.domainId
           ? `${link.domainSlug}/${link.slug}`
           : `${process.env.NEXT_PUBLIC_MARKETING_URL}/view/${link.id}`,
+        showHierarchicalIndex: dataroomIndex,
       },
     );
 

--- a/pages/api/teams/[teamId]/datarooms/[id]/generate-index.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/generate-index.ts
@@ -211,8 +211,6 @@ export default async function handle(
       teamId: link.dataroom.teamId,
     });
 
-    console.log("dataroomIndex", dataroomIndex);
-
     // Generate the index file using the appropriate generator
     const { data, filename, mimeType } = await generateDataroomIndex(
       linkWithDataroom,

--- a/pages/datarooms/[id]/documents/[...name].tsx
+++ b/pages/datarooms/[id]/documents/[...name].tsx
@@ -5,6 +5,8 @@ import { useState } from "react";
 import { useTeam } from "@/context/team-context";
 import { ArrowUpDownIcon, FolderPlusIcon, PlusIcon } from "lucide-react";
 
+import { useDataroom, useDataroomItems } from "@/lib/swr/use-dataroom";
+
 import DownloadDataroomButton from "@/components/datarooms/actions/download-dataroom";
 import GenerateIndexButton from "@/components/datarooms/actions/generate-index-button";
 import { BreadcrumbComponent } from "@/components/datarooms/dataroom-breadcrumb";
@@ -12,6 +14,7 @@ import { DataroomHeader } from "@/components/datarooms/dataroom-header";
 import { DataroomItemsList } from "@/components/datarooms/dataroom-items-list";
 import { DataroomNavigation } from "@/components/datarooms/dataroom-navigation";
 import { SidebarFolderTree } from "@/components/datarooms/folders";
+import RebuildIndexButton from "@/components/datarooms/rebuild-index-button";
 import { DataroomSortableList } from "@/components/datarooms/sortable/sortable-list";
 import { AddDocumentModal } from "@/components/documents/add-document-modal";
 import { LoadingDocuments } from "@/components/documents/loading-document";
@@ -19,8 +22,6 @@ import { AddFolderModal } from "@/components/folders/add-folder-modal";
 import AppLayout from "@/components/layouts/app";
 import { Button } from "@/components/ui/button";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
-
-import { useDataroom, useDataroomItems } from "@/lib/swr/use-dataroom";
 
 export default function Documents() {
   const router = useRouter();
@@ -51,6 +52,10 @@ export default function Documents() {
         <div className="flex items-center justify-between gap-x-2">
           <div className="flex items-center gap-x-2">
             <GenerateIndexButton
+              teamId={teamInfo?.currentTeam?.id!}
+              dataroomId={dataroom?.id!}
+            />
+            <RebuildIndexButton
               teamId={teamInfo?.currentTeam?.id!}
               dataroomId={dataroom?.id!}
             />
@@ -96,7 +101,7 @@ export default function Documents() {
                   onClick={() => setIsReordering(!isReordering)}
                 >
                   <ArrowUpDownIcon className="h-4 w-4" />
-                  Edit index
+                  Reorder
                 </Button>
               ) : null}
             </div>

--- a/pages/datarooms/[id]/documents/index.tsx
+++ b/pages/datarooms/[id]/documents/index.tsx
@@ -11,6 +11,7 @@ import { DataroomHeader } from "@/components/datarooms/dataroom-header";
 import { DataroomItemsList } from "@/components/datarooms/dataroom-items-list";
 import { DataroomNavigation } from "@/components/datarooms/dataroom-navigation";
 import { SidebarFolderTree } from "@/components/datarooms/folders";
+import RebuildIndexButton from "@/components/datarooms/rebuild-index-button";
 import { DataroomSortableList } from "@/components/datarooms/sortable/sortable-list";
 import { AddDocumentModal } from "@/components/documents/add-document-modal";
 import { LoadingDocuments } from "@/components/documents/loading-document";
@@ -48,6 +49,10 @@ export default function Documents() {
               teamId={teamInfo?.currentTeam?.id!}
               dataroomId={dataroom?.id!}
             />
+            <RebuildIndexButton
+              teamId={teamInfo?.currentTeam?.id!}
+              dataroomId={dataroom?.id!}
+            />
             <DownloadDataroomButton
               teamId={teamInfo?.currentTeam?.id!}
               dataroomId={dataroom?.id!}
@@ -81,7 +86,7 @@ export default function Documents() {
               {!isReordering ? (
                 <ResponsiveButton
                   icon={<ArrowUpDownIcon className="h-4 w-4" />}
-                  text="Edit index"
+                  text="Reorder"
                   size="sm"
                   variant="outline"
                   onClick={() => setIsReordering(!isReordering)}

--- a/pages/room_ppreview_demo.tsx
+++ b/pages/room_ppreview_demo.tsx
@@ -73,6 +73,7 @@ export default function ViewPage() {
                 parentId: null,
                 dataroomId: "1",
                 orderIndex: 0,
+                hierarchicalIndex: null,
                 path: "/",
                 createdAt: new Date(),
                 updatedAt: new Date(),
@@ -83,6 +84,7 @@ export default function ViewPage() {
                 parentId: null,
                 dataroomId: "1",
                 orderIndex: 1,
+                hierarchicalIndex: null,
                 path: "/",
                 createdAt: new Date(),
                 updatedAt: new Date(),
@@ -94,6 +96,7 @@ export default function ViewPage() {
                 name: "Q4 Report.pdf",
                 dataroomDocumentId: "1",
                 folderId: null,
+                hierarchicalIndex: null,
                 versions: [
                   {
                     id: "1",
@@ -122,6 +125,7 @@ export default function ViewPage() {
                       parentId: null,
                       dataroomId: "1",
                       orderIndex: 0,
+                      hierarchicalIndex: null,
                       path: "/",
                       createdAt: new Date(),
                       updatedAt: new Date(),
@@ -142,6 +146,7 @@ export default function ViewPage() {
                       parentId: null,
                       dataroomId: "1",
                       orderIndex: 1,
+                      hierarchicalIndex: null,
                       path: "/",
                       createdAt: new Date(),
                       updatedAt: new Date(),
@@ -162,6 +167,7 @@ export default function ViewPage() {
                       dataroomDocumentId: "1",
                       downloadOnly: false,
                       canDownload: false,
+                      hierarchicalIndex: null,
                       versions: [
                         {
                           id: "1",

--- a/pages/view/[linkId]/index.tsx
+++ b/pages/view/[linkId]/index.tsx
@@ -171,6 +171,7 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
           dataroomDocumentId: document.id,
           folderId: document.folderId,
           orderIndex: document.orderIndex,
+          hierarchicalIndex: document.hierarchicalIndex,
           versions: [
             {
               ...versionWithoutTypeAndFile,

--- a/pages/view/domains/[domain]/[slug]/index.tsx
+++ b/pages/view/domains/[domain]/[slug]/index.tsx
@@ -153,6 +153,7 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
           dataroomDocumentId: document.id,
           folderId: document.folderId,
           orderIndex: document.orderIndex,
+          hierarchicalIndex: document.hierarchicalIndex,
           versions: [
             {
               ...versionWithoutTypeAndFile,

--- a/prisma/migrations/20250905000000_add_hierarchical_index_to_dataroom/migration.sql
+++ b/prisma/migrations/20250905000000_add_hierarchical_index_to_dataroom/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "DataroomDocument" ADD COLUMN     "hierarchicalIndex" TEXT;
+
+-- AlterTable
+ALTER TABLE "DataroomFolder" ADD COLUMN     "hierarchicalIndex" TEXT;
+

--- a/prisma/schema/dataroom.prisma
+++ b/prisma/schema/dataroom.prisma
@@ -52,6 +52,7 @@ model DataroomDocument {
   folderId   String?
   folder     DataroomFolder? @relation(fields: [folderId], references: [id], onDelete: SetNull)
   orderIndex Int?
+  hierarchicalIndex String?        // Computed field like "1.2.3" for hierarchical display
 
   conversations Conversation[]
 
@@ -79,6 +80,7 @@ model DataroomFolder {
   dataroomId   String
   dataroom     Dataroom           @relation(fields: [dataroomId], references: [id], onDelete: Cascade)
   orderIndex   Int?
+  hierarchicalIndex String?        // Computed field like "1.2" for hierarchical display
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Hierarchical names for folders/documents across breadcrumbs, cards, trees, viewers, permissions, and exports (feature-flagged).
  - Rebuild Index action with modal UI, server API to compute/persist indexes, and success/error toasts.
  - Per-team dataroomIndex feature flag and a new hook to read feature flags; display utilities for hierarchical naming.

- **Refactor**
  - Consolidated breadcrumb/tree rendering into reusable components for consistent hierarchical display.

- **Chores**
  - DB migration adding hierarchicalIndex and API/type updates to surface it.

- **Style**
  - UI copy updates: “Edit index” → “Reorder”, “Save index” → “Save order”; adjusted toast messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->