### PR TITLE
feat: server-side detection if dataroom index enabled

### DIFF
--- a/components/datarooms/folders/view-tree.tsx
+++ b/components/datarooms/folders/view-tree.tsx
@@ -8,7 +8,7 @@ import { HomeIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   HIERARCHICAL_DISPLAY_STYLE,
-  useHierarchicalDisplayName,
+  getHierarchicalDisplayName,
 } from "@/lib/utils/hierarchical-display";
 
 import { FileTree } from "@/components/ui/nextra-filetree";
@@ -16,10 +16,17 @@ import { FileTree } from "@/components/ui/nextra-filetree";
 import { buildNestedFolderStructureWithDocs } from "./utils";
 
 const ViewerDocumentFileItem = memo(
-  ({ document }: { document: DataroomDocumentWithVersion }) => {
-    const documentDisplayName = useHierarchicalDisplayName(
+  ({
+    document,
+    dataroomIndexEnabled,
+  }: {
+    document: DataroomDocumentWithVersion;
+    dataroomIndexEnabled?: boolean;
+  }) => {
+    const documentDisplayName = getHierarchicalDisplayName(
       document.name,
       document.hierarchicalIndex,
+      dataroomIndexEnabled || false,
     );
 
     return (
@@ -83,18 +90,21 @@ const FolderComponent = memo(
     folderId,
     setFolderId,
     folderPath,
+    dataroomIndexEnabled,
   }: {
     folder: DataroomFolderWithDocuments;
     folderId: string | null;
     setFolderId: React.Dispatch<React.SetStateAction<string | null>>;
     folderPath: Set<string> | null;
+    dataroomIndexEnabled?: boolean;
   }) => {
     const router = useRouter();
 
     // Get hierarchical display name for the folder
-    const folderDisplayName = useHierarchicalDisplayName(
+    const folderDisplayName = getHierarchicalDisplayName(
       folder.name,
       folder.hierarchicalIndex,
+      dataroomIndexEnabled || false,
     );
 
     // Memoize the rendering of the current folder's documents
@@ -107,9 +117,10 @@ const FolderComponent = memo(
               ...doc,
               versions: [], // Not needed for display
             }}
+            dataroomIndexEnabled={dataroomIndexEnabled}
           />
         )),
-      [folder.documents],
+      [folder.documents, dataroomIndexEnabled],
     );
 
     // Recursively render child folders if they exist
@@ -122,9 +133,16 @@ const FolderComponent = memo(
             folderId={folderId}
             setFolderId={setFolderId}
             folderPath={folderPath}
+            dataroomIndexEnabled={dataroomIndexEnabled}
           />
         )),
-      [folder.childFolders, folderId, setFolderId],
+      [
+        folder.childFolders,
+        folderId,
+        setFolderId,
+        folderPath,
+        dataroomIndexEnabled,
+      ],
     );
 
     const isActive = folder.id === folderId;
