### PR TITLE
Prevent duplicate folders in all documents

### DIFF
--- a/lib/api/documents/process-document.ts
+++ b/lib/api/documents/process-document.ts
@@ -72,17 +72,19 @@ export const processDocument = async ({
     }
   }
 
-  const folder = await prisma.folder.findUnique({
-    where: {
-      teamId_path: {
-        teamId,
-        path: "/" + folderPathName,
-      },
-    },
-    select: {
-      id: true,
-    },
-  });
+  const folder = folderPathName
+    ? await prisma.folder.findUnique({
+        where: {
+          teamId_path: {
+            teamId,
+            path: "/" + folderPathName,
+          },
+        },
+        select: {
+          id: true,
+        },
+      })
+    : null;
 
   // determine if the document is download only
   const isDownloadOnly =


### PR DESCRIPTION
Remove the creation of folders in the "All Documents" section when uploading folders directly to a data room.

Previously, uploading folders to a data room would duplicate the folder structure in the "All Documents" section, leading to clutter. This change ensures that only the documents themselves are added to "All Documents" (at the root level), while the folder structure is maintained exclusively within the data room. Regular document and folder uploads outside of a data room context remain unaffected.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1759825067033319?thread_ts=1759825067.033319&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-3a7a47e9-a6f9-4e83-827b-5364a2894e23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a7a47e9-a6f9-4e83-827b-5364a2894e23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

