### PR TITLE
Delayed email verification notice

### DIFF
--- a/app/(auth)/auth/email/[[...params]]/page-client.tsx
+++ b/app/(auth)/auth/email/[[...params]]/page-client.tsx
@@ -42,7 +42,10 @@ export default function EmailVerificationClient() {
 
   // Show email delivery notice after 5 seconds when waiting for verification
   useEffect(() => {
-    if (!emailLocked) return;
+    if (!emailLocked) {
+      setShowEmailDeliveryNotice(false);
+      return;
+    }
 
     const timer = setTimeout(() => {
       setShowEmailDeliveryNotice(true);

--- a/app/(auth)/auth/email/[[...params]]/page-client.tsx
+++ b/app/(auth)/auth/email/[[...params]]/page-client.tsx
@@ -49,7 +49,7 @@ export default function EmailVerificationClient() {
 
     const timer = setTimeout(() => {
       setShowEmailDeliveryNotice(true);
-    }, 5000);
+    }, 10000);
 
     return () => clearTimeout(timer);
   }, [emailLocked]);

--- a/app/(auth)/auth/email/[[...params]]/page-client.tsx
+++ b/app/(auth)/auth/email/[[...params]]/page-client.tsx
@@ -174,8 +174,8 @@ export default function EmailVerificationClient() {
           {showEmailDeliveryNotice && emailLocked && (
             <div className="mx-4 mt-4 rounded-lg border border-orange-200 bg-orange-50 p-4 sm:mx-12">
               <p className="text-sm text-orange-800">
-                We are experiencing delivery issues with some email providers
-                and are working to resolve this.
+                Due to a recent Microsoft outage, we are experiencing delivery
+                issues with Outlook and Microsoft email accounts.
               </p>
               <p className="mt-2 text-sm text-orange-800">
                 Check your junk/spam and quarantine folders and ensure that{" "}

--- a/app/(auth)/auth/email/[[...params]]/page-client.tsx
+++ b/app/(auth)/auth/email/[[...params]]/page-client.tsx
@@ -19,6 +19,7 @@ export default function EmailVerificationClient() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isExpired, setIsExpired] = useState(false);
+  const [showEmailDeliveryNotice, setShowEmailDeliveryNotice] = useState(false);
 
   // Check sessionStorage for pending verification email on mount
   useEffect(() => {
@@ -38,6 +39,17 @@ export default function EmailVerificationClient() {
       // sessionStorage not available, user will need to enter email manually
     }
   }, []);
+
+  // Show email delivery notice after 5 seconds when waiting for verification
+  useEffect(() => {
+    if (!emailLocked) return;
+
+    const timer = setTimeout(() => {
+      setShowEmailDeliveryNotice(true);
+    }, 5000);
+
+    return () => clearTimeout(timer);
+  }, [emailLocked]);
 
   // Code verification
   const handleSubmit = async (e: React.FormEvent) => {
@@ -157,6 +169,26 @@ export default function EmailVerificationClient() {
               )}
             </h3>
           </div>
+
+          {/* Delayed email delivery notice */}
+          {showEmailDeliveryNotice && emailLocked && (
+            <div className="mx-4 mt-4 rounded-lg border border-red-300 bg-red-50 p-4 sm:mx-12">
+              <p className="text-sm text-red-800">
+                We are experiencing delivery issues with some email providers
+                and are working to resolve this.
+              </p>
+              <p className="mt-2 text-sm text-red-800">
+                Check your junk/spam and quarantine folders and ensure that{" "}
+                <a
+                  href="mailto:system@papermark.com"
+                  className="font-medium underline"
+                >
+                  system@papermark.com
+                </a>{" "}
+                is on your allowed senders list.
+              </p>
+            </div>
+          )}
 
           <form
             className="flex flex-col gap-4 px-4 pt-8 sm:px-12"

--- a/app/(auth)/auth/email/[[...params]]/page-client.tsx
+++ b/app/(auth)/auth/email/[[...params]]/page-client.tsx
@@ -172,16 +172,16 @@ export default function EmailVerificationClient() {
 
           {/* Delayed email delivery notice */}
           {showEmailDeliveryNotice && emailLocked && (
-            <div className="mx-4 mt-4 rounded-lg border border-red-300 bg-red-50 p-4 sm:mx-12">
-              <p className="text-sm text-red-800">
+            <div className="mx-4 mt-4 rounded-lg border border-orange-200 bg-orange-50 p-4 sm:mx-12">
+              <p className="text-sm text-orange-800">
                 We are experiencing delivery issues with some email providers
                 and are working to resolve this.
               </p>
-              <p className="mt-2 text-sm text-red-800">
+              <p className="mt-2 text-sm text-orange-800">
                 Check your junk/spam and quarantine folders and ensure that{" "}
                 <a
                   href="mailto:system@papermark.com"
-                  className="font-medium underline"
+                  className="font-medium text-orange-600 underline hover:text-orange-700"
                 >
                   system@papermark.com
                 </a>{" "}


### PR DESCRIPTION
Add a delayed email delivery notice to the email verification page.

This notice appears 5 seconds after the page loads when a user is waiting for their verification email, informing them about potential delivery issues and instructing them to check spam/junk folders and add `system@papermark.com` to their allowed senders.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1769226403262139?thread_ts=1769226403.262139&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-6023b980-b371-4e37-9c2c-e7f5d4a92ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6023b980-b371-4e37-9c2c-e7f5d4a92ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a delayed email delivery notice that appears during the email verification flow after a brief wait.
  * The notice is shown in two places in the verification UI and includes instructions to add system@papermark.com to allowed/trusted senders.
  * Existing verification logic and navigation remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->