### PR TITLE
Add slack connection banner to sidebar

### DIFF
--- a/app/api/integrations/slack/oauth/callback/route.ts
+++ b/app/api/integrations/slack/oauth/callback/route.ts
@@ -111,5 +111,5 @@ export const GET = async (req: Request) => {
     return NextResponse.json({ error: e.message }, { status: 500 });
   }
 
-  redirect(`/settings/slack`);
+  redirect(`/settings/slack?success=true`);
 };

--- a/components/billing/slack-banner.tsx
+++ b/components/billing/slack-banner.tsx
@@ -1,0 +1,60 @@
+import { Dispatch, SetStateAction } from "react";
+
+import { useRouter } from "next/router";
+import Cookies from "js-cookie";
+import { usePlausible } from "next-plausible";
+
+import X from "@/components/shared/icons/x";
+import { SlackIcon } from "@/components/shared/icons/slack-icon";
+import { Button } from "@/components/ui/button";
+
+export default function SlackBanner({
+  setShowSlackBanner,
+}: {
+  setShowSlackBanner: Dispatch<SetStateAction<boolean | null>>;
+}) {
+  const router = useRouter();
+  const plausible = usePlausible();
+
+  const handleHideBanner = () => {
+    setShowSlackBanner(false);
+    plausible("clickedHideSlackBanner");
+    Cookies.set("hideSlackBanner", "slack-banner", {
+      expires: 30, // Hide for 30 days
+    });
+  };
+
+  const handleConnectSlack = () => {
+    plausible("clickedSlackBanner");
+    router.push("/settings/slack");
+  };
+
+  return (
+    <aside className="relative mb-2 flex w-full flex-col justify-center rounded-lg border border-gray-700 bg-background p-4 text-foreground">
+      <button
+        type="button"
+        onClick={handleHideBanner}
+        className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+      >
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </button>
+      <div className="flex items-center space-x-2">
+        <SlackIcon className="h-5 w-5" />
+        <span className="text-sm font-bold">Connect Slack</span>
+      </div>
+      <p className="my-4 text-sm">
+        Get notified in Slack when documents are viewed, downloaded, or accessed.
+      </p>
+      <div className="flex">
+        <Button
+          type="button"
+          className="grow"
+          onClick={handleConnectSlack}
+        >
+          Set up Slack
+        </Button>
+      </div>
+    </aside>
+  );
+}

