### PR TITLE
Command enter link saving

### DIFF
--- a/components/links/link-sheet/index.tsx
+++ b/components/links/link-sheet/index.tsx
@@ -1,14 +1,9 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 
-import {
-  Dispatch,
-  SetStateAction,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
+
+import { useHotkeys } from "react-hotkeys-hook";
 
 import { useTeam } from "@/context/team-context";
 import { PlanEnum } from "@/ee/stripe/constants";
@@ -209,26 +204,17 @@ export default function LinkSheet({
   }, [currentLink]);
 
   // Handle Command+Enter (Mac) or Ctrl+Enter (Windows/Linux) to submit the form
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-        event.preventDefault();
-        if (!isSaving && formRef.current) {
-          formRef.current.requestSubmit();
-        }
+  useHotkeys(
+    "mod+enter",
+    (e) => {
+      e.preventDefault();
+      if (!isSaving && formRef.current) {
+        formRef.current.requestSubmit();
       }
     },
+    { enabled: isOpen, enableOnFormTags: true },
     [isSaving],
   );
-
-  useEffect(() => {
-    if (isOpen) {
-      document.addEventListener("keydown", handleKeyDown);
-      return () => {
-        document.removeEventListener("keydown", handleKeyDown);
-      };
-    }
-  }, [isOpen, handleKeyDown]);
 
   const handlePreviewLink = async (link: LinkWithViews) => {
     if (link.domainId && isFree) {

--- a/ee/features/permissions/components/dataroom-link-sheet.tsx
+++ b/ee/features/permissions/components/dataroom-link-sheet.tsx
@@ -1,7 +1,14 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { useTeam } from "@/context/team-context";
 import {
@@ -113,6 +120,7 @@ export function DataroomLinkSheet({
   const [currentPreset, setCurrentPreset] = useState<LinkPreset | null>(null);
   const [showPermissionsSheet, setShowPermissionsSheet] =
     useState<boolean>(false);
+  const formRef = useRef<HTMLFormElement>(null);
   const [pendingLinkData, setPendingLinkData] =
     useState<DEFAULT_LINK_TYPE | null>(null);
   const [showSuccessSheet, setShowSuccessSheet] = useState<boolean>(false);
@@ -139,6 +147,28 @@ export function DataroomLinkSheet({
   useEffect(() => {
     setData(currentLink || DEFAULT_LINK_PROPS(linkType, groupId, !isDatarooms));
   }, [currentLink]);
+
+  // Handle Command+Enter (Mac) or Ctrl+Enter (Windows/Linux) to submit the form
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+        event.preventDefault();
+        if (!isSaving && formRef.current) {
+          formRef.current.requestSubmit();
+        }
+      }
+    },
+    [isSaving],
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => {
+        document.removeEventListener("keydown", handleKeyDown);
+      };
+    }
+  }, [isOpen, handleKeyDown]);
 
   const handlePreviewLink = async (link: LinkWithViews) => {
     if (link.domainId && isFree) {
@@ -695,6 +725,7 @@ export function DataroomLinkSheet({
           </SheetHeader>
 
           <form
+            ref={formRef}
             className="flex grow flex-col"
             onSubmit={(e) => handleSubmit(e, false)}
           >

--- a/ee/features/permissions/components/dataroom-link-sheet.tsx
+++ b/ee/features/permissions/components/dataroom-link-sheet.tsx
@@ -1,14 +1,9 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 
-import {
-  Dispatch,
-  SetStateAction,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
+
+import { useHotkeys } from "react-hotkeys-hook";
 
 import { useTeam } from "@/context/team-context";
 import {
@@ -149,26 +144,17 @@ export function DataroomLinkSheet({
   }, [currentLink]);
 
   // Handle Command+Enter (Mac) or Ctrl+Enter (Windows/Linux) to submit the form
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-        event.preventDefault();
-        if (!isSaving && formRef.current) {
-          formRef.current.requestSubmit();
-        }
+  useHotkeys(
+    "mod+enter",
+    (e) => {
+      e.preventDefault();
+      if (!isSaving && formRef.current) {
+        formRef.current.requestSubmit();
       }
     },
+    { enabled: isOpen, enableOnFormTags: true },
     [isSaving],
   );
-
-  useEffect(() => {
-    if (isOpen) {
-      document.addEventListener("keydown", handleKeyDown);
-      return () => {
-        document.removeEventListener("keydown", handleKeyDown);
-      };
-    }
-  }, [isOpen, handleKeyDown]);
 
   const handlePreviewLink = async (link: LinkWithViews) => {
     if (link.domainId && isFree) {


### PR DESCRIPTION
Add Command+Enter (Ctrl+Enter) as a keyboard shortcut to save/update links in Data Room and document link forms.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1770017689198419?thread_ts=1770017689.198419&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-de87f9fd-22da-5239-9e71-997191ce193f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-de87f9fd-22da-5239-9e71-997191ce193f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut support to link forms. Users can now submit link creation and editing forms using Cmd/Ctrl + Enter, enabling faster form submission workflows across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->