### PR TITLE
feat: Allow custom email sender via `EMAIL_FROM` env var

### DIFF
--- a/lib/resend.ts
+++ b/lib/resend.ts
@@ -45,6 +45,7 @@ export const sendEmail = async ({
   const plainText = toPlainText(html);
 
   const fromAddress =
+    process.env.EMAIL_FROM ??
     from ??
     (marketing
       ? "Marc from Papermark <marc@ship.papermark.io>"


### PR DESCRIPTION
This PR introduces a new environment variable `EMAIL_FROM` to the `sendEmail` function.

**Changes:**
- Updated logic in `lib/resend.ts` to check `process.env.EMAIL_FROM` before falling back to the `from` argument or hardcoded defaults.

**Why:**
Previously, the sender email addresses were hardcoded to specific names (e.g., "Marc from Papermark"). This change allows:
1.  Self-hosted instances to set their own sender address without modifying source code.
2.  Easier configuration for different environments (staging vs. production).

**Configuration:**
To use this, add the following to your `.env` file:
```bash
EMAIL_FROM="Your Name <hello@yourdomain.com>"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved email configuration handling to ensure environment-based settings take appropriate precedence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->