### PR TITLE
Data room internal name

### DIFF
--- a/components/datarooms/add-dataroom-modal.tsx
+++ b/components/datarooms/add-dataroom-modal.tsx
@@ -68,7 +68,6 @@ export function AddDataroomModal({
 }) {
   const router = useRouter();
   const [dataroomName, setDataroomName] = useState<string>("");
-  const [dataroomInternalName, setDataroomInternalName] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(false);
   const [open, setOpen] = useState<boolean>(openModal);
   const [activeTab, setActiveTab] = useState<string>("create");
@@ -300,10 +299,7 @@ export function AddDataroomModal({
             type: dataroomType,
             // Name will be taken from template
           }
-        : { 
-            name: dataroomName.trim(),
-            ...(dataroomInternalName.trim() && { internalName: dataroomInternalName.trim() }),
-          };
+        : { name: dataroomName.trim() };
 
       const response = await fetch(endpoint, {
         method: "POST",
@@ -366,7 +362,6 @@ export function AddDataroomModal({
     if (!open) {
       setOpen(false);
       setDataroomName("");
-      setDataroomInternalName("");
       setActiveTab("create");
       setDataroomType("");
       setAiDescription("");
@@ -661,24 +656,6 @@ export function AddDataroomModal({
                       value={dataroomName}
                       onChange={(e) => setDataroomName(e.target.value)}
                     />
-                    <p className="text-xs text-muted-foreground">
-                      This name is visible to everyone viewing the dataroom.
-                    </p>
-                  </div>
-                  <div className="space-y-1">
-                    <Label htmlFor="dataroom-internal-name-create">
-                      Internal Name{" "}
-                      <span className="text-xs text-muted-foreground font-normal">(optional)</span>
-                    </Label>
-                    <Input
-                      id="dataroom-internal-name-create"
-                      placeholder="Friends & Family Round"
-                      value={dataroomInternalName}
-                      onChange={(e) => setDataroomInternalName(e.target.value)}
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      A private name only visible to you. Useful for distinguishing multiple datarooms with the same public name.
-                    </p>
                   </div>
                   <Button type="submit" className="w-full" loading={loading}>
                     Add new dataroom

--- a/components/datarooms/add-dataroom-modal.tsx
+++ b/components/datarooms/add-dataroom-modal.tsx
@@ -68,6 +68,7 @@ export function AddDataroomModal({
 }) {
   const router = useRouter();
   const [dataroomName, setDataroomName] = useState<string>("");
+  const [dataroomInternalName, setDataroomInternalName] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(false);
   const [open, setOpen] = useState<boolean>(openModal);
   const [activeTab, setActiveTab] = useState<string>("create");
@@ -299,7 +300,10 @@ export function AddDataroomModal({
             type: dataroomType,
             // Name will be taken from template
           }
-        : { name: dataroomName.trim() };
+        : { 
+            name: dataroomName.trim(),
+            ...(dataroomInternalName.trim() && { internalName: dataroomInternalName.trim() }),
+          };
 
       const response = await fetch(endpoint, {
         method: "POST",
@@ -362,6 +366,7 @@ export function AddDataroomModal({
     if (!open) {
       setOpen(false);
       setDataroomName("");
+      setDataroomInternalName("");
       setActiveTab("create");
       setDataroomType("");
       setAiDescription("");
@@ -656,6 +661,24 @@ export function AddDataroomModal({
                       value={dataroomName}
                       onChange={(e) => setDataroomName(e.target.value)}
                     />
+                    <p className="text-xs text-muted-foreground">
+                      This name is visible to everyone viewing the dataroom.
+                    </p>
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="dataroom-internal-name-create">
+                      Internal Name{" "}
+                      <span className="text-xs text-muted-foreground font-normal">(optional)</span>
+                    </Label>
+                    <Input
+                      id="dataroom-internal-name-create"
+                      placeholder="Friends & Family Round"
+                      value={dataroomInternalName}
+                      onChange={(e) => setDataroomInternalName(e.target.value)}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      A private name only visible to you. Useful for distinguishing multiple datarooms with the same public name.
+                    </p>
                   </div>
                   <Button type="submit" className="w-full" loading={loading}>
                     Add new dataroom

--- a/components/datarooms/dataroom-card.tsx
+++ b/components/datarooms/dataroom-card.tsx
@@ -40,6 +40,7 @@ type DataroomTag = {
 type DataroomWithDetails = {
   id: string;
   name: string;
+  internalName?: string | null;
   _count: {
     documents: number;
     views: number;
@@ -87,7 +88,16 @@ export default function DataroomCard({ dataroom }: DataroomCardProps) {
       <Link href={`/datarooms/${dataroom.id}/documents`}>
         <CardHeader>
           <div className="flex items-start justify-between gap-2">
-            <CardTitle className="truncate text-lg">{dataroom.name}</CardTitle>
+            <div className="flex-1 min-w-0">
+              <CardTitle className="truncate text-lg">
+                {dataroom.internalName || dataroom.name}
+              </CardTitle>
+              {dataroom.internalName && (
+                <p className="truncate text-sm text-muted-foreground mt-0.5">
+                  {dataroom.name}
+                </p>
+              )}
+            </div>
             <div className="flex shrink-0 items-center gap-2">
               <TooltipProvider>
                 <Tooltip>

--- a/components/datarooms/dataroom-header.tsx
+++ b/components/datarooms/dataroom-header.tsx
@@ -18,10 +18,12 @@ import {
 export const DataroomHeader = ({
   title,
   description,
+  internalName,
   actions,
 }: {
   title: string;
   description: string;
+  internalName?: string | null;
   actions?: React.ReactNode[];
 }) => {
   const [isLinkSheetOpen, setIsLinkSheetOpen] = useState<boolean>(false);
@@ -39,9 +41,14 @@ export const DataroomHeader = ({
     <section className="mb-4">
       <div className="flex items-center justify-between">
         <div className="flex min-h-10 items-center gap-x-2 space-y-1">
-          <h1 className="text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
-            {title}
-          </h1>
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
+              {internalName || title}
+            </h1>
+            {internalName && (
+              <p className="text-sm text-muted-foreground">{title}</p>
+            )}
+          </div>
           {dataroom?.enableChangeNotifications ? (
             <Tooltip>
               <TooltipTrigger asChild>

--- a/ee/features/conversations/pages/conversation-detail.tsx
+++ b/ee/features/conversations/pages/conversation-detail.tsx
@@ -364,7 +364,7 @@ export default function ConversationDetailPage() {
     <AppLayout>
       <div className="relative mx-2 my-4 space-y-8 overflow-hidden px-1 sm:mx-3 md:mx-5 md:mt-5 lg:mx-7 lg:mt-8 xl:mx-10">
         <header>
-          <DataroomHeader title={dataroom.name} description={dataroom.pId} />
+          <DataroomHeader title={dataroom.name} description={dataroom.pId} internalName={dataroom.internalName} />
           <DataroomNavigation dataroomId={dataroom.id} />
         </header>
 

--- a/ee/features/conversations/pages/conversation-overview.tsx
+++ b/ee/features/conversations/pages/conversation-overview.tsx
@@ -203,7 +203,7 @@ export default function DataroomConversationsPage() {
     <AppLayout>
       <div className="relative mx-2 my-4 space-y-8 overflow-hidden px-1 sm:mx-3 md:mx-5 md:mt-5 lg:mx-7 lg:mt-8 xl:mx-10">
         <header>
-          <DataroomHeader title={dataroom.name} description={dataroom.pId} />
+          <DataroomHeader title={dataroom.name} description={dataroom.pId} internalName={dataroom.internalName} />
           <DataroomNavigation dataroomId={dataroom.id} />
         </header>
 

--- a/ee/features/conversations/pages/faq-overview.tsx
+++ b/ee/features/conversations/pages/faq-overview.tsx
@@ -285,7 +285,7 @@ export default function FAQOverview() {
       <AppLayout>
         <div className="relative mx-2 mb-10 mt-4 space-y-8 overflow-hidden px-1 sm:mx-3 md:mx-5 md:mt-5 lg:mx-7 lg:mt-8 xl:mx-10">
           <header>
-            <DataroomHeader title={dataroom.name} description={dataroom.pId} />
+            <DataroomHeader title={dataroom.name} description={dataroom.pId} internalName={dataroom.internalName} />
             <DataroomNavigation dataroomId={dataroom.id} />
           </header>
 
@@ -334,7 +334,7 @@ export default function FAQOverview() {
     <AppLayout>
       <div className="relative mx-2 mb-10 mt-4 space-y-8 overflow-hidden px-1 sm:mx-3 md:mx-5 md:mt-5 lg:mx-7 lg:mt-8 xl:mx-10">
         <header>
-          <DataroomHeader title={dataroom.name} description={dataroom.pId} />
+          <DataroomHeader title={dataroom.name} description={dataroom.pId} internalName={dataroom.internalName} />
           <DataroomNavigation dataroomId={dataroom.id} />
         </header>
 

--- a/pages/api/teams/[teamId]/datarooms/[id]/index.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/index.ts
@@ -110,6 +110,7 @@ export default async function handle(
 
       const {
         name,
+        internalName,
         enableChangeNotifications,
         defaultPermissionStrategy,
         allowBulkDownload,
@@ -118,6 +119,7 @@ export default async function handle(
         agentsEnabled,
       } = req.body as {
         name?: string;
+        internalName?: string | null;
         enableChangeNotifications?: boolean;
         defaultPermissionStrategy?: DefaultPermissionStrategy;
         allowBulkDownload?: boolean;
@@ -154,6 +156,9 @@ export default async function handle(
           },
           data: {
             ...(name && { name }),
+            ...(internalName !== undefined && { 
+              internalName: internalName === null || internalName === "" ? null : internalName.trim() 
+            }),
             ...(typeof enableChangeNotifications === "boolean" && {
               enableChangeNotifications,
             }),

--- a/pages/api/teams/[teamId]/datarooms/index.ts
+++ b/pages/api/teams/[teamId]/datarooms/index.ts
@@ -58,12 +58,22 @@ export default async function handle(
         teamId: teamId,
       };
 
-      // Search filter
+      // Search filter - search both name and internalName
       if (search) {
-        whereClause.name = {
-          contains: search,
-          mode: "insensitive",
-        };
+        whereClause.OR = [
+          {
+            name: {
+              contains: search,
+              mode: "insensitive",
+            },
+          },
+          {
+            internalName: {
+              contains: search,
+              mode: "insensitive",
+            },
+          },
+        ];
       }
 
       // Tags filter
@@ -171,7 +181,7 @@ export default async function handle(
     const userId = (session.user as CustomUser).id;
 
     const { teamId } = req.query as { teamId: string };
-    const { name } = req.body as { name: string };
+    const { name, internalName } = req.body as { name: string; internalName?: string };
 
     try {
       // Check if the user is part of the team
@@ -238,6 +248,7 @@ export default async function handle(
           name: name,
           teamId: teamId,
           pId: pId,
+          ...(internalName && { internalName: internalName.trim() }),
         },
       });
 

--- a/pages/datarooms/[id]/analytics/index.tsx
+++ b/pages/datarooms/[id]/analytics/index.tsx
@@ -65,6 +65,7 @@ export default function DataroomAnalyticsPage() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[]}
           />
           <DataroomNavigation dataroomId={dataroom.id} />

--- a/pages/datarooms/[id]/branding/index.tsx
+++ b/pages/datarooms/[id]/branding/index.tsx
@@ -271,6 +271,7 @@ export default function DataroomBrandPage() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[]}
           />
 

--- a/pages/datarooms/[id]/documents/[...name].tsx
+++ b/pages/datarooms/[id]/documents/[...name].tsx
@@ -43,6 +43,7 @@ export default function Documents() {
           <DataroomHeader
             title={dataroom?.name ?? ""}
             description={dataroom?.pId ?? ""}
+            internalName={dataroom?.internalName}
             actions={[]}
           />
 

--- a/pages/datarooms/[id]/documents/index.tsx
+++ b/pages/datarooms/[id]/documents/index.tsx
@@ -37,6 +37,7 @@ export default function Documents() {
           <DataroomHeader
             title={dataroom?.name ?? ""}
             description={dataroom?.pId ?? ""}
+            internalName={dataroom?.internalName}
             actions={[]}
           />
 

--- a/pages/datarooms/[id]/groups/[groupId]/group-analytics.tsx
+++ b/pages/datarooms/[id]/groups/[groupId]/group-analytics.tsx
@@ -23,6 +23,7 @@ export default function DataroomGroupPage() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[]}
           />
 

--- a/pages/datarooms/[id]/groups/[groupId]/index.tsx
+++ b/pages/datarooms/[id]/groups/[groupId]/index.tsx
@@ -30,6 +30,7 @@ export default function DataroomGroupPage() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[]}
           />
 

--- a/pages/datarooms/[id]/groups/[groupId]/links.tsx
+++ b/pages/datarooms/[id]/groups/[groupId]/links.tsx
@@ -27,6 +27,7 @@ export default function DataroomGroupLinksPage() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[]}
           />
 

--- a/pages/datarooms/[id]/groups/[groupId]/members.tsx
+++ b/pages/datarooms/[id]/groups/[groupId]/members.tsx
@@ -23,6 +23,7 @@ export default function DataroomGroupPage() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[]}
           />
 

--- a/pages/datarooms/[id]/groups/[groupId]/permissions.tsx
+++ b/pages/datarooms/[id]/groups/[groupId]/permissions.tsx
@@ -23,6 +23,7 @@ export default function DataroomGroupPage() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[]}
           />
 

--- a/pages/datarooms/[id]/groups/index.tsx
+++ b/pages/datarooms/[id]/groups/index.tsx
@@ -53,6 +53,7 @@ export default function DataroomGroupPage() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[]}
           />
 

--- a/pages/datarooms/[id]/index.tsx
+++ b/pages/datarooms/[id]/index.tsx
@@ -28,6 +28,7 @@ export default function DataroomPage() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[
               <Button onClick={() => setIsLinkSheetOpen(true)} key={1}>
                 Share

--- a/pages/datarooms/[id]/permissions/index.tsx
+++ b/pages/datarooms/[id]/permissions/index.tsx
@@ -32,6 +32,7 @@ export default function DataroomAnalyticsPage() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[
               <Button onClick={() => setIsLinkSheetOpen(true)} key={1}>
                 Share

--- a/pages/datarooms/[id]/settings/downloads.tsx
+++ b/pages/datarooms/[id]/settings/downloads.tsx
@@ -20,6 +20,7 @@ export default function Downloads() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[]}
           />
 

--- a/pages/datarooms/[id]/settings/file-permissions.tsx
+++ b/pages/datarooms/[id]/settings/file-permissions.tsx
@@ -20,6 +20,7 @@ export default function PermissionsSettings() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[]}
           />
 

--- a/pages/datarooms/[id]/settings/index.tsx
+++ b/pages/datarooms/[id]/settings/index.tsx
@@ -97,7 +97,7 @@ export default function Settings() {
               description="A private name only visible to you. Useful for distinguishing multiple data rooms with the same public name."
               inputAttrs={{
                 name: "internalName",
-                placeholder: "Friends & Family Round",
+                placeholder: "e.g., Series A - Sequoia, Buyer Group A",
                 maxLength: 156,
               }}
               defaultValue={dataroom.internalName ?? ""}

--- a/pages/datarooms/[id]/settings/index.tsx
+++ b/pages/datarooms/[id]/settings/index.tsx
@@ -47,6 +47,7 @@ export default function Settings() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[]}
           />
 
@@ -62,7 +63,7 @@ export default function Settings() {
           <div className="grid gap-6">
             <Form
               title="Dataroom Name"
-              description="This is the name of your data room on Papermark."
+              description="This is the public name of your data room visible to all viewers."
               inputAttrs={{
                 name: "name",
                 placeholder: "My Dataroom",
@@ -84,6 +85,39 @@ export default function Settings() {
                       mutate(`/api/teams/${teamId}/datarooms/${dataroom.id}`),
                     ]);
                     toast.success("Successfully updated dataroom name!");
+                  } else {
+                    const { error } = await res.json();
+                    toast.error(error.message);
+                  }
+                })
+              }
+            />
+            <Form
+              title="Internal Name"
+              description="A private name only visible to you. Useful for distinguishing multiple data rooms with the same public name."
+              inputAttrs={{
+                name: "internalName",
+                placeholder: "Friends & Family Round",
+                maxLength: 156,
+              }}
+              defaultValue={dataroom.internalName ?? ""}
+              helpText="Max 156 characters. Leave empty to remove."
+              handleSubmit={(updateData) =>
+                fetch(`/api/teams/${teamId}/datarooms/${dataroom.id}`, {
+                  method: "PATCH",
+                  headers: {
+                    "Content-Type": "application/json",
+                  },
+                  body: JSON.stringify({
+                    internalName: updateData.internalName || null,
+                  }),
+                }).then(async (res) => {
+                  if (res.status === 200) {
+                    await Promise.all([
+                      mutate(`/api/teams/${teamId}/datarooms`),
+                      mutate(`/api/teams/${teamId}/datarooms/${dataroom.id}`),
+                    ]);
+                    toast.success("Successfully updated internal name!");
                   } else {
                     const { error } = await res.json();
                     toast.error(error.message);

--- a/pages/datarooms/[id]/settings/notifications.tsx
+++ b/pages/datarooms/[id]/settings/notifications.tsx
@@ -20,6 +20,7 @@ export default function Notifications() {
           <DataroomHeader
             title={dataroom.name}
             description={dataroom.pId}
+            internalName={dataroom.internalName}
             actions={[]}
           />
 

--- a/pages/datarooms/[id]/users/index.tsx
+++ b/pages/datarooms/[id]/users/index.tsx
@@ -16,7 +16,7 @@ export default function DataroomUsersPage() {
     <AppLayout>
       <div className="relative mx-2 mb-10 mt-4 space-y-8 overflow-hidden px-1 sm:mx-3 md:mx-5 md:mt-5 lg:mx-7 lg:mt-8 xl:mx-10">
         <header>
-          <DataroomHeader title={dataroom.name} description={dataroom.pId} />
+          <DataroomHeader title={dataroom.name} description={dataroom.pId} internalName={dataroom.internalName} />
 
           <DataroomNavigation dataroomId={dataroom.id} />
         </header>

--- a/prisma/migrations/20260113000000_add_internal_name_to_dataroom/migration.sql
+++ b/prisma/migrations/20260113000000_add_internal_name_to_dataroom/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Dataroom" ADD COLUMN     "internalName" TEXT;

--- a/prisma/schema/dataroom.prisma
+++ b/prisma/schema/dataroom.prisma
@@ -2,6 +2,7 @@ model Dataroom {
   id           String             @id @default(cuid())
   pId          String             @unique // This is the generated public ID for the dataroom dr_1234
   name         String
+  internalName String?            // Private, internal name/alias visible only to the dataroom owner
   description  String?
   teamId       String
   team         Team               @relation(fields: [teamId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
Add an optional internal name field to Data Rooms to allow users to privately distinguish between identically named public Data Rooms.

---
Linear Issue: [PM-464](https://linear.app/papermark/issue/PM-464/internal-namingalias-for-data-rooms)

<a href="https://cursor.com/background-agent?bcId=bc-71cfdec1-4077-4671-b110-2a467f274f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-71cfdec1-4077-4671-b110-2a467f274f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal name functionality for datarooms—set a private name displayed as the primary title, with the public name shown as a subtitle.
  * New "Internal Name" form in dataroom settings to manage internal names.
  * Search now filters by both internal name and regular name.

* **Database**
  * Added `internalName` field to dataroom schema.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->