### PR TITLE
Add banner toggle to presets

### DIFF
--- a/components/links/link-sheet/index.tsx
+++ b/components/links/link-sheet/index.tsx
@@ -265,6 +265,7 @@ export default function LinkSheet({
         enableScreenshotProtection:
           preset.enableScreenshotProtection || prev.enableScreenshotProtection,
         enableNotification: !!preset.enableNotification,
+        showBanner: preset.showBanner ?? prev.showBanner,
       };
     });
 

--- a/ee/features/permissions/components/dataroom-link-sheet.tsx
+++ b/ee/features/permissions/components/dataroom-link-sheet.tsx
@@ -217,6 +217,7 @@ export function DataroomLinkSheet({
         enableScreenshotProtection:
           preset.enableScreenshotProtection || prev.enableScreenshotProtection,
         enableNotification: !!preset.enableNotification,
+        showBanner: preset.showBanner ?? prev.showBanner,
       };
     });
 

--- a/lib/zod/schemas/presets.ts
+++ b/lib/zod/schemas/presets.ts
@@ -61,6 +61,9 @@ export const presetDataSchema = z.object({
   // Agreement
   enableAgreement: z.boolean().optional(),
   agreementId: z.string().nullable().optional(),
+
+  // Banner
+  showBanner: z.boolean().optional(),
 });
 
 export type PresetDataSchema = z.infer<typeof presetDataSchema>;

--- a/pages/api/webhooks/services/[...path]/index.ts
+++ b/pages/api/webhooks/services/[...path]/index.ts
@@ -488,7 +488,7 @@ async function handleDocumentCreate(
         enableNotification: link.enableNotification,
         enableFeedback: link.enableFeedback,
         enableScreenshotProtection: link.enableScreenshotProtection,
-        showBanner: link.showBanner,
+        showBanner: link.showBanner ?? preset?.showBanner ?? false,
         audienceType: link.audienceType,
         groupId: isGroupAudience ? link.groupId : null,
         // For group links, ignore allow/deny lists from presets as access is controlled by group membership
@@ -700,7 +700,7 @@ async function handleLinkCreate(
         enableNotification: link.enableNotification,
         enableFeedback: link.enableFeedback,
         enableScreenshotProtection: link.enableScreenshotProtection,
-        showBanner: link.showBanner,
+        showBanner: link.showBanner ?? preset?.showBanner ?? false,
         audienceType: link.audienceType,
         groupId: isGroupAudience ? link.groupId : null,
         // For group links, ignore allow/deny lists from presets as access is controlled by group membership
@@ -877,7 +877,7 @@ async function handleDataroomCreate(
           enableNotification: link.enableNotification,
           enableFeedback: link.enableFeedback,
           enableScreenshotProtection: link.enableScreenshotProtection,
-          showBanner: link.showBanner,
+          showBanner: link.showBanner ?? preset?.showBanner ?? false,
           audienceType: link.audienceType,
           groupId: isGroupAudience ? link.groupId : null,
           allowList: link.allowList || preset?.allowList,

--- a/pages/settings/presets/[id].tsx
+++ b/pages/settings/presets/[id].tsx
@@ -31,6 +31,7 @@ import ExpirationInSection from "@/components/links/link-sheet/expirationIn-sect
 import { LinkUpgradeOptions } from "@/components/links/link-sheet/link-options";
 import OGSection from "@/components/links/link-sheet/og-section";
 import PasswordSection from "@/components/links/link-sheet/password-section";
+import { ProBannerSection } from "@/components/links/link-sheet/pro-banner-section";
 import ScreenshotProtectionSection from "@/components/links/link-sheet/screenshot-protection-section";
 import WatermarkSection from "@/components/links/link-sheet/watermark-section";
 import Preview from "@/components/settings/og-preview";
@@ -138,6 +139,7 @@ export default function EditPreset() {
         enableCustomFields: customFields.length > 0,
         customFields: customFields,
         enableNotification: preset.enableNotification ?? false,
+        showBanner: preset.showBanner ?? false,
       });
     }
   }, [preset]);
