### PR TITLE
fix: stop pausing retroactively

### DIFF
--- a/ee/features/billing/cancellation/components/pause-subscription-modal.tsx
+++ b/ee/features/billing/cancellation/components/pause-subscription-modal.tsx
@@ -54,16 +54,14 @@ export function PauseSubscriptionModal({
         throw new Error("Failed to pause subscription");
       }
 
-      const pauseStartsAt = endsAt ? new Date(endsAt) : new Date();
-      const pauseEndsAt = new Date(pauseStartsAt);
-      pauseEndsAt.setDate(pauseStartsAt.getDate() + 90);
+      const data = await response.json();
 
-      // Track the pause event for analytics
+      // Track the pause event for analytics using actual dates from API
       analytics.capture("Subscription Paused", {
         teamId: currentTeamId,
         plan: plan,
-        pauseStartsAt: pauseStartsAt.toISOString(),
-        pauseEndsAt: pauseEndsAt.toISOString(),
+        pauseStartsAt: data.pauseStartsAt,
+        pauseEndsAt: data.pauseEndsAt,
         pauseDurationDays: 90,
       });
 
@@ -79,7 +77,10 @@ export function PauseSubscriptionModal({
     }
   };
 
-  const pauseStartsAt = endsAt ? new Date(endsAt) : new Date();
+  // Ensure pauseStartsAt is never in the past - pause should start at next billing cycle
+  const now = new Date();
+  const endsAtDate = endsAt ? new Date(endsAt) : now;
+  const pauseStartsAt = endsAtDate > now ? endsAtDate : now;
   const pauseEndsAt = new Date(pauseStartsAt);
   pauseEndsAt.setDate(pauseStartsAt.getDate() + 90);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed subscription pause timing to properly align with Stripe billing cycles instead of local calculations.
  * Resolved an issue where pause dates could be scheduled in the past.

* **New Features**
  * Added pause start and end dates to subscription pause responses for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->