### PR TITLE
fix: inconsistent theme for save button

### DIFF
--- a/pages/branding.tsx
+++ b/pages/branding.tsx
@@ -543,7 +543,6 @@ export default function Branding() {
                     onClick={saveBranding}
                     loading={isLoading}
                     disabled={!!welcomeMessageError}
-                    className="bg-black text-white hover:bg-gray-800"
                   >
                     Save changes
                   </Button>

--- a/pages/datarooms/[id]/branding/index.tsx
+++ b/pages/datarooms/[id]/branding/index.tsx
@@ -708,7 +708,6 @@ export default function DataroomBrandPage() {
                 onClick={saveBranding}
                 loading={isLoading}
                 disabled={!!welcomeMessageError}
-                className="bg-black text-white hover:bg-gray-800"
               >
                 Save changes
               </Button>


### PR DESCRIPTION
The `Save Changes` button in the branding branding page is not visible properly in dark mode. It's updated the removing the class.

Previous:
<img width="417" height="980" alt="image" src="https://github.com/user-attachments/assets/80435129-21fd-496b-965a-cbe0899c2fab" />

After:
<img width="748" height="940" alt="image" src="https://github.com/user-attachments/assets/55cd8ccf-1c5c-42b7-b931-f6c1f5a347ad" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated Save button styling in branding settings pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->