### PR TITLE
Regular pricing and components

### DIFF
--- a/components/analytics/time-range-select.tsx
+++ b/components/analytics/time-range-select.tsx
@@ -16,7 +16,7 @@ import {
 
 import { cn } from "@/lib/utils";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 
 const TIME_RANGES = [
   { value: "24h", label: "Last 24 hours", shortcut: "D" },
@@ -215,7 +215,7 @@ const UpgradeButton = () => {
       >
         Custom Date <CrownIcon className="!size-4" />
       </Button>
-      <UpgradePlanModalWithDiscount
+      <UpgradePlanModal
         clickedPlan={PlanEnum.Pro}
         trigger="dashboard_time_range_custom_select"
         open={open}

--- a/components/billing/add-seat-modal.tsx
+++ b/components/billing/add-seat-modal.tsx
@@ -186,7 +186,7 @@ export function AddSeatModal({
             {loading ? "Redirecting..." : "Proceed to checkout"}
           </Button>
           <Link
-            href="/settings/upgrade-holiday-offer"
+            href="/settings/upgrade"
             className="block w-full text-center text-xs text-muted-foreground underline underline-offset-4 hover:text-foreground"
             onClick={() => setOpen(false)}
           >

--- a/components/billing/pro-banner.tsx
+++ b/components/billing/pro-banner.tsx
@@ -6,7 +6,7 @@ import Cookies from "js-cookie";
 import X from "@/components/shared/icons/x";
 import { Button } from "@/components/ui/button";
 
-import { UpgradePlanModalWithDiscount } from "./upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "./upgrade-plan-modal";
 
 export default function ProBanner({
   setShowProBanner,
@@ -37,14 +37,14 @@ export default function ProBanner({
         Upgrade to unlock custom branding, team members, domains and data rooms.
       </p>
       <div className="flex">
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={PlanEnum.Business}
           trigger={"pro_banner"}
         >
           <Button type="button" className="grow">
             Upgrade
           </Button>
-        </UpgradePlanModalWithDiscount>
+        </UpgradePlanModal>
       </div>
     </aside>
   );

--- a/components/billing/upgrade-plan-container.tsx
+++ b/components/billing/upgrade-plan-container.tsx
@@ -204,7 +204,7 @@ export default function UpgradePlanContainer() {
             clickedPlan={PlanEnum.Business}
             trigger="upgrade_plan"
             useModal={false}
-            onClick={() => router.push("/settings/upgrade-holiday-offer")}
+            onClick={() => router.push("/settings/upgrade")}
           />
         </div>
       );

--- a/components/billing/yearly-upgrade-banner.tsx
+++ b/components/billing/yearly-upgrade-banner.tsx
@@ -17,7 +17,7 @@ import { cn } from "@/lib/utils";
 
 import { Button } from "@/components/ui/button";
 
-import { UpgradePlanModalWithDiscount } from "./upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "./upgrade-plan-modal";
 
 interface YearlyUpgradeBannerProps {
   setShowBanner: Dispatch<SetStateAction<boolean | null>>;
@@ -34,11 +34,6 @@ export default function YearlyUpgradeBanner({
     Cookies.set("hideYearlyUpgradeBanner", "yearly-upgrade-banner", {
       expires: 7,
     });
-  };
-
-  // Calculate 30% discounted yearly price (same as modal)
-  const getDiscountedYearlyPrice = (yearlyPrice: number) => {
-    return Math.round(yearlyPrice * 0.7); // Round to whole number
   };
 
   // Get next higher plan
@@ -75,15 +70,15 @@ export default function YearlyUpgradeBanner({
         </button>
 
         <div className="mb-4 flex items-center gap-2">
-          <Sparkles className="h-5 w-5 text-black" />
-          <span className="text-lg font-bold text-black">
-            LIMITED TIME OFFER
+          <Sparkles className="h-5 w-5 text-[#fb7a00]" />
+          <span className="text-lg font-bold text-black dark:text-white">
+            UPGRADE YOUR PLAN
           </span>
         </div>
 
         <div className="mb-2">
           <p className="text-xs text-gray-500 dark:text-gray-400">
-            Extra 30% off on yearly plans
+            Save up to 35% with yearly plans
           </p>
         </div>
 
@@ -93,11 +88,10 @@ export default function YearlyUpgradeBanner({
           if (!planData) return null;
 
           const yearlyPrice = planData.price.yearly.amount;
-          const discountedYearlyPrice = getDiscountedYearlyPrice(yearlyPrice);
           const monthlyPrice = planData.price.monthly.amount;
           const monthlyForYear = monthlyPrice * 12;
-          const yearlyWithDiscount = Math.round(yearlyPrice * 12 * 0.7);
-          const savings = monthlyForYear - yearlyWithDiscount;
+          const yearlyForYear = yearlyPrice * 12;
+          const savings = monthlyForYear - yearlyForYear;
           const planFeatures = getPlanFeatures(nextPlan, {
             period: "yearly",
             maxFeatures: 4,
@@ -120,13 +114,10 @@ export default function YearlyUpgradeBanner({
               </p>
               <div className="mb-3 flex items-baseline gap-2">
                 <span className="text-2xl font-semibold text-gray-900 dark:text-white">
-                  €{discountedYearlyPrice}
-                </span>
-                <span className="text-sm text-gray-500 line-through">
                   €{yearlyPrice}
                 </span>
                 <span className="text-xs text-gray-600 dark:text-gray-400">
-                  /mo
+                  /mo, billed annually
                 </span>
               </div>
 
@@ -140,7 +131,7 @@ export default function YearlyUpgradeBanner({
                 ))}
               </ul>
 
-              <UpgradePlanModalWithDiscount
+              <UpgradePlanModal
                 clickedPlan={nextPlan}
                 trigger="yearly_upgrade_banner"
               >
@@ -151,19 +142,16 @@ export default function YearlyUpgradeBanner({
                 >
                   Upgrade to {nextPlan} Yearly
                 </Button>
-              </UpgradePlanModalWithDiscount>
+              </UpgradePlanModal>
             </div>
           );
         })()}
 
         <p
-          onClick={() => router.push("/settings/upgrade-holiday-offer")}
+          onClick={() => router.push("/settings/upgrade")}
           className="mt-4 cursor-pointer text-center text-xs text-gray-500 underline hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-300"
         >
           Compare all plans
-        </p>
-        <p className="mt-2 text-center text-xs text-gray-500 dark:text-gray-400">
-          New Year&apos;s offer • Ends Jan 15
         </p>
       </motion.aside>
     </AnimatePresence>

--- a/components/datarooms/actions/generate-index-dialog.tsx
+++ b/components/datarooms/actions/generate-index-dialog.tsx
@@ -14,7 +14,7 @@ import { usePlan } from "@/lib/swr/use-billing";
 import { useDataroomLinks } from "@/lib/swr/use-dataroom";
 import { IndexFileFormat } from "@/lib/types/index-file";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -224,12 +224,12 @@ export default function GenerateIndexDialog({
               {isLoading ? "Generating..." : "Generate"}
             </Button>
           ) : (
-            <UpgradePlanModalWithDiscount
+            <UpgradePlanModal
               clickedPlan={PlanEnum.DataRooms}
               trigger="datarooms_generate_index_button"
             >
               <Button>Upgrade to generate</Button>
-            </UpgradePlanModalWithDiscount>
+            </UpgradePlanModal>
           )}
         </DialogFooter>
       </DialogContent>

--- a/components/datarooms/actions/rebuild-index-button.tsx
+++ b/components/datarooms/actions/rebuild-index-button.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 import { useFeatureFlags } from "@/lib/hooks/use-feature-flags";
 import { usePlan } from "@/lib/swr/use-billing";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -150,13 +150,13 @@ export default function RebuildIndexButton({
               </Button>
             </>
           ) : (
-            <UpgradePlanModalWithDiscount
+            <UpgradePlanModal
               clickedPlan={PlanEnum.DataRoomsPlus}
               trigger="datarooms_rebuild_index_button"
               highlightItem={["indexing"]}
             >
               <Button>Upgrade to rebuild index</Button>
-            </UpgradePlanModalWithDiscount>
+            </UpgradePlanModal>
           )}
         </DialogFooter>
       </DialogContent>

--- a/components/datarooms/add-dataroom-modal.tsx
+++ b/components/datarooms/add-dataroom-modal.tsx
@@ -55,7 +55,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 
-import { UpgradePlanModalWithDiscount } from "../billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "../billing/upgrade-plan-modal";
 
 export function AddDataroomModal({
   children,
@@ -350,12 +350,12 @@ export function AddDataroomModal({
   if (isFree || isPro) {
     if (children) {
       return (
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={PlanEnum.DataRooms}
           trigger={"add_dataroom_overview"}
         >
           {children}
-        </UpgradePlanModalWithDiscount>
+        </UpgradePlanModal>
       );
     }
   }

--- a/components/datarooms/dataroom-trial-modal.tsx
+++ b/components/datarooms/dataroom-trial-modal.tsx
@@ -23,7 +23,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-import { UpgradePlanModalWithDiscount } from "../billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "../billing/upgrade-plan-modal";
 import { PhoneInput } from "../ui/phone-input";
 import {
   Select,
@@ -262,9 +262,9 @@ export function DataroomTrialModal({
 
               <div className="text-xs text-muted-foreground">
                 After the trial, upgrade to{" "}
-                <UpgradePlanModalWithDiscount clickedPlan={PlanEnum.Business}>
+                <UpgradePlanModal clickedPlan={PlanEnum.Business}>
                   <button className="underline">Papermark Business</button>
-                </UpgradePlanModalWithDiscount>{" "}
+                </UpgradePlanModal>{" "}
                 to continue using data rooms.
               </div>
             </div>

--- a/components/datarooms/settings/dataroom-tag-section.tsx
+++ b/components/datarooms/settings/dataroom-tag-section.tsx
@@ -11,7 +11,7 @@ import { usePlan } from "@/lib/swr/use-billing";
 import { useTags } from "@/lib/swr/use-tags";
 import { TagColorProps } from "@/lib/types";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -226,7 +226,7 @@ export default function DataroomTagSection({
         </CardFooter>
       </Card>
       {showUpgradeModal && (
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={PlanEnum.Pro}
           trigger="create_tag"
           open={showUpgradeModal}

--- a/components/datarooms/settings/duplicate-dataroom.tsx
+++ b/components/datarooms/settings/duplicate-dataroom.tsx
@@ -7,7 +7,7 @@ import { PlanEnum } from "@/ee/stripe/constants";
 import { toast } from "sonner";
 import { mutate } from "swr";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -130,7 +130,7 @@ export default function DuplicateDataroom({
         </CardFooter>
       </Card>
       {planModalOpen ? (
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={PlanEnum.DataRooms}
           trigger="datarooms"
           open={planModalOpen}

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -69,7 +69,7 @@ export default function DocumentUpload({
             description: "Upgrade to a paid plan to increase the limit",
             action: {
               label: "Upgrade",
-              onClick: () => router.push("/settings/upgrade-holiday-offer"),
+              onClick: () => router.push("/settings/upgrade"),
             },
             duration: 10000,
           });
@@ -112,7 +112,7 @@ export default function DocumentUpload({
             description: "Upgrade to a paid plan to increase the limit",
             action: {
               label: "Upgrade",
-              onClick: () => router.push("/settings/upgrade-holiday-offer"),
+              onClick: () => router.push("/settings/upgrade"),
             },
             duration: 10000,
           });
@@ -126,7 +126,7 @@ export default function DocumentUpload({
             description: `Upgrade to a paid plan to upload ${file.type} files`,
             action: {
               label: "Upgrade",
-              onClick: () => router.push("/settings/upgrade-holiday-offer"),
+              onClick: () => router.push("/settings/upgrade"),
             },
             duration: 10000,
           });

--- a/components/documents/add-document-modal.tsx
+++ b/components/documents/add-document-modal.tsx
@@ -45,7 +45,7 @@ import {
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-import { UpgradePlanModalWithDiscount } from "../billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "../billing/upgrade-plan-modal";
 
 interface DataroomDocument {
   id: string;
@@ -702,21 +702,21 @@ export function AddDocumentModal({
   if (!canAddDocuments && children) {
     if (newVersion) {
       return (
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={PlanEnum.Pro}
           trigger={"limit_upload_document_version"}
         >
           {children}
-        </UpgradePlanModalWithDiscount>
+        </UpgradePlanModal>
       );
     }
     return (
-      <UpgradePlanModalWithDiscount
+      <UpgradePlanModal
         clickedPlan={PlanEnum.Pro}
         trigger={"limit_upload_documents"}
       >
         <Button>Upgrade to Add Documents</Button>
-      </UpgradePlanModalWithDiscount>
+      </UpgradePlanModal>
     );
   }
 
@@ -818,7 +818,7 @@ export function AddDocumentModal({
                             </button>{" "}
                             or{" "}
                             {isFree && !isTrial ? (
-                              <UpgradePlanModalWithDiscount
+                              <UpgradePlanModal
                                 clickedPlan={PlanEnum.Pro}
                                 trigger={"add_web_link_document"}
                               >
@@ -828,7 +828,7 @@ export function AddDocumentModal({
                                 >
                                   share link as a document
                                 </button>
-                              </UpgradePlanModalWithDiscount>
+                              </UpgradePlanModal>
                             ) : (
                               <button
                                 type="button"

--- a/components/documents/document-card.tsx
+++ b/components/documents/document-card.tsx
@@ -28,7 +28,7 @@ import { cn, getBreadcrumbPath, nFormatter, timeAgo } from "@/lib/utils";
 import { fileIcon } from "@/lib/utils/get-file-icon";
 import { useCopyToClipboard } from "@/lib/utils/use-copy-to-clipboard";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { DataroomTrialModal } from "@/components/datarooms/dataroom-trial-modal";
 import { AddToDataroomModal } from "@/components/documents/add-document-to-dataroom-modal";
 import { DocumentPreviewModal } from "@/components/documents/document-preview-modal";
@@ -497,7 +497,7 @@ export default function DocumentsCard({
         />
       ) : null}
       {planModalOpen ? (
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={PlanEnum.DataRooms}
           trigger="datarooms"
           open={planModalOpen}

--- a/components/documents/document-header.tsx
+++ b/components/documents/document-header.tsx
@@ -58,7 +58,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 import PlanBadge from "../billing/plan-badge";
-import { UpgradePlanModalWithDiscount } from "../billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "../billing/upgrade-plan-modal";
 import AdvancedSheet from "../shared/icons/advanced-sheet";
 import PortraitLandscape from "../shared/icons/portrait-landscape";
 import LoadingSpinner from "../ui/loading-spinner";
@@ -991,7 +991,7 @@ export default function DocumentHeader({
       ) : null}
 
       {planModalOpen ? (
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={selectedPlan}
           trigger={planModalTrigger}
           open={planModalOpen}

--- a/components/domains/add-domain-modal.tsx
+++ b/components/domains/add-domain-modal.tsx
@@ -23,7 +23,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-import { UpgradePlanModalWithDiscount } from "../billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "../billing/upgrade-plan-modal";
 import { UpgradeButton } from "../ui/upgrade-button";
 
 export function AddDomainModal({
@@ -131,7 +131,7 @@ export function AddDomainModal({
       );
     } else {
       return (
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={
             linkType === "DATAROOM_LINK"
               ? PlanEnum.DataRooms

--- a/components/emails/custom-domain-setup.tsx
+++ b/components/emails/custom-domain-setup.tsx
@@ -100,7 +100,7 @@ export default function CustomDomainSetup({
               ) : (
                 <Button
                   className="rounded bg-black text-center text-xs font-semibold text-white no-underline"
-                  href={`https://app.papermark.com/settings/upgrade-holiday-offer`}
+                  href={`https://app.papermark.com/settings/upgrade`}
                   style={{ padding: "12px 20px" }}
                 >
                   Upgrade to use custom domains
@@ -124,7 +124,7 @@ export default function CustomDomainSetup({
                 <>
                   Want to learn more about our plans?{" "}
                   <Link
-                    href="https://app.papermark.com/settings/upgrade-holiday-offer"
+                    href="https://app.papermark.com/settings/upgrade"
                     className="font-medium text-blue-600 no-underline"
                   >
                     View pricing

--- a/components/folders/add-folder-modal.tsx
+++ b/components/folders/add-folder-modal.tsx
@@ -25,7 +25,7 @@ import { Label } from "@/components/ui/label";
 import { useAnalytics } from "@/lib/analytics";
 import { usePlan } from "@/lib/swr/use-billing";
 
-import { UpgradePlanModalWithDiscount } from "../billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "../billing/upgrade-plan-modal";
 
 export function AddFolderModal({
   // open,
@@ -139,13 +139,13 @@ export function AddFolderModal({
   if (isFree && !isTrial) {
     if (children) {
       return (
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={PlanEnum.Pro}
           trigger={"add_folder_button"}
           highlightItem={["folder", "multi-file"]}
         >
           {children}
-        </UpgradePlanModalWithDiscount>
+        </UpgradePlanModal>
       );
     }
   }

--- a/components/layouts/app.tsx
+++ b/components/layouts/app.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/sidebar";
 
 import { usePlan } from "@/lib/swr/use-billing";
-import YearlyUpgradeBanner from "@/components/billing/yearly-upgrade-banner";
+// import YearlyUpgradeBanner from "@/components/billing/yearly-upgrade-banner";
 
 import { BlockingModal } from "./blocking-modal";
 
@@ -23,24 +23,24 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   const isSidebarOpen =
     cookieValue === undefined ? true : cookieValue === "true";
 
-  const { isAnnualPlan, isFree } = usePlan();
-  const [showYearlyBanner, setShowYearlyBanner] = useState<boolean | null>(null);
+  // const { isAnnualPlan, isFree } = usePlan();
+  // const [showYearlyBanner, setShowYearlyBanner] = useState<boolean | null>(null);
 
   // Show banner only for paid monthly subscribers (not free, not yearly)
-  useEffect(() => {
-    // Hide banner for free users or yearly subscribers
-    if (isFree || isAnnualPlan) {
-      setShowYearlyBanner(false);
-      return;
-    }
+  // useEffect(() => {
+  //   // Hide banner for free users or yearly subscribers
+  //   if (isFree || isAnnualPlan) {
+  //     setShowYearlyBanner(false);
+  //     return;
+  //   }
 
-    // Show banner for monthly paid users (if not dismissed)
-    if (Cookies.get("hideYearlyUpgradeBanner") !== "yearly-upgrade-banner") {
-      setShowYearlyBanner(true);
-    } else {
-      setShowYearlyBanner(false);
-    }
-  }, [isFree, isAnnualPlan]);
+  //   // Show banner for monthly paid users (if not dismissed)
+  //   if (Cookies.get("hideYearlyUpgradeBanner") !== "yearly-upgrade-banner") {
+  //     setShowYearlyBanner(true);
+  //   } else {
+  //     setShowYearlyBanner(false);
+  //   }
+  // }, [isFree, isAnnualPlan]);
 
   return (
     <SidebarProvider defaultOpen={isSidebarOpen}>
@@ -59,9 +59,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
           <main className="flex-1">{children}</main>
         </SidebarInset>
       </div>
-      {showYearlyBanner && (
+      {/* {showYearlyBanner && (
         <YearlyUpgradeBanner setShowBanner={setShowYearlyBanner} />
-      )}
+      )} */}
     </SidebarProvider>
   );
 }

--- a/components/layouts/blocking-modal.tsx
+++ b/components/layouts/blocking-modal.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 
-import { UpgradePlanModalWithDiscount } from "../billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "../billing/upgrade-plan-modal";
 import { AddTeamModal } from "../teams/add-team-modal";
 
 export const BlockingModal = () => {
@@ -129,14 +129,14 @@ export const BlockingModal = () => {
                 plan.
               </p>
             </div>
-            <UpgradePlanModalWithDiscount
+            <UpgradePlanModal
               clickedPlan={PlanEnum.Pro}
               trigger="trial_end_blocking_modal"
             >
               <Button type="button" variant="orange">
                 Upgrade
               </Button>
-            </UpgradePlanModalWithDiscount>
+            </UpgradePlanModal>
             <Button type="button" variant="outline">
               Dismiss
             </Button>
@@ -181,14 +181,14 @@ export const BlockingModal = () => {
             >
               Log out
             </Button>
-            <UpgradePlanModalWithDiscount
+            <UpgradePlanModal
               clickedPlan={PlanEnum.Business}
               trigger="trial_end_blocking_modal_for_team_member"
             >
               <Button className="w-full sm:w-auto" type="button">
                 Upgrade
               </Button>
-            </UpgradePlanModalWithDiscount>
+            </UpgradePlanModal>
             {userTeam ? (
               <Button
                 variant="outline"

--- a/components/layouts/trial-banner.tsx
+++ b/components/layouts/trial-banner.tsx
@@ -9,7 +9,7 @@ import { usePlan } from "@/lib/swr/use-billing";
 import useDataroomsSimple from "@/lib/swr/use-datarooms-simple";
 import { daysLeft } from "@/lib/utils";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import {
   Alert,
   AlertClose,
@@ -83,14 +83,14 @@ function TrialBannerComponent({
         <AlertDescription>
           {isExpired ? (
             <>
-              <UpgradePlanModalWithDiscount
+              <UpgradePlanModal
                 clickedPlan={PlanEnum.DataRooms}
                 trigger={"trial_navbar"}
               >
                 <span className="cursor-pointer font-bold text-black underline underline-offset-4 hover:text-gray-700 dark:text-white dark:hover:text-gray-300">
                   Upgrade to keep access
                 </span>
-              </UpgradePlanModalWithDiscount>{" "}
+              </UpgradePlanModal>{" "}
               to unlimited data rooms, custom domains, advanced access controls,
               and granular file permissions ✨
             </>
@@ -99,14 +99,14 @@ function TrialBannerComponent({
               You are on the <span className="font-bold">Data Rooms</span> plan
               trial, you have access to advanced access controls, granular file
               permissions, and data room. <br />
-              <UpgradePlanModalWithDiscount
+              <UpgradePlanModal
                 clickedPlan={PlanEnum.DataRooms}
                 trigger={"trial_navbar"}
               >
                 <span className="cursor-pointer font-bold text-orange-500 underline underline-offset-4 hover:text-orange-600">
                   Upgrade to keep access
                 </span>
-              </UpgradePlanModalWithDiscount>
+              </UpgradePlanModal>
               , unlock unlimited data rooms and custom domains ✨
             </>
           )}

--- a/components/links/link-sheet/domain-section.tsx
+++ b/components/links/link-sheet/domain-section.tsx
@@ -12,7 +12,7 @@ import { BasePlan, usePlan } from "@/lib/swr/use-billing";
 import useLimits from "@/lib/swr/use-limits";
 import { cn } from "@/lib/utils";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { AddDomainModal } from "@/components/domains/add-domain-modal";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -316,7 +316,7 @@ export default function DomainSection({
       />
 
       {/* Upgrade plan modal when trying to use custom domains without the right plan */}
-      <UpgradePlanModalWithDiscount
+      <UpgradePlanModal
         clickedPlan={
           linkType === "DATAROOM_LINK" ? PlanEnum.DataRooms : PlanEnum.Business
         }

--- a/components/links/link-sheet/index.tsx
+++ b/components/links/link-sheet/index.tsx
@@ -19,7 +19,7 @@ import useLimits from "@/lib/swr/use-limits";
 import { LinkWithViews, WatermarkConfig } from "@/lib/types";
 import { convertDataUrlToFile, fetcher, uploadImage } from "@/lib/utils";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -496,14 +496,14 @@ export default function LinkSheet({
                             Group
                           </TabsTrigger>
                         ) : (
-                          <UpgradePlanModalWithDiscount
+                          <UpgradePlanModal
                             clickedPlan={PlanEnum.DataRooms}
                             trigger="add_group_link"
                           >
                             <div className="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all">
                               Group
                             </div>
-                          </UpgradePlanModalWithDiscount>
+                          </UpgradePlanModal>
                         )}
                       </TabsList>
                     ) : null}

--- a/components/links/link-sheet/link-options.tsx
+++ b/components/links/link-sheet/link-options.tsx
@@ -9,7 +9,7 @@ import { usePlan } from "@/lib/swr/use-billing";
 import useLimits from "@/lib/swr/use-limits";
 import { cn } from "@/lib/utils";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { DEFAULT_LINK_TYPE } from "@/components/links/link-sheet";
 import AllowDownloadSection from "@/components/links/link-sheet/allow-download-section";
 import AllowListSection from "@/components/links/link-sheet/allow-list-section";
@@ -298,7 +298,7 @@ export const LinkOptions = ({
         </div>
       </CollapsibleSection>
 
-      <UpgradePlanModalWithDiscount
+      <UpgradePlanModal
         clickedPlan={upgradePlan}
         open={openUpgradeModal}
         setOpen={setOpenUpgradeModal}

--- a/components/links/link-sheet/tags/tag-section.tsx
+++ b/components/links/link-sheet/tags/tag-section.tsx
@@ -11,7 +11,7 @@ import { usePlan } from "@/lib/swr/use-billing";
 import { useTags } from "@/lib/swr/use-tags";
 import { TagProps } from "@/lib/types";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select-v2";
 import { BadgeTooltip } from "@/components/ui/tooltip";
@@ -145,7 +145,7 @@ export default function TagSection({
         />
       </div>
       {showUpgradeModal && (
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={PlanEnum.Pro}
           trigger="create_tag"
           open={showUpgradeModal}

--- a/components/links/links-table.tsx
+++ b/components/links/links-table.tsx
@@ -31,7 +31,7 @@ import { LinkWithViews, WatermarkConfig } from "@/lib/types";
 import { cn, copyToClipboard, nFormatter, timeAgo } from "@/lib/utils";
 import { useMediaQuery } from "@/lib/utils/use-media-query";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { Button } from "@/components/ui/button";
 import {
   Collapsible,
@@ -524,12 +524,12 @@ export default function LinksTable({
   const AddLinkButton = () => {
     if (!canAddLinks) {
       return (
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={isTrial ? PlanEnum.Business : PlanEnum.Pro}
           trigger={"limit_add_link"}
         >
           <Button>Upgrade to Create Link</Button>
-        </UpgradePlanModalWithDiscount>
+        </UpgradePlanModal>
       );
     } else {
       return (

--- a/components/navigation-menu.tsx
+++ b/components/navigation-menu.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 
 import { Separator } from "@/components/ui/separator";
 
-import { UpgradePlanModalWithDiscount } from "./billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "./billing/upgrade-plan-modal";
 
 type Props = {
   navigation: {
@@ -99,7 +99,7 @@ const NavItem: React.FC<Props["navigation"][0]> = ({
       )}
     >
       {limited ? (
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           key={label}
           clickedPlan={PlanEnum.DataRoomsPlus}
           trigger={label}
@@ -109,7 +109,7 @@ const NavItem: React.FC<Props["navigation"][0]> = ({
             {label}
             <CrownIcon className="h-4 w-4 text-muted-foreground" />
           </div>
-        </UpgradePlanModalWithDiscount>
+        </UpgradePlanModal>
       ) : (
         <Link
           href={href}

--- a/components/sidebar/app-sidebar.tsx
+++ b/components/sidebar/app-sidebar.tsx
@@ -208,12 +208,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           },
         ],
       },
-      {
-        title: "2025 Recap",
-        url: "/dashboard?openRecap=true",
-        icon: SparklesIcon,
-        current: false,
-      },
+      // {
+      //   title: "2025 Recap",
+      //   url: "/dashboard?openRecap=true",
+      //   icon: SparklesIcon,
+      //   current: false,
+      // },
     ],
   };
 

--- a/components/sidebar/nav-main.tsx
+++ b/components/sidebar/nav-main.tsx
@@ -27,7 +27,7 @@ import {
   SidebarMenuSubItem,
 } from "@/components/ui/sidebar";
 
-import { UpgradePlanModalWithDiscount } from "../billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "../billing/upgrade-plan-modal-with-discount";
 
 export interface NavItem {
   title: string;
@@ -78,7 +78,7 @@ export function NavMain({ items }: { items: NavItem[] }) {
                 )}
               >
                 {item.disabled ? (
-                  <UpgradePlanModalWithDiscount
+                  <UpgradePlanModal
                     key={item.title}
                     clickedPlan={item.plan as PlanEnum}
                     trigger={item.trigger}
@@ -94,7 +94,7 @@ export function NavMain({ items }: { items: NavItem[] }) {
                         <CrownIcon className="!size-4" />
                       </span>
                     </div>
-                  </UpgradePlanModalWithDiscount>
+                  </UpgradePlanModal>
                 ) : (
                   <Link
                     href={item.url}

--- a/components/sidebar/nav-main.tsx
+++ b/components/sidebar/nav-main.tsx
@@ -27,7 +27,7 @@ import {
   SidebarMenuSubItem,
 } from "@/components/ui/sidebar";
 
-import { UpgradePlanModal } from "../billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "../billing/upgrade-plan-modal";
 
 export interface NavItem {
   title: string;

--- a/components/sidebar/team-switcher.tsx
+++ b/components/sidebar/team-switcher.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/ui/sidebar";
 
 import { AddSeatModal } from "../billing/add-seat-modal";
-import { UpgradePlanModalWithDiscount } from "../billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "../billing/upgrade-plan-modal-with-discount";
 import { AddTeamMembers } from "../teams/add-team-member-modal";
 import { AddTeamModal } from "../teams/add-team-modal";
 import { Avatar, AvatarFallback } from "../ui/avatar";
@@ -119,7 +119,7 @@ export function TeamSwitcher({
                 </DropdownMenuItem>
               </AddTeamModal>
             ) : (
-              <UpgradePlanModalWithDiscount
+              <UpgradePlanModal
                 clickedPlan={PlanEnum.DataRoomsPremium}
                 trigger="add_new_team"
                 highlightItem={["teams"]}
@@ -133,14 +133,14 @@ export function TeamSwitcher({
                   </div>
                   <div className="font-medium text-muted-foreground">Add new team</div>
                 </DropdownMenuItem>
-              </UpgradePlanModalWithDiscount>
+              </UpgradePlanModal>
             )}
           </DropdownMenuContent>
         </DropdownMenu>
       </SidebarMenuItem>
       <SidebarMenuItem>
         {showUpgradePlanModal ? (
-          <UpgradePlanModalWithDiscount
+          <UpgradePlanModal
             clickedPlan={isTrial ? PlanEnum.Business : PlanEnum.Pro}
             trigger={"invite_team_members"}
           >
@@ -150,7 +150,7 @@ export function TeamSwitcher({
             >
               <UserRoundPlusIcon className="!size-5" strokeWidth={1.5} />
             </SidebarMenuButton>
-          </UpgradePlanModalWithDiscount>
+          </UpgradePlanModal>
         ) : canAddUsers ? (
           <AddTeamMembers
             open={isTeamMemberInviteModalOpen}

--- a/components/sidebar/team-switcher.tsx
+++ b/components/sidebar/team-switcher.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/ui/sidebar";
 
 import { AddSeatModal } from "../billing/add-seat-modal";
-import { UpgradePlanModal } from "../billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "../billing/upgrade-plan-modal";
 import { AddTeamMembers } from "../teams/add-team-member-modal";
 import { AddTeamModal } from "../teams/add-team-modal";
 import { Avatar, AvatarFallback } from "../ui/avatar";

--- a/components/tags/add-tag-modal.tsx
+++ b/components/tags/add-tag-modal.tsx
@@ -6,7 +6,7 @@ import { usePlan } from "@/lib/swr/use-billing";
 import { TagColorProps } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -75,12 +75,12 @@ export function AddTagsModal({
   if (isFree && tagCount >= 5) {
     if (children) {
       return (
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={isTrial ? PlanEnum.Business : PlanEnum.Pro}
           trigger={"create_tag"}
         >
           <Button>Upgrade to Create Tags</Button>
-        </UpgradePlanModalWithDiscount>
+        </UpgradePlanModal>
       );
     }
   }

--- a/components/ui/upgrade-button.tsx
+++ b/components/ui/upgrade-button.tsx
@@ -5,7 +5,7 @@ import { CrownIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { Button } from "@/components/ui/button";
 
 interface UpgradeButtonProps {
@@ -68,7 +68,7 @@ export function UpgradeButton({
   return (
     <>
       {buttonContent}
-      <UpgradePlanModalWithDiscount
+      <UpgradePlanModal
         clickedPlan={clickedPlan}
         trigger={trigger}
         open={open}

--- a/components/visitors/visitor-useragent-placeholder.tsx
+++ b/components/visitors/visitor-useragent-placeholder.tsx
@@ -1,7 +1,7 @@
 import { PlanEnum } from "@/ee/stripe/constants";
 import { CrownIcon } from "lucide-react";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { Button } from "@/components/ui/button";
 import UAIcon from "@/components/user-agent-icon";
 
@@ -37,7 +37,7 @@ export default function VisitorUserAgentPlaceholder() {
         </div>
       </div>
       <div className="absolute left-8 top-3">
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={PlanEnum.Pro}
           trigger="visitor-table-user-agent"
         >
@@ -49,7 +49,7 @@ export default function VisitorUserAgentPlaceholder() {
             <CrownIcon className="size-4" />
             <span>See more visitor info</span>
           </Button>
-        </UpgradePlanModalWithDiscount>
+        </UpgradePlanModal>
       </div>
     </div>
   );

--- a/components/visitors/visitors-table.tsx
+++ b/components/visitors/visitors-table.tsx
@@ -45,7 +45,7 @@ import {
 import { TimestampTooltip } from "@/components/ui/timestamp-tooltip";
 import { BadgeTooltip } from "@/components/ui/tooltip";
 
-import { UpgradePlanModalWithDiscount } from "../billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "../billing/upgrade-plan-modal";
 import { Pagination } from "../documents/pagination";
 import { Button } from "../ui/button";
 import {
@@ -190,7 +190,7 @@ export default function VisitorsTable({
                           Some older visits may not be shown because your
                           document has more than 20 views.{" "}
                         </span>
-                        <UpgradePlanModalWithDiscount
+                        <UpgradePlanModal
                           clickedPlan={
                             isTrial ? PlanEnum.Business : PlanEnum.Pro
                           }
@@ -199,7 +199,7 @@ export default function VisitorsTable({
                           <button className="underline hover:text-gray-800">
                             Upgrade to see full history
                           </button>
-                        </UpgradePlanModalWithDiscount>
+                        </UpgradePlanModal>
                       </div>
                     )}
                   </TableCell>

--- a/components/welcome/containers/onboarding-link-options.tsx
+++ b/components/welcome/containers/onboarding-link-options.tsx
@@ -7,7 +7,7 @@ import { LinkPreset } from "@prisma/client";
 import { usePlan } from "@/lib/swr/use-billing";
 import useLimits from "@/lib/swr/use-limits";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { DEFAULT_LINK_TYPE } from "@/components/links/link-sheet";
 import AgreementSection from "@/components/links/link-sheet/agreement-section";
 import AllowDownloadSection from "@/components/links/link-sheet/allow-download-section";
@@ -262,7 +262,7 @@ export const OnboardingLinkOptions = ({
     <div>
       {basicSettings}
       {showAdvancedSettings && advancedSettings}
-      <UpgradePlanModalWithDiscount
+      <UpgradePlanModal
         clickedPlan={upgradePlan}
         open={openUpgradeModal}
         setOpen={setOpenUpgradeModal}

--- a/components/welcome/dataroom-trial.tsx
+++ b/components/welcome/dataroom-trial.tsx
@@ -23,7 +23,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-import { UpgradePlanModalWithDiscount } from "../billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "../billing/upgrade-plan-modal";
 import { Input } from "../ui/input";
 
 export default function DataroomTrial() {
@@ -327,18 +327,18 @@ export default function DataroomTrial() {
 
             <div className="text-xs text-muted-foreground">
               {/* Data rooms are available on our{" "}
-              <UpgradePlanModalWithDiscount clickedPlan={PlanEnum.Business}>
+              <UpgradePlanModal clickedPlan={PlanEnum.Business}>
                 <button className="underline">Business</button>
-              </UpgradePlanModalWithDiscount>{" "}
+              </UpgradePlanModal>{" "}
               plan. <br /> */}
               No credit card is required. After the trial, upgrade to{" "}
-              <UpgradePlanModalWithDiscount
+              <UpgradePlanModal
                 clickedPlan={PlanEnum.Business}
                 highlightItem={["datarooms"]}
                 trigger="dataroom_trial_form"
               >
                 <button className="underline">Papermark Data Rooms</button>
-              </UpgradePlanModalWithDiscount>{" "}
+              </UpgradePlanModal>{" "}
               to continue using data rooms.
             </div>
           </div>

--- a/ee/features/permissions/components/dataroom-link-sheet.tsx
+++ b/ee/features/permissions/components/dataroom-link-sheet.tsx
@@ -721,14 +721,14 @@ export function DataroomLinkSheet({
                             Group
                           </TabsTrigger>
                         ) : (
-                          <UpgradePlanModalWithDiscount
+                          <UpgradePlanModal
                             clickedPlan={PlanEnum.DataRooms}
                             trigger="add_group_link"
                           >
                             <div className="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all">
                               Group
                             </div>
-                          </UpgradePlanModalWithDiscount>
+                          </UpgradePlanModal>
                         )}
                       </TabsList>
                     ) : null} */}

--- a/ee/features/permissions/components/permissions-sheet.tsx
+++ b/ee/features/permissions/components/permissions-sheet.tsx
@@ -35,7 +35,7 @@ import {
 } from "@/lib/utils/hierarchical-display";
 
 import PlanBadge from "@/components/billing/plan-badge";
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import CloudDownloadOff from "@/components/shared/icons/cloud-download-off";
 import { Button } from "@/components/ui/button";
 import {
@@ -964,7 +964,7 @@ export function PermissionsSheet({
                 <div className="flex items-center gap-2">
                   <h4 className="text-sm font-medium">Share Entire Dataroom</h4>
                   {!canSetCustomPermissions && (
-                    <UpgradePlanModalWithDiscount
+                    <UpgradePlanModal
                       clickedPlan={PlanEnum.DataRooms}
                       trigger="dataroom_permissions_sheet_toggle"
                     >
@@ -974,7 +974,7 @@ export function PermissionsSheet({
                       >
                         <PlanBadge plan={PlanEnum.DataRooms} />
                       </button>
-                    </UpgradePlanModalWithDiscount>
+                    </UpgradePlanModal>
                   )}
                 </div>
                 <p className="text-sm text-muted-foreground">

--- a/pages/account/general.tsx
+++ b/pages/account/general.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 import { AccountHeader } from "@/components/account/account-header";
 import { UpdateMailSubscribe } from "@/components/account/update-subscription";
 import UploadAvatar from "@/components/account/upload-avatar";
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import AppLayout from "@/components/layouts/app";
 import { Form } from "@/components/ui/form";
 import { PlanEnum } from "@/ee/stripe/constants";
@@ -40,7 +40,7 @@ const ProfilePage: NextPage = () => {
 
   return (
     <AppLayout>
-      <UpgradePlanModalWithDiscount
+      <UpgradePlanModal
         clickedPlan={nextPlan}
         trigger="account_page"
         open={showUpgradeModal}

--- a/pages/branding.tsx
+++ b/pages/branding.tsx
@@ -15,7 +15,7 @@ import { usePlan } from "@/lib/swr/use-billing";
 import { useBrand } from "@/lib/swr/use-brand";
 import { cn, convertDataUrlToFile, uploadImage } from "@/lib/utils";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import AppLayout from "@/components/layouts/app";
 import { NavMenu } from "@/components/navigation-menu";
 import { Button } from "@/components/ui/button";

--- a/pages/datarooms/[id]/groups/index.tsx
+++ b/pages/datarooms/[id]/groups/index.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { PlanEnum } from "@/ee/stripe/constants";
 import { CircleHelpIcon, InfoIcon, UsersIcon } from "lucide-react";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { DataroomHeader } from "@/components/datarooms/dataroom-header";
 import { DataroomNavigation } from "@/components/datarooms/dataroom-navigation";
 import { AddGroupModal } from "@/components/datarooms/groups/add-group-modal";
@@ -37,12 +37,12 @@ export default function DataroomGroupPage() {
       return <Button onClick={() => setModalOpen(true)}>Create group</Button>;
     }
     return (
-      <UpgradePlanModalWithDiscount
+      <UpgradePlanModal
         clickedPlan={PlanEnum.DataRooms}
         trigger="create_group_button"
       >
         <Button>Upgrade to create group</Button>
-      </UpgradePlanModalWithDiscount>
+      </UpgradePlanModal>
     );
   };
 

--- a/pages/datarooms/[id]/settings/index.tsx
+++ b/pages/datarooms/[id]/settings/index.tsx
@@ -374,14 +374,14 @@ export default function Settings() {
                         </Button>
                       ) : null}
                       {isNotBusiness ? (
-                        <UpgradePlanModalWithDiscount
+                        <UpgradePlanModal
                           clickedPlan={"Business"}
                           trigger={"feedback_question"}
                         >
                           <Button type="submit" loading={loading}>
                             {feedback ? "Update question" : "Create question"}
                           </Button>
-                        </UpgradePlanModalWithDiscount>
+                        </UpgradePlanModal>
                       ) : (
                         <Button type="submit" loading={loading}>
                           {feedback ? "Update question" : "Create question"}

--- a/pages/datarooms/index.tsx
+++ b/pages/datarooms/index.tsx
@@ -14,7 +14,7 @@ import useLimits from "@/lib/swr/use-limits";
 import { useTags } from "@/lib/swr/use-tags";
 import { daysLeft } from "@/lib/utils";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import { AddDataroomModal } from "@/components/datarooms/add-dataroom-modal";
 import DataroomCard from "@/components/datarooms/dataroom-card";
 import { DataroomTrialModal } from "@/components/datarooms/dataroom-trial-modal";
@@ -101,7 +101,7 @@ export default function DataroomsPage() {
           </div>
           <div className="flex items-center gap-x-1">
             {isBusiness && !canCreateUnlimitedDatarooms ? (
-              <UpgradePlanModalWithDiscount
+              <UpgradePlanModal
                 clickedPlan={PlanEnum.DataRooms}
                 trigger="datarooms"
               >
@@ -111,7 +111,7 @@ export default function DataroomsPage() {
                 >
                   <span>Upgrade to Add Data Room</span>
                 </Button>
-              </UpgradePlanModalWithDiscount>
+              </UpgradePlanModal>
             ) : isTrial &&
               datarooms &&
               !isBusiness &&
@@ -135,7 +135,7 @@ export default function DataroomsPage() {
                     })()}
                   </span>
                 </div>
-                <UpgradePlanModalWithDiscount
+                <UpgradePlanModal
                   clickedPlan={PlanEnum.DataRooms}
                   trigger="datarooms"
                 >
@@ -145,7 +145,7 @@ export default function DataroomsPage() {
                   >
                     <span>Upgrade to Add Data Room</span>
                   </Button>
-                </UpgradePlanModalWithDiscount>
+                </UpgradePlanModal>
               </div>
             ) : isBusiness || isDatarooms || isDataroomsPlus ? (
               <AddDataroomModal>

--- a/pages/documents/[id]/index.tsx
+++ b/pages/documents/[id]/index.tsx
@@ -10,7 +10,7 @@ import { PlanEnum } from "@/ee/stripe/constants";
 import { useDocumentLinks } from "@/lib/swr/use-document";
 import { useDocumentOverview } from "@/lib/swr/use-document-overview";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import DocumentHeader from "@/components/documents/document-header";
 import { DocumentPreviewButton } from "@/components/documents/document-preview-button";
 // Import placeholder components
@@ -96,14 +96,14 @@ export default function DocumentPage() {
   const AddLinkButton = () => {
     if (!limits?.canAddLinks) {
       return (
-        <UpgradePlanModalWithDiscount
+        <UpgradePlanModal
           clickedPlan={team?.isTrial ? PlanEnum.Business : PlanEnum.Pro}
           trigger={"limit_add_link"}
         >
           <Button className="flex h-8 whitespace-nowrap text-xs lg:h-9 lg:text-sm">
             Upgrade to Create Link
           </Button>
-        </UpgradePlanModalWithDiscount>
+        </UpgradePlanModal>
       );
     } else {
       return (

--- a/pages/settings/general.tsx
+++ b/pages/settings/general.tsx
@@ -10,7 +10,7 @@ import { usePlan } from "@/lib/swr/use-billing";
 import { useTeamSettings } from "@/lib/swr/use-team-settings";
 import { validateContent } from "@/lib/utils/sanitize-html";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import AppLayout from "@/components/layouts/app";
 import DeleteTeam from "@/components/settings/delete-team";
 import GlobalBlockListForm from "@/components/settings/global-block-list-form";
@@ -230,7 +230,7 @@ export default function General() {
         </div>
 
         {planModalOpen ? (
-          <UpgradePlanModalWithDiscount
+          <UpgradePlanModal
             clickedPlan={selectedPlan}
             trigger={planModalTrigger}
             open={planModalOpen}

--- a/pages/settings/presets/[id].tsx
+++ b/pages/settings/presets/[id].tsx
@@ -15,7 +15,7 @@ import useLimits from "@/lib/swr/use-limits";
 import { WatermarkConfig } from "@/lib/types";
 import { fetcher } from "@/lib/utils";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import AppLayout from "@/components/layouts/app";
 import { DEFAULT_LINK_TYPE } from "@/components/links/link-sheet";
 import AgreementSection from "@/components/links/link-sheet/agreement-section";
@@ -525,7 +525,7 @@ export default function EditPreset() {
           </div>
         </form>
       </main>
-      <UpgradePlanModalWithDiscount
+      <UpgradePlanModal
         clickedPlan={upgradePlan}
         open={openUpgradeModal}
         setOpen={setOpenUpgradeModal}

--- a/pages/settings/presets/index.tsx
+++ b/pages/settings/presets/index.tsx
@@ -13,7 +13,7 @@ import useSWR from "swr";
 import { usePlan } from "@/lib/swr/use-billing";
 import { fetcher, formatExpirationTime } from "@/lib/utils";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import AppLayout from "@/components/layouts/app";
 import { SettingsHeader } from "@/components/settings/settings-header";
 import { Badge } from "@/components/ui/badge";
@@ -131,7 +131,7 @@ export default function Presets() {
           )}
         </div>
       </main>
-      <UpgradePlanModalWithDiscount
+      <UpgradePlanModal
         clickedPlan={PlanEnum.Business}
         trigger="presets_page"
         open={showUpgradeModal}

--- a/pages/settings/presets/new.tsx
+++ b/pages/settings/presets/new.tsx
@@ -13,7 +13,7 @@ import { toast } from "sonner";
 import { usePlan } from "@/lib/swr/use-billing";
 import useLimits from "@/lib/swr/use-limits";
 
-import { UpgradePlanModalWithDiscount } from "@/components/billing/upgrade-plan-modal-with-discount";
+import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import AppLayout from "@/components/layouts/app";
 import {
   DEFAULT_LINK_PROPS,
@@ -361,7 +361,7 @@ export default function NewPreset() {
           </div>
         </form>
       </main>
-      <UpgradePlanModalWithDiscount
+      <UpgradePlanModal
         clickedPlan={upgradePlan}
         open={openUpgradeModal}
         setOpen={setOpenUpgradeModal}


### PR DESCRIPTION
Remove the New Year's offer and revert pricing to regular, and comment out the 2025 recap banner from the sidebar.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1768769168646309?thread_ts=1768769168.646309&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-40059c82-503f-4813-803a-f11423d672eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-40059c82-503f-4813-803a-f11423d672eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Promotions**
  * Holiday discount banners and special yearly promotion have been removed.

* **Navigation**
  * Upgrade links consolidated to a single settings path.

* **UI**
  * 2025 Recap navigation item removed from the sidebar.

* **Consistency**
  * Upgrade prompt behavior standardized across the app for a unified upgrade experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->