@@ -197,11 +215,13 @@ const SidebarFolders = ({
   documents,
   folderId,
   setFolderId,
+  dataroomIndexEnabled,
 }: {
   folders: DataroomFolder[];
   documents: DataroomDocumentWithVersion[];
   folderId: string | null;
   setFolderId: React.Dispatch<React.SetStateAction<string | null>>;
+  dataroomIndexEnabled?: boolean;
 }) => {
   const nestedFolders = useMemo(() => {
     if (folders) {
@@ -235,6 +255,7 @@ const SidebarFolders = ({
           folderId={folderId}
           setFolderId={setFolderId}
           folderPath={folderPath}
+          dataroomIndexEnabled={dataroomIndexEnabled}
         />
       ))}
     </FileTree>
@@ -246,11 +267,13 @@ export function ViewFolderTree({
   documents,
   setFolderId,
   folderId,
+  dataroomIndexEnabled,
 }: {
   folders: DataroomFolder[];
   documents: DataroomDocumentWithVersion[];
   setFolderId: React.Dispatch<React.SetStateAction<string | null>>;
   folderId: string | null;
+  dataroomIndexEnabled?: boolean;
 }) {
   if (!folders) return null;
 
@@ -260,6 +283,7 @@ export function ViewFolderTree({
       documents={documents}
       setFolderId={setFolderId}
       folderId={folderId}
+      dataroomIndexEnabled={dataroomIndexEnabled}
     />
   );
 }

--- a/components/view/dataroom/dataroom-view.tsx
+++ b/components/view/dataroom/dataroom-view.tsx
@@ -59,6 +59,7 @@ export default function DataroomView({
   logoOnAccessForm,
   isEmbedded,
   preview,
+  dataroomIndexEnabled,
 }: {
   link: LinkWithDataroom;
   userEmail: string | null | undefined;
@@ -73,6 +74,7 @@ export default function DataroomView({
   isEmbedded?: boolean;
   preview?: boolean;
   logoOnAccessForm?: boolean;
+  dataroomIndexEnabled?: boolean;
 }) {
   useDisablePrint();
   const {
@@ -282,6 +284,7 @@ export default function DataroomView({
           viewerId={viewData.viewerId}
           viewData={viewData}
           isEmbedded={isEmbedded}
+          dataroomIndexEnabled={dataroomIndexEnabled}
           viewerEmail={
             viewData.viewerEmail ??
             data.email ??

--- a/components/view/dataroom/document-card.tsx
+++ b/components/view/dataroom/document-card.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
 import { fileIcon } from "@/lib/utils/get-file-icon";
 import {
   HIERARCHICAL_DISPLAY_STYLE,
-  useHierarchicalDisplayName,
+  getHierarchicalDisplayName,
 } from "@/lib/utils/hierarchical-display";
 
 import { Button } from "@/components/ui/button";
@@ -42,6 +42,7 @@ type DocumentsCardProps = {
   isPreview: boolean;
   allowDownload: boolean;
   isProcessing?: boolean;
+  dataroomIndexEnabled?: boolean;
 };
 
 export default function DocumentCard({
@@ -51,6 +52,7 @@ export default function DocumentCard({
   isPreview,
   allowDownload,
   isProcessing = false,
+  dataroomIndexEnabled,
 }: DocumentsCardProps) {
   const { theme, systemTheme } = useTheme();
   const canDownload = document.canDownload && allowDownload;
@@ -60,9 +62,10 @@ export default function DocumentCard({
   const router = useRouter();
 
   // Get hierarchical display name
-  const displayName = useHierarchicalDisplayName(
+  const displayName = getHierarchicalDisplayName(
     document.name,
     document.hierarchicalIndex,
+    dataroomIndexEnabled || false,
   );
   const { previewToken, domain, slug } = router.query as {
     previewToken?: string;

--- a/components/view/dataroom/folder-card.tsx
+++ b/components/view/dataroom/folder-card.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 import { timeAgo } from "@/lib/utils";
 import {
   HIERARCHICAL_DISPLAY_STYLE,
-  useHierarchicalDisplayName,
+  getHierarchicalDisplayName,
 } from "@/lib/utils/hierarchical-display";
 
 import { Button } from "@/components/ui/button";
@@ -27,6 +27,7 @@ type FolderCardProps = {
   linkId: string;
   viewId?: string;
   allowDownload: boolean;
+  dataroomIndexEnabled?: boolean;
 };
 export default function FolderCard({
   folder,
@@ -36,13 +37,15 @@ export default function FolderCard({
   linkId,
   viewId,
   allowDownload,
+  dataroomIndexEnabled,
 }: FolderCardProps) {
   const [open, setOpen] = useState(false);
 
   // Get hierarchical display name
-  const displayName = useHierarchicalDisplayName(
+  const displayName = getHierarchicalDisplayName(
     folder.name,
     folder.hierarchicalIndex,
+    dataroomIndexEnabled || false,
   );
   const downloadDocument = async () => {
     if (!allowDownload) {

--- a/components/view/viewer/dataroom-viewer.tsx
+++ b/components/view/viewer/dataroom-viewer.tsx
@@ -15,7 +15,7 @@ import { PanelLeftIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   HIERARCHICAL_DISPLAY_STYLE,
-  useHierarchicalDisplayName,
+  getHierarchicalDisplayName,
 } from "@/lib/utils/hierarchical-display";
 import { sortByIndexThenName } from "@/lib/utils/sort-items-by-index-name";
 
@@ -48,14 +48,17 @@ const ViewerBreadcrumbItem = ({
   folder,
   setFolderId,
   isLast,
+  dataroomIndexEnabled,
 }: {
   folder: any;
   setFolderId: (id: string | null) => void;
   isLast: boolean;
+  dataroomIndexEnabled?: boolean;
 }) => {
-  const displayName = useHierarchicalDisplayName(
+  const displayName = getHierarchicalDisplayName(
     folder.name,
     folder.hierarchicalIndex,
+    dataroomIndexEnabled || false,
   );
 
   if (isLast) {
@@ -135,6 +138,7 @@ export default function DataroomViewer({
   enableIndexFile,
   isEmbedded,
   viewerEmail,
+  dataroomIndexEnabled,
 }: {
   brand: Partial<DataroomBrand>;
   viewId?: string;
@@ -150,6 +154,7 @@ export default function DataroomViewer({
   enableIndexFile?: boolean;
   isEmbedded?: boolean;
   viewerEmail?: string;
+  dataroomIndexEnabled?: boolean;
 }) {
   const { documents, folders, allowBulkDownload } = dataroom as {
     documents: DataroomDocument[];
@@ -342,6 +347,7 @@ export default function DataroomViewer({
           isPreview={!!isPreview}
           allowDownload={allowDownload && item.canDownload}
           isProcessing={isProcessing}
+          dataroomIndexEnabled={dataroomIndexEnabled}
         />
       );
     }
@@ -356,6 +362,7 @@ export default function DataroomViewer({
         linkId={linkId}
         viewId={viewId}
         allowDownload={item.allowDownload}
+        dataroomIndexEnabled={dataroomIndexEnabled}
       />
     );
   };
@@ -388,6 +395,7 @@ export default function DataroomViewer({
                 documents={documents}
                 setFolderId={setFolderId}
                 folderId={folderId}
+                dataroomIndexEnabled={dataroomIndexEnabled}
               />
               <ScrollBar orientation="horizontal" />
               <ScrollBar orientation="vertical" />
@@ -421,6 +429,7 @@ export default function DataroomViewer({
                             documents={documents}
                             setFolderId={setFolderId}
                             folderId={folderId}
+                            dataroomIndexEnabled={dataroomIndexEnabled}
                           />
                         </div>
                         <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
@@ -452,6 +461,7 @@ export default function DataroomViewer({
                               folder={folder}
                               setFolderId={setFolderId}
                               isLast={index === breadcrumbFolders.length - 1}
+                              dataroomIndexEnabled={dataroomIndexEnabled}
                             />
                           </BreadcrumbItem>
                         </React.Fragment>

--- a/pages/view/[linkId]/index.tsx
+++ b/pages/view/[linkId]/index.tsx
@@ -11,6 +11,7 @@ import { ExtendedRecordMap } from "notion-types";
 import { parsePageId } from "notion-utils";
 import z from "zod";
 
+import { getFeatureFlags } from "@/lib/featureFlags";
 import notion from "@/lib/notion";
 import { addSignedUrls } from "@/lib/notion/utils";
 import {
@@ -57,6 +58,7 @@ export interface ViewPageProps {
   useAdvancedExcelViewer: boolean;
   useCustomAccessForm: boolean;
   logoOnAccessForm: boolean;
+  dataroomIndexEnabled?: boolean;
 }
 
 export const getStaticProps = async (context: GetStaticPropsContext) => {
@@ -186,6 +188,10 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
 
       const { teamId } = link.dataroom;
 
+      // Check if dataroomIndex feature flag is enabled
+      const featureFlags = await getFeatureFlags({ teamId });
+      const dataroomIndexEnabled = featureFlags.dataroomIndex;
+
       const lastUpdatedAt = link.dataroom.documents.reduce((max, doc) => {
         return Math.max(
           max,
@@ -227,6 +233,7 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
           logoOnAccessForm:
             teamId === "cm7nlkrhm0000qgh0nvyrrywr" ||
             teamId === "clup33by90000oewh4rfvp2eg",
+          dataroomIndexEnabled,
         },
         revalidate: 10,
       };
@@ -253,6 +260,7 @@ export default function ViewPage({
   useAdvancedExcelViewer,
   useCustomAccessForm,
   logoOnAccessForm,
+  dataroomIndexEnabled,
   error,
   notionError,
 }: ViewPageProps & { error?: boolean; notionError?: boolean }) {
@@ -468,6 +476,7 @@ export default function ViewPage({
           token={storedToken}
           previewToken={previewToken}
           preview={!!preview}
+          dataroomIndexEnabled={dataroomIndexEnabled}
         />
       </>
     );

--- a/pages/view/domains/[domain]/[slug]/index.tsx
+++ b/pages/view/domains/[domain]/[slug]/index.tsx
@@ -11,6 +11,7 @@ import { ExtendedRecordMap } from "notion-types";
 import { parsePageId } from "notion-utils";
 import z from "zod";
 
+import { getFeatureFlags } from "@/lib/featureFlags";
 import notion from "@/lib/notion";
 import {
   CustomUser,
@@ -168,6 +169,10 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
 
       const { teamId } = link.dataroom;
 
+      // Check if dataroomIndex feature flag is enabled
+      const featureFlags = await getFeatureFlags({ teamId });
+      const dataroomIndexEnabled = featureFlags.dataroomIndex;
+
       const lastUpdatedAt = link.dataroom.documents.reduce((max, doc) => {
         return Math.max(
           max,
@@ -209,6 +214,7 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
           logoOnAccessForm:
             teamId === "cm7nlkrhm0000qgh0nvyrrywr" ||
             teamId === "clup33by90000oewh4rfvp2eg",
+          dataroomIndexEnabled,
         },
         revalidate: 10,
       };
@@ -234,6 +240,7 @@ export default function ViewPage({
   useAdvancedExcelViewer,
   useCustomAccessForm,
   logoOnAccessForm,
+  dataroomIndexEnabled,
   error,
 }: {
   linkData: DocumentLinkData | DataroomLinkData;
@@ -254,6 +261,7 @@ export default function ViewPage({
   useAdvancedExcelViewer: boolean;
   useCustomAccessForm: boolean;
   logoOnAccessForm: boolean;
+  dataroomIndexEnabled?: boolean;
   error?: boolean;
 }) {
   const router = useRouter();
@@ -459,6 +467,7 @@ export default function ViewPage({
           previewToken={previewToken}
           preview={!!preview}
           logoOnAccessForm={logoOnAccessForm}
+          dataroomIndexEnabled={dataroomIndexEnabled}
         />
       </>
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces index-aware display names across datarooms, affecting documents, folders, breadcrumbs, and folder trees.
  - Behavior is feature-flagged; when disabled, naming remains unchanged.
  - Consistent experience on direct link and custom domain view pages.

- Chores
  - Adds per-team feature flag plumbing to enable staged rollout of index-aware naming across the viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->