--- a/components/sidebar/app-sidebar.tsx
+++ b/components/sidebar/app-sidebar.tsx
@@ -22,6 +22,7 @@ import {
 
 import { usePlan } from "@/lib/swr/use-billing";
 import useLimits from "@/lib/swr/use-limits";
+import { useSlackIntegration } from "@/lib/swr/use-slack-integration";
 import { nFormatter } from "@/lib/utils";
 
 import { NavMain } from "@/components/sidebar/nav-main";
@@ -38,6 +39,7 @@ import {
 
 import ProAnnualBanner from "../billing/pro-annual-banner";
 import ProBanner from "../billing/pro-banner";
+import SlackBanner from "../billing/slack-banner";
 import { Progress } from "../ui/progress";
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
@@ -46,6 +48,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const [showProAnnualBanner, setShowProAnnualBanner] = useState<
     boolean | null
   >(null);
+  const [showSlackBanner, setShowSlackBanner] = useState<boolean | null>(null);
   const { currentTeam, teams, setCurrentTeam, isLoading }: TeamContextType =
     useTeam() || initialState;
   const {
@@ -63,6 +66,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const linksLimit = limits?.links;
   const documentsLimit = limits?.documents;
 
+  // Check Slack integration status
+  const { integration: slackIntegration } = useSlackIntegration({
+    enabled: !!currentTeam?.id,
+  });
+
   useEffect(() => {
     if (Cookies.get("hideProBanner") !== "pro-banner") {
       setShowProBanner(true);
@@ -73,6 +81,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       setShowProAnnualBanner(true);
     } else {
       setShowProAnnualBanner(false);
+    }
+    if (Cookies.get("hideSlackBanner") !== "slack-banner") {
+      setShowSlackBanner(true);
+    } else {
+      setShowSlackBanner(false);
     }
   }, []);
 
@@ -215,6 +228,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarMenu className="group-data-[collapsible=icon]:hidden">
           <SidebarMenuItem>
             <div>
+              {/*
+               * Show Slack banner to all users if they haven't dismissed it and don't have Slack connected
+               */}
+              {!slackIntegration && showSlackBanner ? (
+                <SlackBanner setShowSlackBanner={setShowSlackBanner} />
+              ) : null}
               {/*
                * if user is free and showProBanner is true show pro banner
                */}

--- a/components/sidebar/app-sidebar.tsx
+++ b/components/sidebar/app-sidebar.tsx
@@ -11,7 +11,6 @@ import { PlanEnum } from "@/ee/stripe/constants";
 import Cookies from "js-cookie";
 import {
   BrushIcon,
-  CircleUserRound,
   CogIcon,
   ContactIcon,
   FolderIcon,
@@ -39,8 +38,8 @@ import {
 
 import ProAnnualBanner from "../billing/pro-annual-banner";
 import ProBanner from "../billing/pro-banner";
-import SlackBanner from "../billing/slack-banner";
 import { Progress } from "../ui/progress";
+import SlackBanner from "./banners/slack-banner";
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const router = useRouter();

--- a/components/sidebar/banners/slack-banner.tsx
+++ b/components/sidebar/banners/slack-banner.tsx
@@ -1,11 +1,14 @@
+import { useRouter } from "next/router";
+
 import { Dispatch, SetStateAction } from "react";
 
-import { useRouter } from "next/router";
 import Cookies from "js-cookie";
 import { usePlausible } from "next-plausible";
 
-import X from "@/components/shared/icons/x";
+import { useAnalytics } from "@/lib/analytics";
+
 import { SlackIcon } from "@/components/shared/icons/slack-icon";
+import X from "@/components/shared/icons/x";
 import { Button } from "@/components/ui/button";
 
 export default function SlackBanner({
@@ -15,6 +18,7 @@ export default function SlackBanner({
 }) {
   const router = useRouter();
   const plausible = usePlausible();
+  const analytics = useAnalytics();
 
   const handleHideBanner = () => {
     setShowSlackBanner(false);
@@ -26,6 +30,10 @@ export default function SlackBanner({
 
   const handleConnectSlack = () => {
     plausible("clickedSlackBanner");
+    analytics.capture("Slack Connect Button Clicked", {
+      source: "slack_banner",
+      location: "sidebar",
+    });
     router.push("/settings/slack");
   };
 
@@ -43,12 +51,11 @@ export default function SlackBanner({
         <SlackIcon className="h-5 w-5" />
         <span className="text-sm font-bold">Connect Slack</span>
       </div>
-      <p className="my-4 text-sm">
-        Get notified in Slack when documents are viewed, downloaded, or accessed.
-      </p>
+      <p className="my-4 text-sm">Get visit notifications in Slack channel.</p>
       <div className="flex">
         <Button
           type="button"
+          variant="outline"
           className="grow"
           onClick={handleConnectSlack}
         >


### PR DESCRIPTION
Add a dismissible Slack connection banner to the sidebar to encourage users to integrate Slack for notifications.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1757971691206239?thread_ts=1757971691.206239&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-96603387-7596-4940-b240-8ae11fc12f17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96603387-7596-4940-b240-8ae11fc12f17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dismissible Slack setup banner in the sidebar, shown when Slack isn’t connected. Dismissal hides it for 30 days.
  * Banner includes a “Set up Slack” button that takes you to Slack settings to connect.
  * Sidebar now checks Slack integration status to control banner visibility.
  * After connecting Slack, you’re redirected to the settings page with a success indicator for clearer confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->