### PR TITLE
Slack app permissions issues

### DIFF
--- a/app/api/integrations/slack/oauth/callback/route.ts
+++ b/app/api/integrations/slack/oauth/callback/route.ts
@@ -97,7 +97,15 @@ export const GET = async (req: Request) => {
       scope: data.scope,
       accessToken: encryptSlackToken(data.access_token),
       tokenType: data.token_type,
-      authUser: data.authed_user,
+      authUser: {
+        id: data.authed_user.id,
+        scope: data.authed_user.scope,
+        // Store user token if available (required for accessing private channels the user is member of)
+        accessToken: data.authed_user.access_token
+          ? encryptSlackToken(data.authed_user.access_token)
+          : undefined,
+        tokenType: data.authed_user.token_type,
+      },
       team: data.team,
     };
 

--- a/lib/integrations/slack/install.ts
+++ b/lib/integrations/slack/install.ts
@@ -4,6 +4,11 @@ import { redis } from "@/lib/redis";
 
 import { getSlackEnv } from "./env";
 
+// User scopes needed for accessing private channels the user is a member of
+// - groups:read: Required to list private channels
+// - channels:read: Required to list public channels (backup in user context)
+const USER_SCOPES = ["groups:read", "channels:read"];
+
 // Get the installation URL for Slack
 export const getSlackInstallationUrl = async (
   teamId: string,
@@ -21,6 +26,14 @@ export const getSlackInstallationUrl = async (
     `${process.env.NEXT_PUBLIC_BASE_URL}/api/integrations/slack/oauth/callback`,
   );
   url.searchParams.set("state", state);
+
+  // Add user_scope to request user-level permissions for private channel access
+  // This allows the app to see private channels the installing user is a member of
+  const existingUserScope = url.searchParams.get("user_scope");
+  const combinedUserScopes = existingUserScope
+    ? [...new Set([...existingUserScope.split(","), ...USER_SCOPES])].join(",")
+    : USER_SCOPES.join(",");
+  url.searchParams.set("user_scope", combinedUserScopes);
 
   return url.toString();
 };

--- a/lib/integrations/slack/types.ts
+++ b/lib/integrations/slack/types.ts
@@ -6,7 +6,12 @@ export type SlackCredential = {
   scope: string;
   accessToken: string;
   tokenType: string;
-  authUser: { id: string };
+  authUser: {
+    id: string;
+    scope?: string;
+    accessToken?: string;
+    tokenType?: string;
+  };
   team: { id: string; name: string };
 };
 

--- a/pages/api/teams/[teamId]/integrations/slack/channels.ts
+++ b/pages/api/teams/[teamId]/integrations/slack/channels.ts
@@ -57,8 +57,11 @@ export default async function handler(
 
       try {
         const slackClient = getSlackClient();
+        const credentials = integration.credentials as SlackCredential;
+        // Pass both bot token and user token (if available) for better private channel visibility
         const channels = await slackClient.getChannels(
-          (integration.credentials as SlackCredential).accessToken,
+          credentials.accessToken,
+          credentials.authUser?.accessToken,
         );
 
         const availableChannels = channels


### PR DESCRIPTION
Fix Slack app installation and private channel visibility for users.

Previously, the Slack app only used bot tokens, which cannot list private channels unless the bot is explicitly invited. The OAuth flow also lacked the necessary user scopes (`groups:read`) to allow the app to see private channels the installing user had access to. This PR updates the OAuth flow to request user scopes and modifies channel fetching to use the user's token for private channels, improving visibility and installation success.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1770173104208899?thread_ts=1770173104.208899&cid=C095YUQAYRJ)

<a href="https://cursor.com/background-agent?bcId=bc-87c3b59b-0756-5179-9825-cce52d943877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87c3b59b-0756-5179-9825-cce52d943877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for accessing private Slack channels in the integration.
  * Enhanced channel selection interface with visual indicators (lock icons) for private channels and setup guidance to enable private channel access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->