### PR TITLE
feat: two emails for abandoned checkout

### DIFF
--- a/components/billing/upgrade-plan-modal-old.tsx
+++ b/components/billing/upgrade-plan-modal-old.tsx
@@ -106,8 +106,19 @@ export function UpgradePlanModal({
         trigger: trigger,
         teamId: teamInfo?.currentTeam?.id,
       });
+
+      // Track upgrade click for email scheduling (with trigger info for personalization)
+      if (teamInfo?.currentTeam?.id) {
+        fetch(`/api/teams/${teamInfo.currentTeam.id}/billing/track-upgrade-click`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ trigger }),
+        }).catch(() => {
+          // Silently fail - this is just for tracking
+        });
+      }
     }
-  }, [open, trigger]);
+  }, [open, trigger, teamInfo?.currentTeam?.id]);
 
   // Track analytics event when child button is present
   const handleUpgradeClick = () => {

--- a/components/billing/upgrade-plan-modal-with-discount.tsx
+++ b/components/billing/upgrade-plan-modal-with-discount.tsx
@@ -217,10 +217,21 @@ export function UpgradePlanModalWithDiscount({
         trigger: trigger,
         teamId,
       });
+
+      // Track upgrade click for email scheduling (with trigger info for personalization)
+      if (teamId) {
+        fetch(`/api/teams/${teamId}/billing/track-upgrade-click`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ trigger }),
+        }).catch(() => {
+          // Silently fail - this is just for tracking
+        });
+      }
     } else {
       setDataRoomsPlanSelection("base");
     }
-  }, [open, trigger]);
+  }, [open, trigger, teamId]);
 
   const handleUpgradeClick = () => {
     analytics.capture("Upgrade Button Clicked", {

--- a/components/billing/upgrade-plan-modal.tsx
+++ b/components/billing/upgrade-plan-modal.tsx
@@ -193,10 +193,21 @@ export function UpgradePlanModal({
         trigger: trigger,
         teamId,
       });
+
+      // Track upgrade click for email scheduling (with trigger info for personalization)
+      if (teamId) {
+        fetch(`/api/teams/${teamId}/billing/track-upgrade-click`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ trigger }),
+        }).catch(() => {
+          // Silently fail - this is just for tracking
+        });
+      }
     } else {
       setDataRoomsPlanSelection("base");
     }