@@ -188,6 +190,7 @@ export default function EditPreset() {
           enableCustomFields: data.enableCustomFields,
           customFields: data.customFields,
           enableNotification: data.enableNotification,
+          showBanner: data.showBanner,
         }),
       });
 
@@ -474,6 +477,22 @@ export default function EditPreset() {
                   }
                   handleUpgradeStateChange={handleUpgradeStateChange}
                   presets={null}
+                />
+              </div>
+
+              <div className="rounded-lg border p-6">
+                <h3 className="mb-4 text-lg font-medium">Branding</h3>
+                <ProBannerSection
+                  data={data as any}
+                  setData={setData as any}
+                  isAllowed={
+                    isTrial ||
+                    (isPro && allowAdvancedLinkControls) ||
+                    isBusiness ||
+                    isDatarooms ||
+                    isDataroomsPlus
+                  }
+                  handleUpgradeStateChange={handleUpgradeStateChange}
                 />
               </div>
             </div>

--- a/pages/settings/presets/new.tsx
+++ b/pages/settings/presets/new.tsx
@@ -32,6 +32,7 @@ import ExpirationInSection from "@/components/links/link-sheet/expirationIn-sect
 import { LinkUpgradeOptions } from "@/components/links/link-sheet/link-options";
 import OGSection from "@/components/links/link-sheet/og-section";
 import PasswordSection from "@/components/links/link-sheet/password-section";
+import { ProBannerSection } from "@/components/links/link-sheet/pro-banner-section";
 import ScreenshotProtectionSection from "@/components/links/link-sheet/screenshot-protection-section";
 import WatermarkSection from "@/components/links/link-sheet/watermark-section";
 import Preview from "@/components/settings/og-preview";
@@ -137,6 +138,7 @@ export default function NewPreset() {
             : false,
           customFields: data.customFields,
           enableNotification: data.enableNotification,
+          showBanner: data.showBanner,
         }),
       });
 
@@ -311,6 +313,22 @@ export default function NewPreset() {
                   }
                   handleUpgradeStateChange={handleUpgradeStateChange}
                   presets={null}
+                />
+              </div>
+
+              <div className="rounded-lg border p-6">
+                <h3 className="mb-4 text-lg font-medium">Branding</h3>
+                <ProBannerSection
+                  data={data}
+                  setData={setData}
+                  isAllowed={
+                    isTrial ||
+                    (isPro && allowAdvancedLinkControls) ||
+                    isBusiness ||
+                    isDatarooms ||
+                    isDataroomsPlus
+                  }
+                  handleUpgradeStateChange={handleUpgradeStateChange}
                 />
               </div>
             </div>

--- a/prisma/migrations/20251017000000_add_show_banner_to_presets/migration.sql
+++ b/prisma/migrations/20251017000000_add_show_banner_to_presets/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "LinkPreset" ADD COLUMN "showBanner" BOOLEAN DEFAULT false;

--- a/prisma/schema/link.prisma
+++ b/prisma/schema/link.prisma
@@ -125,6 +125,8 @@ model LinkPreset {
   enableCustomFields Boolean? @default(false)
   customFields       Json? //[{type: "SHORT_TEXT", identifier: "name", label: "Name", required: true}]
 
+  showBanner Boolean? @default(false) // Optional give user a option to show the "Powered by Papermark" banner
+
   isDefault Boolean @default(false)
 
   createdAt DateTime @default(now())


### PR DESCRIPTION
Add a toggle to presets to control the "Powered by Papermark" banner on documents.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1760715052198229?thread_ts=1760715052.198229&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-d3baf63b-34a2-403f-bf2e-683875738aa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d3baf63b-34a2-403f-bf2e-683875738aa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Branding configuration to presets. Users can now control banner display when creating or editing presets. Settings automatically apply to documents and dataroom links using these presets, with fallback to default behavior when not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->