### PR TITLE
feat: hide document/folder updated at when hidden in dataroom

### DIFF
--- a/components/view/dataroom/document-card.tsx
+++ b/components/view/dataroom/document-card.tsx
@@ -43,6 +43,7 @@ type DocumentsCardProps = {
   allowDownload: boolean;
   isProcessing?: boolean;
   dataroomIndexEnabled?: boolean;
+  showLastUpdated?: boolean;
 };
 
 export default function DocumentCard({
@@ -53,6 +54,7 @@ export default function DocumentCard({
   allowDownload,
   isProcessing = false,
   dataroomIndexEnabled,
+  showLastUpdated = true,
 }: DocumentsCardProps) {
   const { theme, systemTheme } = useTheme();
   const canDownload = document.canDownload && allowDownload;
@@ -219,11 +221,13 @@ export default function DocumentCard({
               </button>
             </h2>
           </div>
-          <div className="mt-1 flex items-center space-x-1 text-xs leading-5 text-muted-foreground">
-            <p className="truncate">
-              Updated {timeAgo(document.versions[0].updatedAt)}
-            </p>
-          </div>
+          {showLastUpdated && (
+            <div className="mt-1 flex items-center space-x-1 text-xs leading-5 text-muted-foreground">
+              <p className="truncate">
+                Updated {timeAgo(document.versions[0].updatedAt)}
+              </p>
+            </div>
+          )}
         </div>
       </div>
       {canDownload && !isProcessing && (

--- a/components/view/dataroom/folder-card.tsx
+++ b/components/view/dataroom/folder-card.tsx
@@ -28,6 +28,7 @@ type FolderCardProps = {
   viewId?: string;
   allowDownload: boolean;
   dataroomIndexEnabled?: boolean;
+  showLastUpdated?: boolean;
 };
 export default function FolderCard({
   folder,
@@ -38,6 +39,7 @@ export default function FolderCard({
   viewId,
   allowDownload,
   dataroomIndexEnabled,
+  showLastUpdated = true,
 }: FolderCardProps) {
   const [open, setOpen] = useState(false);
 
@@ -121,9 +123,11 @@ export default function FolderCard({
               </span>
             </h2>
           </div>
-          <div className="mt-1 flex items-center space-x-1 text-xs leading-5 text-muted-foreground">
-            <p className="truncate">Updated {timeAgo(folder.updatedAt)}</p>
-          </div>
+          {showLastUpdated && (
+            <div className="mt-1 flex items-center space-x-1 text-xs leading-5 text-muted-foreground">
+              <p className="truncate">Updated {timeAgo(folder.updatedAt)}</p>
+            </div>
+          )}
         </div>
       </div>
       {allowDownload ? (

--- a/components/view/viewer/dataroom-viewer.tsx
+++ b/components/view/viewer/dataroom-viewer.tsx
@@ -354,6 +354,7 @@ export default function DataroomViewer({
           allowDownload={allowDownload && item.canDownload}
           isProcessing={isProcessing}
           dataroomIndexEnabled={dataroomIndexEnabled}
+          showLastUpdated={dataroom?.showLastUpdated ?? true}
         />
       );
     }
@@ -369,6 +370,7 @@ export default function DataroomViewer({
         viewId={viewId}
         allowDownload={item.allowDownload}
         dataroomIndexEnabled={dataroomIndexEnabled}
+        showLastUpdated={dataroom?.showLastUpdated ?? true}
       />
     );
   };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documents and folders in the dataroom now support optional hiding of last-updated timestamps. Timestamps remain visible by default, maintaining existing behavior while enabling flexible presentation options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->