### PR TITLE
fix

### DIFF
--- a/components/links/link-sheet/domain-section.tsx
+++ b/components/links/link-sheet/domain-section.tsx
@@ -41,7 +41,10 @@ export default function DomainSection({
 }) {
   const [isModalOpen, setModalOpen] = useState(false);
   const [isUpgradeModalOpen, setUpgradeModalOpen] = useState(false);
-  const [displayValue, setDisplayValue] = useState<string>("papermark.com");
+  // Initialize displayValue from data.domain when editing, otherwise "papermark.com"
+  const [displayValue, setDisplayValue] = useState<string>(
+    editLink && data.domain ? data.domain : "papermark.com",
+  );
   const teamInfo = useTeam();
   const { limits } = useLimits();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Domain field now correctly displays the current domain value when editing existing links, instead of defaulting to the standard domain for all edits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->