### PR TITLE
feat: add privacy line

### DIFF
--- a/components/view/access-form/email-section.tsx
+++ b/components/view/access-form/email-section.tsx
@@ -1,7 +1,6 @@
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 
 import { Brand, DataroomBrand } from "@prisma/client";
-import { ArrowUpRightIcon } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
 
 import { cn } from "@/lib/utils";
@@ -145,19 +144,8 @@ export default function EmailSection({
       )}
       <p className="text-sm text-gray-500">
         {useCustomAccessForm
-          ? "This data will be shared with the content provider. "
-          : "This data will be shared with the sender. "}
-        Learn more about how we use and protect your data in our{" "}
-        <a
-          href={`${process.env.NEXT_PUBLIC_MARKETING_URL}/privacy`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center text-gray-500 hover:text-gray-600"
-        >
-          <span>Privacy Policy</span>
-          <ArrowUpRightIcon className="h-4 w-4 text-gray-500" />
-        </a>
-        .
+          ? "This data will be shared with the content provider."
+          : "This data will be shared with the sender."}
       </p>
     </div>
   );

--- a/components/view/access-form/index.tsx
+++ b/components/view/access-form/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { Brand, CustomField, DataroomBrand } from "@prisma/client";
+import { ArrowUpRightIcon } from "lucide-react";
 
 import { determineTextColor } from "@/lib/utils/determine-text-color";
 
@@ -193,16 +194,29 @@ export default function AccessForm({
         </div>
       </div>
       {!useCustomAccessForm ? (
-        <div className="flex justify-center">
+        <div className="flex flex-col items-center gap-0.5">
           <p className="text-center text-sm tracking-tight text-gray-500">
             This document is securely shared with you using{" "}
             <a
-              href="https://www.papermark.com"
+              href="https://www.papermark.com/home"
               target="_blank"
               rel="noopener noreferrer"
-              className="font-semibold"
+              className="font-medium hover:text-gray-600"
             >
               Papermark
+            </a>
+            .
+          </p>
+          <p className="text-center text-sm text-gray-500">
+            See how we protect your data in our{" "}
+            <a
+              href={`${process.env.NEXT_PUBLIC_MARKETING_URL}/privacy`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-0.5 hover:text-gray-600"
+            >
+              <span>Privacy Policy</span>
+              <ArrowUpRightIcon className="h-3 w-3" />
             </a>
           </p>
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added a Privacy Policy link with an external-arrow icon in the access form footer, directing to the marketing privacy page.

* Style
  * Updated the access form footer to a vertical layout with improved spacing for readability.
  * Refined Papermark link styling (medium weight with hover state) and added punctuation for clarity.
  * Updated the Papermark link destination to papermark.com/home.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->