### PR TITLE
chore: add annual billing indicator

### DIFF
--- a/components/billing/upgrade-plan-modal-with-discount.tsx
+++ b/components/billing/upgrade-plan-modal-with-discount.tsx
@@ -395,7 +395,7 @@ export function UpgradePlanModalWithDiscount({
                             </span>
                           </div>
                           <span className="text-gray-500 dark:text-white/75">
-                            /month
+                            /month, billed annually
                           </span>
                         </>
                       ) : (

--- a/components/billing/upgrade-plan-modal.tsx
+++ b/components/billing/upgrade-plan-modal.tsx
@@ -298,7 +298,7 @@ export function UpgradePlanModal({
                     }
                   </span>
                   <span className="text-gray-500 dark:text-white/75">
-                    /month
+                    /month{period === "yearly" && ", billed annually"}
                   </span>
                 </div>
 

--- a/pages/settings/upgrade-holiday-offer.tsx
+++ b/pages/settings/upgrade-holiday-offer.tsx
@@ -265,7 +265,7 @@ export default function UpgradeHolidayOfferPage() {
                 <div className="mb-2 text-balance text-4xl font-medium tabular-nums text-foreground">
                   €{period === "yearly" ? discountedYearlyPrice : monthlyPrice}
                   <span className="text-base font-normal dark:text-white/75">
-                    /month
+                    /month{period === "yearly" && ", billed annually"}
                   </span>
                 </div>
                 {period === "yearly" && (
@@ -456,7 +456,7 @@ export default function UpgradeHolidayOfferPage() {
                 <div className="mb-2 text-balance text-4xl font-medium tabular-nums text-foreground">
                   €{period === "yearly" ? discountedYearlyPrice : monthlyPrice}
                   <span className="text-base font-normal dark:text-white/75">
-                    /month
+                    /month{period === "yearly" && ", billed annually"}
                   </span>
                 </div>
                 {period === "yearly" && (
@@ -646,7 +646,7 @@ export default function UpgradeHolidayOfferPage() {
                 <div className="mb-2 text-balance text-4xl font-medium tabular-nums text-foreground">
                   €{period === "yearly" ? discountedYearlyPrice : monthlyPrice}
                   <span className="text-base font-normal dark:text-white/75">
-                    /month
+                    /month{period === "yearly" && ", billed annually"}
                   </span>
                 </div>
                 {period === "yearly" && (

--- a/pages/settings/upgrade.tsx
+++ b/pages/settings/upgrade.tsx
@@ -232,7 +232,7 @@ export default function UpgradePage() {
                 €
                 {PLANS.find((p) => p.name === planOption)!.price[period].amount}
                 <span className="text-base font-normal dark:text-white/75">
-                  /month
+                  /month{period === "yearly" && ", billed annually"}
                 </span>
               </div>
               <p className="mt-4 text-sm text-gray-600 dark:text-white">
@@ -389,7 +389,7 @@ export default function UpgradePage() {
                   {PLANS.find((p) => p.name === planOption)!.price[period]
                     .amount}
                   <span className="text-base font-normal dark:text-white/75">
-                    /month
+                    /month{period === "yearly" && ", billed annually"}
                   </span>
                 </div>
                 <p className="mt-4 text-sm text-gray-600 dark:text-white">
@@ -546,7 +546,7 @@ export default function UpgradePage() {
                     {PLANS.find((p) => p.name === planOption)!.price[period]
                       .amount}
                     <span className="text-base font-normal dark:text-white/75">
-                      /month
+                      /month{period === "yearly" && ", billed annually"}
                     </span>
                   </div>
                   <p className="mt-4 text-sm text-gray-600 dark:text-white">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated pricing display labels across billing pages to clearly indicate "/month, billed annually" when yearly billing is selected, improving clarity on how annual subscriptions are charged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->