### PR TITLE
fix: email footer

### DIFF
--- a/components/emails/shared/footer.tsx
+++ b/components/emails/shared/footer.tsx
@@ -2,7 +2,7 @@ import { Hr, Section, Text } from "@react-email/components";
 
 export const Footer = ({
   withAddress = false,
-  footerText = "If you have any feedback or questions about this email, simply reply to it. I&apos;d love to hear from you!",
+  footerText = "If you have any feedback or questions about this email, simply reply to it. I'd love to hear from you!",
 }: {
   withAddress?: boolean;
   footerText?: string | React.ReactNode;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected apostrophe rendering in the email footer text to display a proper apostrophe instead of an HTML entity. Users will now see a clean, readable message in the footer across emails, improving clarity and polish without altering functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->