### PR TITLE
Add spacing between logo and home button

### DIFF
--- a/components/view/nav.tsx
+++ b/components/view/nav.tsx
@@ -246,7 +246,7 @@ export default function Nav({
               )}
             </div>
             {isDataroom ? (
-              <Breadcrumb>
+              <Breadcrumb className="ml-6">
                 <BreadcrumbList>
                   <BreadcrumbItem>
                     <BreadcrumbLink


### PR DESCRIPTION
Add horizontal padding between the logo and the "Home" button in the dataroom navbar.

This improves the visual separation and overall layout of the dataroom navbar.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1758048961993969?thread_ts=1758048961.993969&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-6c49157e-33c1-460d-90ab-c6289794b272">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c49157e-33c1-460d-90ab-c6289794b272">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted breadcrumb spacing in data room views by adding a left margin, improving visual alignment and readability.
  * Applies only to the standard breadcrumb variant used in data room pages; Notion-style breadcrumbs are unchanged.
  * No impact on navigation behavior or interactions; links and structure remain the same.
  * Users may notice a subtle rightward shift of the breadcrumb for a cleaner, more consistent header layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->