### PR TITLE
Stop trial expiration emails for paying users

### DIFF
--- a/pages/api/teams/[teamId]/datarooms/trial.ts
+++ b/pages/api/teams/[teamId]/datarooms/trial.ts
@@ -120,7 +120,7 @@ export default async function handle(
       );
       waitUntil(
         sendDataroomTrial24hReminderEmailTask.trigger(
-          { to: email!, name: fullName.split(" ")[0] },
+          { to: email!, name: fullName.split(" ")[0], teamId },
           { delay: "6d" },
         ),
       );


### PR DESCRIPTION
Prevent trial expiry emails from being sent to users who have already purchased a subscription by adding a plan check to the reminder task.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1758775689654869?thread_ts=1758775689.654869&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-199bfa45-8839-4cc2-86f1-fa8612191af4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-199bfa45-8839-4cc2-86f1-fa8612191af4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 24-hour dataroom trial reminder emails are now sent only to eligible trial teams, preventing unnecessary reminders for non-trial plans.
  - Improved reliability by validating the team before sending reminders.

- Chores
  - Updated internal email task to include the team identifier for more accurate targeting (no user-facing changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->