### PR TITLE
Preview eyeball click bug

### DIFF
--- a/components/documents/document-preview-button.tsx
+++ b/components/documents/document-preview-button.tsx
@@ -61,6 +61,11 @@ export function DocumentPreviewButton({
     setIsPreviewOpen(true);
   };
 
+  // Stop propagation on the container to prevent parent click handlers from firing
+  const handleContainerClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+  };
+
   const button = (
     <Button
       variant={variant}
@@ -93,14 +98,14 @@ export function DocumentPreviewButton({
   );
 
   return (
-    <>
+    <div onClick={handleContainerClick} onMouseDown={handleContainerClick}>
       {wrappedButton}
       <DocumentPreviewModal
         documentId={documentId}
         isOpen={isPreviewOpen}
         onClose={() => setIsPreviewOpen(false)}
       />
-    </>
+    </div>
   );
 }
 

--- a/components/links/preview-button.tsx
+++ b/components/links/preview-button.tsx
@@ -15,8 +15,18 @@ const PreviewButton = ({
   isProcessing: boolean;
   onPreview: (link: LinkWithViews) => void;
 }) => {
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    onPreview(link);
+  };
+
+  const handleContainerClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
   return (
-    <div className="relative">
+    <div className="relative" onClick={handleContainerClick} onMouseDown={handleContainerClick}>
       <ButtonTooltip
         content={isProcessing ? "Preparing preview" : "Preview link"}
       >
@@ -25,7 +35,7 @@ const PreviewButton = ({
             variant={"link"}
             size={"icon"}
             className="group h-7 w-8"
-            onClick={() => onPreview(link)}
+            onClick={handleClick}
             disabled={isProcessing}
           >
             <span className="sr-only">Preview link</span>


### PR DESCRIPTION
Consistently stop event propagation on preview buttons to prevent accidental document navigation.

The issue occurred because clicks on the preview button's interactive area sometimes propagated to parent elements, triggering document navigation instead of just opening the preview. This fix ensures that all clicks within the preview button's bounds are captured and do not propagate further, addressing both `onClick` and `onMouseDown` events to prevent interference with drag-and-drop systems.

---
Linear Issue: [PM-460](https://linear.app/papermark/issue/PM-460/clicking-the-preview-eyeball-sometimes-opens-the-document-instead)

<a href="https://cursor.com/background-agent?bcId=bc-b0a7ceb7-b988-446b-9455-f29d2aafb682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b0a7ceb7-b988-446b-9455-f29d2aafb682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event handling in preview components to ensure more reliable click interactions and prevent unintended event propagation that could interfere with other UI elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->