### PR TITLE
Allow custom fields on data room subscription

### DIFF
--- a/components/links/link-sheet/custom-fields-panel/index.tsx
+++ b/components/links/link-sheet/custom-fields-panel/index.tsx
@@ -42,7 +42,7 @@ export default function CustomFieldsPanel({
   const { isDatarooms, isDataroomsPlus, isBusiness } = usePlan();
 
   const fieldLimit = useMemo(() => {
-    if (isDatarooms || isDataroomsPlus) return 3;
+    if (isDatarooms || isDataroomsPlus) return 5;
     if (isBusiness) return 1;
     return 0;
   }, [isDatarooms, isDataroomsPlus, isBusiness]);


### PR DESCRIPTION
Increase the custom field limit for Data Rooms and Data Rooms Plus subscriptions from 3 to 5.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1761142685931859?thread_ts=1761142685.931859&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-a065d0f6-ab6e-426f-8838-9e2c0d9ab6bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a065d0f6-ab6e-426f-8838-9e2c0d9ab6bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the custom fields creation limit to 5 for Data Rooms and Data Rooms Plus plans (previously 3). Users on these plans can now create more custom fields with updated messaging reflecting the new availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->