### PR TITLE
feat: add revalidation for error props

### DIFF
--- a/pages/view/[linkId]/d/[documentId].tsx
+++ b/pages/view/[linkId]/d/[documentId].tsx
@@ -269,7 +269,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     };
   } catch (error) {
     console.error("Fetching error:", error);
-    return { notFound: true };
+    return { props: { error: true }, revalidate: 30 };
   }
 }
 

--- a/pages/view/domains/[domain]/[slug]/d/[documentId].tsx
+++ b/pages/view/domains/[domain]/[slug]/d/[documentId].tsx
@@ -288,7 +288,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     };
   } catch (error) {
     console.error("Fetching error:", error);
-    return { notFound: true };
+    return { props: { error: true }, revalidate: 30 };
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Document view pages now display a clear error state instead of a 404 when data can’t be fetched.
  * Pages automatically attempt to recover with background revalidation (up to ~30 seconds), reducing transient failures.
  * Improves reliability for both direct link and domain-based document URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->