### PR TITLE
feat: add viewerName if available

### DIFF
--- a/components/analytics/visitors-table.tsx
+++ b/components/analytics/visitors-table.tsx
@@ -51,6 +51,7 @@ interface Visitor {
   uniqueDocuments: number;
   verified: boolean;
   totalDuration: number;
+  viewerName?: string | null;
 }
 
 const columns: ColumnDef<Visitor>[] = [
@@ -63,13 +64,18 @@ const columns: ColumnDef<Visitor>[] = [
         <div className="min-w-0 flex-1">
           <div className="focus:outline-none">
             <p className="flex items-center gap-x-2 overflow-visible text-sm font-medium text-gray-800 dark:text-gray-200">
-              {row.original.email}{" "}
+              {row.original.viewerName || row.original.email}{" "}
               {row.original.verified && (
                 <BadgeTooltip content="Verified visitor">
                   <BadgeCheckIcon className="h-4 w-4 text-emerald-500 hover:text-emerald-600" />
                 </BadgeTooltip>
               )}
             </p>
+            {row.original.viewerName && row.original.email && (
+              <p className="text-xs text-muted-foreground/60">
+                {row.original.email}
+              </p>
+            )}
             <p className="text-sm text-muted-foreground">
               {row.original.uniqueDocuments} document
               {row.original.uniqueDocuments !== 1 ? "s" : ""} viewed

--- a/components/visitors/contacts-table.tsx
+++ b/components/visitors/contacts-table.tsx
@@ -39,6 +39,7 @@ type Viewer = {
   updatedAt: Date;
   totalVisits: number;
   lastViewed: Date | null;
+  viewerName?: string | null;
 };
 
 export function ContactsTable({
@@ -149,8 +150,13 @@ export function ContactsTable({
             <div className="min-w-0 flex-1">
               <div className="focus:outline-none">
                 <p className="flex items-center gap-x-2 overflow-visible text-sm font-medium text-gray-800 dark:text-gray-200">
-                  {row.original.email}
+                  {row.original.viewerName || row.original.email}
                 </p>
+                {row.original.viewerName && row.original.email && (
+                  <p className="text-xs text-muted-foreground/60">
+                    {row.original.email}
+                  </p>
+                )}
               </div>
             </div>
           </div>

--- a/components/visitors/dataroom-viewers.tsx
+++ b/components/visitors/dataroom-viewers.tsx
@@ -77,7 +77,7 @@ export default function DataroomViewersTable({
                               <p className="flex items-center gap-x-2 overflow-visible text-sm font-medium text-gray-800 dark:text-gray-200">
                                 {viewer.email ? (
                                   <>
-                                    {viewer.email}{" "}
+                                    {(viewer as any).viewerName || viewer.email}{" "}
                                     {viewer.verified && (
                                       <BadgeTooltip
                                         content="Verified visitor"
@@ -107,6 +107,11 @@ export default function DataroomViewersTable({
                                   "Anonymous"
                                 )}
                               </p>
+                              {(viewer as any).viewerName && viewer.email && (
+                                <p className="text-xs text-muted-foreground/60">
+                                  {viewer.email}
+                                </p>
+                              )}
                               <p className="text-xs text-muted-foreground/60 sm:text-sm">
                                 {/* {view.link.name ? view.link.name : view.linkId} */}
                               </p>

--- a/components/visitors/dataroom-visitors-table.tsx
+++ b/components/visitors/dataroom-visitors-table.tsx
@@ -103,7 +103,7 @@ export default function DataroomVisitorsTable({
                               <p className="flex items-center gap-x-2 overflow-visible text-sm font-medium text-gray-800 dark:text-gray-200">
                                 {view.viewerEmail ? (
                                   <>
-                                    {view.viewerEmail}{" "}
+                                    {view.viewerName || view.viewerEmail}{" "}
                                     {view.verified && (
                                       <BadgeTooltip
                                         content="Verified visitor"
@@ -141,6 +141,11 @@ export default function DataroomVisitorsTable({
                                   "Anonymous"
                                 )}
                               </p>
+                              {view.viewerName && view.viewerEmail && (
+                                <p className="text-xs text-muted-foreground/60">
+                                  {view.viewerEmail}
+                                </p>
+                              )}
                               <p className="text-xs text-muted-foreground/60 sm:text-sm">
                                 {view.link.name ? view.link.name : view.linkId}
                               </p>

--- a/components/visitors/visitors-table.tsx
+++ b/components/visitors/visitors-table.tsx
@@ -164,31 +164,38 @@ export default function VisitorsTable({
                       key={view.id}
                       className="group/row opacity-50 grayscale"
                     >
-                      {/* Name */}
-                      <TableCell>
-                        <div className="flex items-center overflow-visible sm:space-x-3">
-                          <VisitorAvatar
-                            viewerEmail={view.viewerEmail}
-                            isArchived
-                          />
-                          <div className="min-w-0 flex-1">
-                            <div className="focus:outline-none">
-                              <p className="flex items-center gap-x-2 overflow-visible text-sm font-medium text-gray-800 dark:text-gray-200">
-                                {view.viewerEmail ? (
-                                  <>{view.viewerEmail}</>
-                                ) : (
-                                  "Anonymous"
-                                )}
-                              </p>
-                              <p className="text-xs text-muted-foreground/60 sm:text-sm">
-                                {view.link && view.link.name
-                                  ? view.link.name
-                                  : view.linkId}
-                              </p>
+                          {/* Name */}
+                          <TableCell>
+                            <div className="flex items-center overflow-visible sm:space-x-3">
+                              <VisitorAvatar
+                                viewerEmail={view.viewerEmail}
+                                isArchived
+                              />
+                              <div className="min-w-0 flex-1">
+                                <div className="focus:outline-none">
+                                  <p className="flex items-center gap-x-2 overflow-visible text-sm font-medium text-gray-800 dark:text-gray-200">
+                                    {view.viewerEmail ? (
+                                      <>
+                                        {view.viewerName || view.viewerEmail}
+                                      </>
+                                    ) : (
+                                      "Anonymous"
+                                    )}
+                                  </p>
+                                  {view.viewerName && view.viewerEmail && (
+                                    <p className="text-xs text-muted-foreground/60">
+                                      {view.viewerEmail}
+                                    </p>
+                                  )}
+                                  <p className="text-xs text-muted-foreground/60 sm:text-sm">
+                                    {view.link && view.link.name
+                                      ? view.link.name
+                                      : view.linkId}
+                                  </p>
+                                </div>
+                              </div>
                             </div>
-                          </div>
-                        </div>
-                      </TableCell>
+                          </TableCell>
                       {/* Duration */}
                       <TableCell className="">
                         <div className="text-sm text-muted-foreground">
@@ -277,7 +284,7 @@ export default function VisitorsTable({
                                   <p className="flex items-center gap-x-2 overflow-visible text-sm font-medium text-gray-800 dark:text-gray-200">
                                     {view.viewerEmail ? (
                                       <>
-                                        {view.viewerEmail}{" "}
+                                        {view.viewerName || view.viewerEmail}{" "}
                                         {view.verified && (
                                           <BadgeTooltip
                                             content="Verified visitor"
@@ -336,6 +343,11 @@ export default function VisitorsTable({
                                       "Anonymous"
                                     )}
                                   </p>
+                                  {view.viewerName && view.viewerEmail && (
+                                    <p className="text-xs text-muted-foreground/60">
+                                      {view.viewerEmail}
+                                    </p>
+                                  )}
                                   <p className="text-xs text-muted-foreground/60 sm:text-sm">
                                     {view.link && view.link.name
                                       ? view.link.name

--- a/pages/api/analytics/index.ts
+++ b/pages/api/analytics/index.ts
@@ -479,6 +479,9 @@ export default async function handler(
               console.error("Error fetching Tinybird data:", error);
             }
 
+            // Get the name from the most recent view that has a name
+            const viewerName = viewer.views.find((v) => v.viewerName)?.viewerName;
+            
             return {
               email: viewer.email,
               viewerId: viewer.id,
@@ -487,6 +490,7 @@ export default async function handler(
               uniqueDocuments: uniqueDocuments.size,
               verified: viewer.verified,
               totalDuration,
+              viewerName: viewerName || null,
             };
           }),
         );

--- a/pages/api/teams/[teamId]/datarooms/[id]/viewers/index.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/viewers/index.ts
@@ -65,6 +65,12 @@ export default async function handle(
             orderBy: {
               viewedAt: "desc",
             },
+            select: {
+              id: true,
+              viewedAt: true,
+              downloadedAt: true,
+              viewerName: true,
+            },
           },
         },
       });
@@ -93,11 +99,15 @@ export default async function handle(
       });
 
       const returnViews = viewers.map((viewer) => {
+        // Get the name from the most recent view that has a name
+        const viewerName = viewer.views.find((v) => v.viewerName)?.viewerName;
+        
         return {
           ...viewer,
           dataroomName: dataroom?.name,
           lastViewedAt:
             viewer.views.length > 0 ? viewer.views[0].viewedAt : null,
+          viewerName: viewerName || null,
           internal: users.some((user) => user.email === viewer.email), // set internal to true if view.viewerEmail is in the users list
         };
       });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Visitor and viewer records now display names (when available) instead of showing email addresses only
- Email addresses appear as secondary information beneath visitor names
- Falls back to email address when visitor name data is unavailable
- Visitor name information now available in updated API responses

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->