### PR TITLE
Link expiration indicator

### DIFF
--- a/components/links/links-table.tsx
+++ b/components/links/links-table.tsx
@@ -10,6 +10,7 @@ import { DocumentVersion, LinkAudienceType } from "@prisma/client";
 import { isWithinInterval, subMinutes } from "date-fns";
 import {
   BoxesIcon,
+  ClockFadingIcon,
   Code2Icon,
   CopyPlusIcon,
   EyeIcon,
@@ -682,10 +683,11 @@ export default function LinksTable({
                                   timestamp={link.expiresAt}
                                   side="right"
                                   rows={["local", "utc"]}
+                                  title="Expired at"
+                                  fullLabels
                                 >
-                                  <span className="flex cursor-default items-center gap-1 rounded-full bg-destructive/10 px-2 py-0.5 text-xs text-destructive ring-1 ring-destructive/20">
+                                  <span className="flex cursor-default items-center rounded-full bg-destructive/10 p-1 text-destructive ring-1 ring-destructive/20">
                                     <TimerOffIcon className="h-3 w-3" />
-                                    Expired
                                   </span>
                                 </TimestampTooltip>
                               ) : (
@@ -693,10 +695,11 @@ export default function LinksTable({
                                   timestamp={link.expiresAt}
                                   side="right"
                                   rows={["local", "utc"]}
+                                  title="Expires at"
+                                  fullLabels
                                 >
-                                  <span className="flex cursor-default items-center gap-1 rounded-full bg-orange-100 px-2 py-0.5 text-xs text-orange-700 ring-1 ring-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:ring-orange-800">
-                                    <HourglassIcon className="h-3 w-3" />
-                                    Expires
+                                  <span className="flex cursor-default items-center rounded-full bg-orange-100 p-1 text-orange-700 ring-1 ring-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:ring-orange-800">
+                                    <ClockFadingIcon className="h-3 w-3" />
                                   </span>
                                 </TimestampTooltip>
                               ))}

--- a/components/ui/timestamp-tooltip.tsx
+++ b/components/ui/timestamp-tooltip.tsx
@@ -30,6 +30,9 @@ export type TimestampTooltipProps = {
   className?: string;
   side?: "top" | "right" | "bottom" | "left";
   align?: "start" | "center" | "end";
+  title?: string;
+  /** Force full labels (e.g., "Australia/Melbourne") instead of short labels (e.g., "GMT+11"). Defaults to auto-detect. */
+  fullLabels?: boolean;
   children?: React.ReactNode;
 };
 
@@ -49,6 +52,8 @@ export function TimestampTooltip({
   side = "top",
   align = "center",
   className,
+  title,
+  fullLabels,
   children,
 }: TimestampTooltipProps) {
   if (!timestamp || new Date(timestamp).toString() === "Invalid Date")
@@ -70,6 +75,8 @@ export function TimestampTooltip({
             timestamp={timestamp}
             rows={rows}
             interactive={interactive}
+            title={title}
+            fullLabels={fullLabels}
           />
         </TooltipContent>
       </TooltipPortal>
@@ -81,7 +88,12 @@ function TimestampTooltipContent({
   timestamp,
   rows = ["local", "utc"],
   interactive,
-}: Pick<TimestampTooltipProps, "timestamp" | "rows" | "interactive">) {
+  title,
+  fullLabels: forceFullLabels,
+}: Pick<
+  TimestampTooltipProps,
+  "timestamp" | "rows" | "interactive" | "title" | "fullLabels"
+>) {
   if (!timestamp)
     throw new Error("Falsy timestamp not permitted in TimestampTooltipContent");
 
@@ -159,7 +171,8 @@ function TimestampTooltipContent({
     [rows, date],
   );
 
-  const shortLabels = items.every(({ shortLabel }) => shortLabel);
+  const shortLabels =
+    !forceFullLabels && items.every(({ shortLabel }) => shortLabel);
 
   // Re-render every second to update the relative time
   const [_, setRenderCount] = useState(0);
@@ -170,6 +183,9 @@ function TimestampTooltipContent({
 
   return (
     <div className="flex max-w-[360px] flex-col gap-2 px-2.5 py-2 text-left text-xs">
+      {title && (
+        <span className="font-medium text-muted-foreground">{title}</span>
+      )}
       <table>
         {items.map((row, idx) => (
           <tr


### PR DESCRIPTION
Add an 'Expired' badge with a tooltip to the link table to clearly indicate when a link is no longer active.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1769426081302049?thread_ts=1769426081.302049&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-0662bc05-a6c7-4f9b-8b5d-f9072dede90b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0662bc05-a6c7-4f9b-8b5d-f9072dede90b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expiration status badges ("Expired" / "Expires") to links with timestamp tooltips showing local and UTC times.
  * Timestamp tooltip can now show an optional title and supports forcing full (versus short) time labels for clearer display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->