### PR TITLE
Add presentation full screen button

### DIFF
--- a/components/view/nav.tsx
+++ b/components/view/nav.tsx
@@ -8,6 +8,7 @@ import {
   ArrowUpRight,
   BadgeInfoIcon,
   Download,
+  Maximize,
   MessageCircle,
   Slash,
   ZoomInIcon,
@@ -76,6 +77,7 @@ export default function Nav({
   hasWatermark,
   handleZoomIn,
   handleZoomOut,
+  handleFullscreen,
 }: {
   navData: TNavData;
   type?: "pdf" | "notion" | "sheet";
@@ -85,6 +87,7 @@ export default function Nav({
   hasWatermark?: boolean;
   handleZoomIn?: () => void;
   handleZoomOut?: () => void;
+  handleFullscreen?: () => void;
 }) {
   const router = useRouter();
   const asPath = router.asPath;
@@ -421,6 +424,28 @@ export default function Nav({
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
+
+                {handleFullscreen && (
+                  <TooltipProvider delayDuration={50}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          onClick={handleFullscreen}
+                          className="bg-gray-900 text-white hover:bg-gray-900/80"
+                          size="icon"
+                        >
+                          <Maximize className="h-5 w-5" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <span className="mr-2 text-xs">Fullscreen</span>
+                        <span className="ml-auto rounded-sm border bg-muted p-0.5 text-xs tracking-widest text-muted-foreground">
+                          F
+                        </span>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                )}
               </div>
             )}
 

--- a/components/view/viewer/image-viewer.tsx
+++ b/components/view/viewer/image-viewer.tsx
@@ -80,7 +80,18 @@ export default function ImageViewer({
     setScale((prev) => Math.max(prev - 0.25, 0.5)); // Min zoom 0.5x
   };
 
-  // Add keyboard shortcuts for zooming
+  // Add fullscreen handler
+  const handleFullscreen = () => {
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen().catch((err) => {
+        console.error("Error attempting to enable fullscreen:", err);
+      });
+    } else {
+      document.exitFullscreen();
+    }
+  };
+
+  // Add keyboard shortcuts for zooming and fullscreen
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.metaKey || e.ctrlKey) {
@@ -94,6 +105,9 @@ export default function ImageViewer({
           e.preventDefault();
           setScale(1);
         }
+      } else if (e.key === "f" || e.key === "F") {
+        e.preventDefault();
+        handleFullscreen();
       }
     };
 
@@ -285,6 +299,7 @@ export default function ImageViewer({
         hasWatermark={!!watermarkConfig}
         handleZoomIn={handleZoomIn}
         handleZoomOut={handleZoomOut}
+        handleFullscreen={handleFullscreen}
         navData={navData}
       />
       <div

--- a/components/view/viewer/pages-horizontal-viewer.tsx
+++ b/components/view/viewer/pages-horizontal-viewer.tsx
@@ -556,7 +556,18 @@ export default function PagesHorizontalViewer({
     setScale((prev) => Math.max(prev - 0.25, 0.5)); // Min zoom 0.5x
   };
 
-  // Add keyboard shortcuts for zooming
+  // Add fullscreen handler
+  const handleFullscreen = () => {
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen().catch((err) => {
+        console.error("Error attempting to enable fullscreen:", err);
+      });
+    } else {
+      document.exitFullscreen();
+    }
+  };
+
+  // Add keyboard shortcuts for zooming and fullscreen
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.metaKey || e.ctrlKey) {
@@ -570,6 +581,9 @@ export default function PagesHorizontalViewer({
           e.preventDefault();
           setScale(1);
         }
+      } else if (e.key === "f" || e.key === "F") {
+        e.preventDefault();
+        handleFullscreen();
       }
     };
 
@@ -602,6 +616,7 @@ export default function PagesHorizontalViewer({
         hasWatermark={!!watermarkConfig}
         handleZoomIn={handleZoomIn}
         handleZoomOut={handleZoomOut}
+        handleFullscreen={handleFullscreen}
         navData={navDataWithAnnotations}
       />
       <div

--- a/components/view/viewer/pages-vertical-viewer.tsx
+++ b/components/view/viewer/pages-vertical-viewer.tsx
@@ -728,7 +728,18 @@ export default function PagesVerticalViewer({
     setScale((prev) => Math.max(prev - 0.25, 0.5)); // Min zoom 0.5x
   };
 
-  // Add keyboard shortcuts for zooming
+  // Add fullscreen handler
+  const handleFullscreen = () => {
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen().catch((err) => {
+        console.error("Error attempting to enable fullscreen:", err);
+      });
+    } else {
+      document.exitFullscreen();
+    }
+  };
+
+  // Add keyboard shortcuts for zooming and fullscreen
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.metaKey || e.ctrlKey) {
@@ -742,6 +753,9 @@ export default function PagesVerticalViewer({
           e.preventDefault();
           setScale(1);
         }
+      } else if (e.key === "f" || e.key === "F") {
+        e.preventDefault();
+        handleFullscreen();
       }
     };
 
@@ -769,6 +783,7 @@ export default function PagesVerticalViewer({
         hasWatermark={watermarkConfig ? true : false}
         handleZoomIn={handleZoomIn}
         handleZoomOut={handleZoomOut}
+        handleFullscreen={handleFullscreen}
         navData={navDataWithAnnotations}
       />
       <div


### PR DESCRIPTION
Add a fullscreen button to the viewer navigation to allow users to view presentations in full screen.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1762371996192759?thread_ts=1762371996.192759&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-8f00b07b-68f1-4f5c-9574-e43af8d228b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f00b07b-68f1-4f5c-9574-e43af8d228b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added fullscreen viewing mode with convenient access through a navigation bar button
* F keyboard shortcut enables quick fullscreen toggling
* Fullscreen functionality available across all viewer modes with contextual tooltip guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->