### PR TITLE
Migrate transactional emails to papermark.com

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout({
     <html lang="en">
       <head>
         <PlausibleProvider
-          domain="papermark.io"
+          domain="papermark.com"
           enabled={process.env.NEXT_PUBLIC_VERCEL_ENV === "production"}
         />
       </head>

--- a/components/links/link-sheet/allow-list-section.tsx
+++ b/components/links/link-sheet/allow-list-section.tsx
@@ -112,7 +112,7 @@ export default function AllowListSection({
               className="focus:ring-inset"
               rows={5}
               placeholder={`Enter allowed emails/domains, one per line, e.g.
-marc@papermark.io
+marc@papermark.com
 @example.org`}
               value={allowListInput}
               onChange={handleAllowListChange}

--- a/components/links/link-sheet/deny-list-section.tsx
+++ b/components/links/link-sheet/deny-list-section.tsx
@@ -111,7 +111,7 @@ export default function DenyListSection({
               className="focus:ring-inset"
               rows={5}
               placeholder={`Enter blocked emails/domains, one per line, e.g.
-marc@papermark.io
+marc@papermark.com
 @example.org`}
               value={denyListInput}
               onChange={handleDenyListChange}

--- a/components/profile-menu.tsx
+++ b/components/profile-menu.tsx
@@ -141,7 +141,7 @@ const ProfileMenu = ({ className, size }: ProfileMenuProps) => {
                   </button>
 
                   <a
-                    href="mailto:support@papermark.io"
+                    href="mailto:support@papermark.com"
                     className="my-1 flex items-center px-3 py-2 text-sm duration-200 hover:bg-gray-200 dark:hover:bg-muted"
                   >
                     <HelpCircle className="mr-2 h-4 w-4" />

--- a/components/sidebar/nav-user.tsx
+++ b/components/sidebar/nav-user.tsx
@@ -165,8 +165,8 @@ export function NavUser() {
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => {
-                    navigator.clipboard.writeText("support@papermark.io");
-                    toast.success("support@papermark.io copied to clipboard");
+                    navigator.clipboard.writeText("support@papermark.com");
+                    toast.success("support@papermark.com copied to clipboard");
                   }}
                 >
                   <MailIcon />

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -47,7 +47,7 @@ const Progress = React.forwardRef<
         <div className="absolute inset-0 flex items-center justify-center py-2">
           <div className="absolute inset-0 flex items-center justify-center gap-x-2 overflow-hidden bg-destructive text-destructive-foreground">
             <span className="text-xs">{text}</span>
-            <a href="mailto:support@papermark.io" title="Contact Support">
+            <a href="mailto:support@papermark.com" title="Contact Support">
               <HelpCircleIcon className="size-4" />
             </a>
           </div>

--- a/lib/middleware/domain.ts
+++ b/lib/middleware/domain.ts
@@ -47,7 +47,7 @@ export default async function DomainMiddleware(req: NextRequest) {
     headers: {
       "X-Robots-Tag": "noindex",
       "X-Powered-By":
-        "Papermark.io - Document sharing infrastructure for the modern web",
+        "Papermark.com - Document sharing infrastructure for the modern web",
     },
   });
 }

--- a/lib/resend.ts
+++ b/lib/resend.ts
@@ -46,21 +46,21 @@ export const sendEmail = async ({
   const fromAddress =
     from ??
     (marketing
-      ? "Marc from Papermark <marc@ship.papermark.io>"
+      ? "Marc from Papermark <marc@ship.papermark.com>"
       : system
-        ? "Papermark <system@papermark.io>"
+        ? "Papermark <system@papermark.com>"
         : verify
-          ? "Papermark <system@verify.papermark.io>"
+          ? "Papermark <system@verify.papermark.com>"
           : !!scheduledAt
-            ? "Marc Seitz <marc@papermark.io>"
-            : "Marc from Papermark <marc@papermark.io>");
+            ? "Marc Seitz <marc@papermark.com>"
+            : "Marc from Papermark <marc@papermark.com>");
 
   try {
     const { data, error } = await resend.emails.send({
       from: fromAddress,
       to: test ? "delivered@resend.dev" : to,
       cc: cc,
-      replyTo: marketing ? "marc@papermark.io" : replyTo,
+      replyTo: marketing ? "marc@papermark.com" : replyTo,
       subject,
       react,
       scheduledAt,

--- a/lib/year-in-review/send-emails.ts
+++ b/lib/year-in-review/send-emails.ts
@@ -145,7 +145,7 @@ export async function processEmailQueue() {
 
                   return {
                     email: {
-                      from: "Papermark <system@papermark.io>",
+                      from: "Papermark <system@papermark.com>",
                       to: userTeam.user.email || "delivered@resend.dev",
                       subject: "2024 in Review: Your Year with Papermark",
                       react,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -75,7 +75,7 @@ export default function App({
         <PostHogCustomProvider>
           <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
             <PlausibleProvider
-              domain="papermark.io"
+              domain="papermark.com"
               enabled={process.env.NEXT_PUBLIC_VERCEL_ENV === "production"}
             >
               <NuqsAdapter>


### PR DESCRIPTION
Migrate transactional email sending domain from `papermark.io` to `papermark.com` for consistent branding and improved deliverability.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1757163975536749?thread_ts=1757163975.536749&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-c1c50409-367d-4d6a-a1ba-e477899605b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1c50409-367d-4d6a-a1ba-e477899605b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

