### PR TITLE
Subscription pause timing

### DIFF
--- a/ee/features/billing/cancellation/api/pause-route.ts
+++ b/ee/features/billing/cancellation/api/pause-route.ts
@@ -77,7 +77,8 @@ export async function handleRoute(req: NextApiRequest, res: NextApiResponse) {
       const pauseStartsAt = stripePeriodEnd > now ? stripePeriodEnd : now;
 
       const pauseEndsAt = new Date(pauseStartsAt);
-      pauseEndsAt.setDate(pauseStartsAt.getDate() + 90);
+      // Use 3 calendar months instead of 90 days to properly align with billing cycles
+      pauseEndsAt.setMonth(pauseStartsAt.getMonth() + 3);
       const reminderAt = new Date(pauseEndsAt);
       reminderAt.setDate(pauseEndsAt.getDate() - 3);
 

--- a/ee/features/billing/cancellation/components/pause-subscription-modal.tsx
+++ b/ee/features/billing/cancellation/components/pause-subscription-modal.tsx
@@ -82,7 +82,8 @@ export function PauseSubscriptionModal({
   const endsAtDate = endsAt ? new Date(endsAt) : now;
   const pauseStartsAt = endsAtDate > now ? endsAtDate : now;
   const pauseEndsAt = new Date(pauseStartsAt);
-  pauseEndsAt.setDate(pauseStartsAt.getDate() + 90);
+  // Use 3 calendar months instead of 90 days to properly align with billing cycles
+  pauseEndsAt.setMonth(pauseStartsAt.getMonth() + 3);
 
   const pauseStartsAtString = new Date(pauseStartsAt).toLocaleDateString(
     "en-US",


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-412c61a2-53e8-4b0e-aaae-ff90f9ca729c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-412c61a2-53e8-4b0e-aaae-ff90f9ca729c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated subscription pause duration to align with billing cycles. Pauses now last for 3 calendar months instead of a fixed 90-day window.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->