### PR TITLE
Backend otp resend rate limit

### DIFF
--- a/app/api/views-dataroom/route.ts
+++ b/app/api/views-dataroom/route.ts
@@ -400,6 +400,21 @@ export async function POST(request: NextRequest) {
       if (link.emailAuthenticated && !code && !token && !dataroomVerified) {
         const ipAddressValue = ipAddress(request);
 
+        // Rate limit per email/link combination (1 per 30 seconds) to prevent OTP flooding
+        const { success: emailLimitSuccess } = await ratelimit(1, "30 s").limit(
+          `send-otp:${linkId}:${email}`,
+        );
+        if (!emailLimitSuccess) {
+          return NextResponse.json(
+            {
+              message:
+                "Please wait before requesting another code. Try again in 30 seconds.",
+            },
+            { status: 429 },
+          );
+        }
+
+        // Additional IP-based rate limit (10 per minute) to prevent abuse across different emails
         const { success } = await ratelimit(10, "1 m").limit(
           `send-otp:${ipAddressValue}`,
         );


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-1273ab08-57e5-4cec-adce-9301ea4f16eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1273ab08-57e5-4cec-adce-9301ea4f16eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented per-email rate limiting for OTP requests: 1 request per 30 seconds across verification flows.
  * Enforced per-IP rate limiting for OTP requests: 10 requests per minute, with appropriate error responses when limits are exceeded.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->