### PR TITLE
Investigate login verification loop issue

### DIFF
--- a/app/(auth)/verify/page.tsx
+++ b/app/(auth)/verify/page.tsx
@@ -57,7 +57,8 @@ export default function VerifyPage({
   const isValidVerificationUrl = (url: string, checksum: string): boolean => {
     try {
       const urlObj = new URL(url);
-      if (urlObj.origin !== process.env.NEXTAUTH_URL) return false;
+      const expectedOrigin = new URL(process.env.NEXTAUTH_URL!).origin;
+      if (urlObj.origin !== expectedOrigin) return false;
       const expectedChecksum = generateChecksum(url);
       return checksum === expectedChecksum;
     } catch {


### PR DESCRIPTION
Normalize URL origins in `isValidVerificationUrl` to fix a login verification loop.

The previous comparison `urlObj.origin !== process.env.NEXTAUTH_URL` failed when `process.env.NEXTAUTH_URL` included a trailing slash, as `urlObj.origin` never has one. This mismatch caused the verification to fail and users to get stuck in a login loop. The fix ensures both URLs are normalized to their origin before comparison.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1760441354006889?thread_ts=1760441354.006889&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-e209bf1e-1ad4-4049-9772-b7d9ab9be553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e209bf1e-1ad4-4049-9772-b7d9ab9be553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

