### PR TITLE
correct dark mode color styling

### DIFF
--- a/ee/features/conversations/components/dashboard/edit-faq-modal.tsx
+++ b/ee/features/conversations/components/dashboard/edit-faq-modal.tsx
@@ -220,7 +220,7 @@ export function EditFAQModal({
                     handleInputChange("editedQuestion", e.target.value)
                   }
                 />
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-muted-foreground">
                   You can edit the question to make it clearer for visitors.
                 </p>
               </div>

--- a/ee/features/conversations/components/dashboard/publish-faq-modal.tsx
+++ b/ee/features/conversations/components/dashboard/publish-faq-modal.tsx
@@ -295,7 +295,7 @@ export function PublishFAQModal({
                     handleInputChange("editedQuestion", e.target.value)
                   }
                 />
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-muted-foreground">
                   You can edit the question to make it clearer for other
                   visitors.
                 </p>

--- a/ee/features/conversations/components/viewer/conversation-view-sidebar.tsx
+++ b/ee/features/conversations/components/viewer/conversation-view-sidebar.tsx
@@ -342,7 +342,7 @@ export function ConversationViewSidebar({
                           type="text"
                           value={newMessage}
                           onChange={(e) => setNewMessage(e.target.value)}
-                          className="flex-1 rounded-md border border-input px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                           placeholder="Type your message..."
                         />
                         <Button type="submit" disabled={!newMessage.trim()}>
@@ -383,7 +383,7 @@ export function ConversationViewSidebar({
                           value={newMessage}
                           onChange={(e) => setNewMessage(e.target.value)}
                           placeholder="Type your question..."
-                          className="min-h-[100px] w-full rounded-md border border-input px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          className="min-h-[100px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                           required
                         />
                       </div>

--- a/ee/features/conversations/components/viewer/faq-section.tsx
+++ b/ee/features/conversations/components/viewer/faq-section.tsx
@@ -208,7 +208,7 @@ export function FAQSection({
                         <span className="flex-shrink-0 rounded bg-secondary px-1.5 py-0.5 text-xs font-medium text-secondary-foreground">
                           Q
                         </span>
-                        <div className="line-clamp-2 min-w-0 flex-1 text-left text-sm font-medium text-gray-900">
+                        <div className="line-clamp-2 min-w-0 flex-1 text-left text-sm font-medium text-foreground">
                           {faq.editedQuestion}
                         </div>
                       </div>
@@ -220,7 +220,7 @@ export function FAQSection({
                           <span className="flex-shrink-0 rounded bg-primary/80 px-1.5 py-0.5 text-xs font-medium text-primary-foreground">
                             A
                           </span>
-                          <p className="whitespace-pre-wrap text-sm font-medium text-gray-700">
+                          <p className="whitespace-pre-wrap text-sm font-medium text-muted-foreground">
                             {faq.answer}
                           </p>
                         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated helper text styling under “Question” fields in FAQ modals for clearer, theme-consistent appearance.
  * Adjusted new message input and “New Question” textarea to use background and foreground theme colors for better readability in different themes.
  * Refined FAQ section colors: “Q” label now uses standard foreground color; answer text uses muted foreground for improved contrast hierarchy.
  * Overall visual consistency improved across conversation viewer and FAQ flows without changing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->