-  }, [open, trigger]);
+  }, [open, trigger, teamId]);
 
   const handleUpgradeClick = () => {
     analytics.capture("Upgrade Button Clicked", {

--- a/components/emails/abandoned-checkout.tsx
+++ b/components/emails/abandoned-checkout.tsx
@@ -1,0 +1,49 @@
+import {
+  Body,
+  Head,
+  Html,
+  Link,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+interface AbandonedCheckoutEmailProps {
+  name: string | null | undefined;
+}
+
+const AbandonedCheckoutEmail = ({ name }: AbandonedCheckoutEmailProps) => {
+  return (
+    <Html>
+      <Head />
+      <Tailwind>
+        <Body className="font-sans text-sm">
+          <Text>Hi{name && ` ${name}`},</Text>
+          <Text>
+            I noticed you started the checkout process but didn&apos;t complete
+            it. Did something go wrong?
+          </Text>
+          <Text>
+            If you ran into any issues or have questions about our plans,
+            I&apos;d be happy to help. Just reply to this email.
+          </Text>
+          <Text>
+            <Link
+              href="https://app.papermark.com/settings/upgrade"
+              target="_blank"
+              className="text-blue-500 underline"
+            >
+              Complete your upgrade →
+            </Link>
+          </Text>
+          <Text>
+            Best,
+            <br />
+            Marc
+          </Text>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default AbandonedCheckoutEmail;

--- a/components/emails/upgrade-intent.tsx
+++ b/components/emails/upgrade-intent.tsx
@@ -1,0 +1,118 @@
+import {
+  Body,
+  Head,
+  Html,
+  Link,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+// Map trigger names to feature titles
+const FEATURE_NAMES: Record<string, string> = {
+  // Custom domains
+  add_domain_overview: "Custom Domains",
+  add_domain_link_sheet: "Custom Domains",
+  // Data rooms
+  datarooms: "Secure Data Rooms",
+  add_dataroom_overview: "Secure Data Rooms",
+  datarooms_generate_index_button: "Data Room Index",
+  datarooms_rebuild_index_button: "Data Room Index",
+  // Team features
+  invite_team_members: "Team Collaboration",
+  add_new_team: "Multiple Teams",
+  // Visitor analytics
+  "visitor-table-user-agent": "Visitor Analytics",
+  // Tags
+  create_tag: "Document Tags",
+  // Folders
+  add_folder_button: "Folders",
+  // Document limits
+  limit_upload_documents: "Unlimited Documents",
+  limit_upload_document_version: "Document Versions",
+  // Link limits
+  limit_add_link: "Unlimited Links",
+  // Analytics exports
+  dashboard_visitors_export: "Analytics Export",
+  dashboard_views_export: "Analytics Export",
+  dashboard_links_export: "Analytics Export",
+  dashboard_documents_export: "Analytics Export",
+  dashboard_time_range_custom_select: "Custom Date Ranges",
+  // Branding
+  pro_banner: "Custom Branding",
+  // Web links
+  add_web_link_document: "Web Links",
+  // Groups
+  add_group_link: "Link Groups",
+};
+
+// Get unique feature names from triggers (deduplicated, lowercase)
+function getUniqueFeatureNames(triggers: string[]): string[] {
+  const seenTitles = new Set<string>();
+  const featureNames: string[] = [];
+
+  for (const trigger of triggers) {
+    const title = FEATURE_NAMES[trigger];
+    if (title && !seenTitles.has(title)) {
+      seenTitles.add(title);
+      featureNames.push(title.toLowerCase());
+    }
+  }
+
+  return featureNames.slice(0, 3); // Max 3 features
+}
+
+// Format feature names into a sentence (e.g., "secure data rooms, custom domains and team collaboration")
+function formatFeatureList(names: string[]): string {
+  if (names.length === 0) return "";
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+}
+
+interface UpgradeIntentEmailProps {
+  name: string | null | undefined;
+  triggers?: string[];
+}
+
+const UpgradeIntentEmail = ({ name, triggers = [] }: UpgradeIntentEmailProps) => {
+  const featureNames = getUniqueFeatureNames(triggers);
+  const hasFeatures = featureNames.length > 0;
+  const featureList = formatFeatureList(featureNames);
+
+  return (
+    <Html>
+      <Head />
+      <Tailwind>
+        <Body className="font-sans text-sm">
+          <Text>Hi{name && ` ${name}`},</Text>
+          <Text>
+            I noticed you&apos;ve been exploring our upgrade options.
+            {hasFeatures &&
+              ` I am happy to share more about Papermark ${featureList}.`}
+          </Text>
+          <Text>
+            Is there anything holding you back or any questions I can help
+            answer?
+          </Text>
+          <Text>
+            <Link
+              href="https://app.papermark.com/settings/upgrade"
+              target="_blank"
+              className="text-blue-500 underline"
+            >
+              View upgrade options →
+            </Link>
+          </Text>
+          <Text>Just reply to this email and I&apos;ll get back to you.</Text>
+          <Text>
+            Best,
+            <br />
+            Marc
+          </Text>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default UpgradeIntentEmail;

--- a/lib/emails/send-abandoned-checkout.ts
+++ b/lib/emails/send-abandoned-checkout.ts
@@ -1,0 +1,30 @@
+import { sendEmail } from "@/lib/resend";
+
+import AbandonedCheckoutEmail from "@/components/emails/abandoned-checkout";
+
+import { CreateUserEmailProps } from "../types";
+
+export const sendAbandonedCheckoutEmail = async (
+  params: CreateUserEmailProps,
+) => {
+  const { name, email } = params.user;
+
+  // Get the first name from the full name
+  const firstName = name ? name.split(" ")[0] : null;
+
+  const emailTemplate = AbandonedCheckoutEmail({
+    name: firstName,
+  });
+
+  try {
+    await sendEmail({
+      to: email as string,
+      subject: "Did something block checkout?",
+      from: "Marc Seitz <marc@papermark.com>",
+      react: emailTemplate,
+      test: process.env.NODE_ENV === "development",
+    });
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/lib/emails/send-upgrade-intent.ts
+++ b/lib/emails/send-upgrade-intent.ts
@@ -1,0 +1,38 @@
+import { sendEmail } from "@/lib/resend";
+
+import UpgradeIntentEmail from "@/components/emails/upgrade-intent";
+
+interface SendUpgradeIntentEmailProps {
+  user: {
+    name: string | null | undefined;
+    email: string | null | undefined;
+  };
+  triggers?: string[];
+}
+
+export const sendUpgradeIntentEmail = async (
+  params: SendUpgradeIntentEmailProps,
+) => {
+  const { name, email } = params.user;
+  const triggers = params.triggers || [];
+
+  // Get the first name from the full name
+  const firstName = name ? name.split(" ")[0] : null;
+
+  const emailTemplate = UpgradeIntentEmail({
+    name: firstName,
+    triggers,
+  });
+
+  try {
+    await sendEmail({
+      to: email as string,
+      subject: "Need help with your upgrade?",
+      from: "Marc Seitz <marc@papermark.com>",
+      react: emailTemplate,
+      test: process.env.NODE_ENV === "development",
+    });
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/pages/api/teams/[teamId]/billing/track-upgrade-click.ts
+++ b/pages/api/teams/[teamId]/billing/track-upgrade-click.ts
@@ -1,0 +1,156 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { waitUntil } from "@vercel/functions";
+import { getServerSession } from "next-auth/next";
+
+import prisma from "@/lib/prisma";
+import { redis } from "@/lib/redis";
+import { sendUpgradeIntentEmailTask } from "@/lib/trigger/send-scheduled-email";
+import { CustomUser } from "@/lib/types";
+
+import { authOptions } from "../../../auth/[...nextauth]";
+
+export const config = {
+  supportsResponseStreaming: true,
+};
+
+const THREE_DAYS_IN_SECONDS = 3 * 24 * 60 * 60;
+const REQUIRED_CLICKS = 3;
+
+export default async function handle(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method === "POST") {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session) {
+      return res.status(401).end("Unauthorized");
+    }
+
+    const { teamId } = req.query as { teamId: string };
+    const { trigger } = req.body as { trigger?: string };
+    const {
+      id: userId,
+      email: userEmail,
+      name: userName,
+    } = session.user as CustomUser;
+
+    // Verify user belongs to team
+    const userTeam = await prisma.userTeam.findFirst({
+      where: {
+        teamId,
+        userId,
+      },
+    });
+
+    if (!userTeam) {
+      return res.status(404).end("Team not found");
+    }
+
+    // Check if team is already on a paid plan
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      select: { plan: true },
+    });
+
+    if (!team) {
+      return res.status(404).end("Team not found");
+    }
+
+    const paidPlans = [
+      "pro",
+      "business",
+      "datarooms",
+      "datarooms-plus",
+      "datarooms-premium",
+    ];
+    const isPaidPlan = paidPlans.some((plan) => team.plan.includes(plan));
+
+    if (isPaidPlan) {
+      // Team already on paid plan, no need to track
+      return res.status(200).json({ tracked: false, reason: "already_paid" });
+    }
+
+    const upgradeClicksKey = `upgrade:clicks:${teamId}`;
+    const upgradeTriggersKey = `upgrade:triggers:${teamId}`;
+    const now = Date.now();
+    const threeDaysAgo = now - THREE_DAYS_IN_SECONDS * 1000;
+
+    // Get existing clicks
+    const existingClicks = await redis.zrange(upgradeClicksKey, 0, -1, {
+      withScores: true,
+    });
+
+    // Filter clicks within the last 3 days
+    const recentClicks: number[] = [];
+    for (let i = 0; i < existingClicks.length; i += 2) {
+      const timestamp = existingClicks[i + 1] as number;
+      if (timestamp > threeDaysAgo) {
+        recentClicks.push(timestamp);
+      }
+    }
+
+    // Add new click
+    await redis.zadd(upgradeClicksKey, { score: now, member: now.toString() });
+
+    // Store the trigger if provided
+    if (trigger) {
+      await redis.sadd(upgradeTriggersKey, trigger);
+      await redis.expire(upgradeTriggersKey, THREE_DAYS_IN_SECONDS);
+    }
+
+    // Remove old clicks (older than 3 days)
+    await redis.zremrangebyscore(upgradeClicksKey, 0, threeDaysAgo);
+
+    // Set expiry on the key (3 days from now)
+    await redis.expire(upgradeClicksKey, THREE_DAYS_IN_SECONDS);
+
+    const totalRecentClicks = recentClicks.length + 1;
+
+    // If this is the 3rd click (or more) within 3 days, schedule the email
+    if (totalRecentClicks >= REQUIRED_CLICKS) {
+      // Check if we already scheduled an email for this session
+      const emailScheduledKey = `upgrade:email-scheduled:${teamId}`;
+      const alreadyScheduled = await redis.get(emailScheduledKey);
+
+      if (!alreadyScheduled) {
+        // Get all triggers the user clicked on
+        const triggers = (await redis.smembers(upgradeTriggersKey)) as string[];
+
+        // Mark as scheduled
+        await redis.set(emailScheduledKey, "1", { ex: THREE_DAYS_IN_SECONDS });
+
+        // Schedule email for 1 day after the last click
+        waitUntil(
+          sendUpgradeIntentEmailTask.trigger(
+            {
+              to: userEmail as string,
+              name: userName as string,
+              teamId,
+              triggers,
+            },
+            {
+              delay: "1d",
+            },
+          ),
+        );
+
+        return res.status(200).json({
+          tracked: true,
+          clicks: totalRecentClicks,
+          triggers,
+          emailScheduled: true,
+        });
+      }
+    }
+
+    return res.status(200).json({
+      tracked: true,
+      clicks: totalRecentClicks,
+      emailScheduled: false,
+    });
+  } else {
+    res.setHeader("Allow", ["POST"]);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}


### PR DESCRIPTION
Here two emails, one after 1h when person was already in checkout, and other after 3 times opened the

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added upgrade click tracking to monitor user engagement with billing upgrades
  * Implemented abandoned checkout reminder emails to re-engage users who initiate the upgrade process
  * Added upgrade intent email notifications triggered by repeated user engagement signals within a timeframe

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->