### PR TITLE
Manage sidebar visibility on signup and dataroom

### DIFF
--- a/components/layouts/app.tsx
+++ b/components/layouts/app.tsx
@@ -1,4 +1,7 @@
+import React, { useEffect, useState } from "react";
 import Cookies from "js-cookie";
+import { useRouter } from "next/router";
+import { useSession } from "next-auth/react";
 
 import { AppBreadcrumb } from "@/components/layouts/breadcrumb";
 import TrialBanner from "@/components/layouts/trial-banner";
@@ -10,14 +13,66 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
+import { CustomUser } from "@/lib/types";
 
 import { BlockingModal } from "./blocking-modal";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
-  const isSidebarOpen = Cookies.get(SIDEBAR_COOKIE_NAME) === "true";
+  const router = useRouter();
+  const { data: session } = useSession();
+  const [sidebarOpen, setSidebarOpen] = useState<boolean | null>(null);
+  const [userHasToggledOnDataroom, setUserHasToggledOnDataroom] = useState(false);
+  
+  // Check if user is new (created within last 10 seconds, same logic as middleware)
+  const isNewUser = session?.user && (session.user as CustomUser).createdAt &&
+    new Date((session.user as CustomUser).createdAt!).getTime() > Date.now() - 10000;
+  
+  // Check if current page is a dataroom page
+  const isDataroomPage = router.pathname.startsWith('/datarooms/[id]');
+  
+  useEffect(() => {
+    // Reset user toggle state when navigating away from dataroom
+    if (!isDataroomPage) {
+      setUserHasToggledOnDataroom(false);
+    }
+  }, [isDataroomPage]);
+  
+  useEffect(() => {
+    // Get current cookie value
+    const cookieValue = Cookies.get(SIDEBAR_COOKIE_NAME);
+    
+    if (isNewUser) {
+      // For new users, always start with sidebar open and update cookie
+      setSidebarOpen(true);
+      const maxAge = 60 * 60 * 24 * 7;
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=true; path=/; max-age=${maxAge}`;
+    } else if (isDataroomPage && !userHasToggledOnDataroom) {
+      // For dataroom pages, close the sidebar initially but allow user to override
+      setSidebarOpen(false);
+    } else {
+      // For all other cases, use default behavior (let SidebarProvider handle it)
+      setSidebarOpen(null);
+    }
+  }, [isNewUser, isDataroomPage, userHasToggledOnDataroom]);
+
+  // Use controlled mode when we need to override the sidebar state
+  const shouldUseControlledMode = (isNewUser || (isDataroomPage && !userHasToggledOnDataroom));
+
+  const handleSidebarChange = (open: boolean) => {
+    setSidebarOpen(open);
+    // If user manually toggles on dataroom page, remember that
+    if (isDataroomPage) {
+      setUserHasToggledOnDataroom(true);
+    }
+  };
 
   return (
-    <SidebarProvider defaultOpen={isSidebarOpen}>
+    <SidebarProvider 
+      {...(shouldUseControlledMode ? { 
+        open: sidebarOpen!, 
+        onOpenChange: handleSidebarChange 
+      } : {})}
+    >
       <div className="flex flex-1 flex-col gap-x-1 bg-gray-50 dark:bg-black md:flex-row">
         <AppSidebar />
         <SidebarInset className="ring-1 ring-gray-200 dark:ring-gray-800">


### PR DESCRIPTION
Adjust sidebar default state for new users and dataroom pages, while preserving user overrides.

The sidebar is now initially open for new users (detected within 10 seconds of creation) and automatically closes when navigating to any dataroom page. For dataroom pages, if a user manually toggles the sidebar, their preference is respected for that session, overriding the automatic close behavior. This integrates with the existing `SidebarProvider` by using its controlled mode for these specific scenarios.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1758311833262079?thread_ts=1758311833.262079&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-500bd3ce-518e-4f1d-8e04-62b0b7b11aa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-500bd3ce-518e-4f1d-8e04-62b0b7b11aa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

