### PR TITLE
Slack notifications domain ignore

### DIFF
--- a/lib/integrations/slack/events.ts
+++ b/lib/integrations/slack/events.ts
@@ -12,25 +12,66 @@ export class SlackEventManager {
     this.client = new SlackClient();
   }
 
+  /**
+   * Check if the viewer's email domain is in the team's ignored domains list
+   */
+  private isViewerDomainIgnored(
+    viewerEmail: string | undefined,
+    ignoredDomains: string[] | null,
+  ): boolean {
+    if (!viewerEmail || !ignoredDomains || ignoredDomains.length === 0) {
+      return false;
+    }
+
+    const viewerDomain = viewerEmail.split("@").pop();
+    if (!viewerDomain) {
+      return false;
+    }
+
+    // Normalize ignored domains (remove @ prefix if present)
+    const normalizedIgnoredDomains = ignoredDomains.map((d) =>
+      d.startsWith("@") ? d.substring(1) : d,
+    );
+
+    return normalizedIgnoredDomains.includes(viewerDomain.toLowerCase());
+  }
+
   async processEvent(eventData: SlackEventData): Promise<void> {
     try {
       const env = getSlackEnv();
 
-      const integration = await prisma.installedIntegration.findUnique({
-        where: {
-          teamId_integrationId: {
-            teamId: eventData.teamId,
-            integrationId: env.SLACK_INTEGRATION_ID,
+      // Fetch integration and team's ignored domains in parallel
+      const [integration, team] = await Promise.all([
+        prisma.installedIntegration.findUnique({
+          where: {
+            teamId_integrationId: {
+              teamId: eventData.teamId,
+              integrationId: env.SLACK_INTEGRATION_ID,
+            },
           },
-        },
-        select: {
-          enabled: true,
-          credentials: true,
-          configuration: true,
-        },
-      });
+          select: {
+            enabled: true,
+            credentials: true,
+            configuration: true,
+          },
+        }),
+        prisma.team.findUnique({
+          where: { id: eventData.teamId },
+          select: { ignoredDomains: true },
+        }),
+      ]);
 
       if (!integration || !integration.enabled) {
+        return;
+      }
+
+      // Check if the viewer's email domain is in the ignored domains list
+      if (
+        this.isViewerDomainIgnored(eventData.viewerEmail, team?.ignoredDomains ?? null)
+      ) {
+        console.log(
+          `Slack notification skipped for ignored domain: ${eventData.viewerEmail}`,
+        );
         return;
       }
 

--- a/lib/integrations/slack/events.ts
+++ b/lib/integrations/slack/events.ts
@@ -33,7 +33,7 @@ export class SlackEventManager {
       d.startsWith("@") ? d.substring(1) : d,
     );
 
-    return normalizedIgnoredDomains.includes(viewerDomain.toLowerCase());
+    return normalizedIgnoredDomains.includes(viewerDomain);
   }
 
   async processEvent(eventData: SlackEventData): Promise<void> {
@@ -69,8 +69,10 @@ export class SlackEventManager {
       if (
         this.isViewerDomainIgnored(eventData.viewerEmail, team?.ignoredDomains ?? null)
       ) {
+        // Log only the domain to avoid persisting PII
+        const redactedDomain = eventData.viewerEmail?.split("@").pop() ?? "unknown-domain";
         console.log(
-          `Slack notification skipped for ignored domain: ${eventData.viewerEmail}`,
+          `Slack notification skipped for ignored domain: ${redactedDomain}`,
         );
         return;
       }


### PR DESCRIPTION
Ensure Slack notifications respect the team's ignored domains list to prevent notifications from ignored visitors.

This change aligns Slack notification behavior with existing email notifications, which already filter out visitors from ignored domains, ensuring consistent notification policies across the application.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1770343098425359?thread_ts=1770343098.425359&cid=C095YUQAYRJ)

<p><a href="https://cursor.com/background-agent?bcId=bc-b6f01584-0f65-5b9b-895e-9661c92cd003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6f01584-0f65-5b9b-895e-9661c92cd003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added domain-based filtering to prevent notifications for specified email domains.

* **Performance**
  * Improved efficiency by fetching related data in parallel.

* **Behavior**
  * Notifications are now skipped when a viewer's email domain is configured to be ignored; events are logged with domain information redacted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->