### PR TITLE
Dataroom document renaming

### DIFF
--- a/components/datarooms/dataroom-document-card.tsx
+++ b/components/datarooms/dataroom-document-card.tsx
@@ -8,6 +8,7 @@ import { TeamContextType } from "@/context/team-context";
 import {
   ArchiveXIcon,
   BetweenHorizontalStartIcon,
+  FilePenIcon,
   FileSlidersIcon,
   FolderInputIcon,
   MoreVertical,
@@ -39,6 +40,7 @@ import {
 import { AddToDataroomModal } from "../documents/add-document-to-dataroom-modal";
 import { DocumentPreviewButton } from "../documents/document-preview-button";
 import FileProcessStatusBar from "../documents/file-process-status-bar";
+import { EditDataroomDocumentModal } from "./edit-dataroom-document-modal";
 import { SetUnifiedPermissionsModal } from "./groups/set-unified-permissions-modal";
 import { MoveToDataroomFolderModal } from "./move-dataroom-folder-modal";
 
@@ -74,6 +76,7 @@ export default function DataroomDocumentCard({
   const [isFirstClick, setIsFirstClick] = useState<boolean>(false);
   const [menuOpen, setMenuOpen] = useState<boolean>(false);
   const [moveFolderOpen, setMoveFolderOpen] = useState<boolean>(false);
+  const [renameOpen, setRenameOpen] = useState<boolean>(false);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const [addDataRoomOpen, setAddDataRoomOpen] = useState<boolean>(false);
 
@@ -91,6 +94,14 @@ export default function DataroomDocumentCard({
       });
     }
   }, [moveFolderOpen]);
+
+  useEffect(() => {
+    if (!renameOpen) {
+      setTimeout(() => {
+        document.body.style.pointerEvents = "";
+      });
+    }
+  }, [renameOpen]);
 
   useEffect(() => {
     function handleClickOutside(event: { target: any }) {
@@ -290,6 +301,15 @@ export default function DataroomDocumentCard({
                 <DropdownMenuItem
                   onClick={(e) => {
                     e.stopPropagation();
+                    setRenameOpen(true);
+                  }}
+                >
+                  <FilePenIcon className="mr-2 h-4 w-4" />
+                  Rename
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation();
                     setMoveFolderOpen(true);
                   }}
                 >
@@ -353,6 +373,15 @@ export default function DataroomDocumentCard({
             />
           )}
       </div>
+      {renameOpen ? (
+        <EditDataroomDocumentModal
+          open={renameOpen}
+          setOpen={setRenameOpen}
+          documentId={dataroomDocument.document.id}
+          documentName={dataroomDocument.document.name}
+          dataroomId={dataroomId}
+        />
+      ) : null}
       {addDataRoomOpen ? (
         <AddToDataroomModal
           open={addDataRoomOpen}

--- a/components/datarooms/edit-dataroom-document-modal.tsx
+++ b/components/datarooms/edit-dataroom-document-modal.tsx
@@ -1,0 +1,138 @@
+import { useRouter } from "next/router";
+
+import { useState } from "react";
+
+import { useTeam } from "@/context/team-context";
+import { toast } from "sonner";
+import { mutate } from "swr";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export function EditDataroomDocumentModal({
+  open,
+  setOpen,
+  documentId,
+  documentName,
+  dataroomId,
+}: {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  documentId: string;
+  documentName: string;
+  dataroomId: string;
+}) {
+  const [name, setName] = useState<string>(documentName);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const teamInfo = useTeam();
+  const router = useRouter();
+  const currentFolderPath = router.query.name as string[] | undefined;
+
+  const editDocumentNameSchema = z.object({
+    name: z
+      .string()
+      .min(1, {
+        message: "Please provide a document name.",
+      })
+      .max(255, {
+        message: "Document name is too long.",
+      }),
+  });
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const validation = editDocumentNameSchema.safeParse({ name });
+    if (!validation.success) {
+      return toast.error(validation.error.errors[0].message);
+    }
+
+    setLoading(true);
+
+    try {
+      const response = await fetch(
+        `/api/teams/${teamInfo?.currentTeam?.id}/documents/${documentId}/update-name`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            name: name.trim(),
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        const { error, message } = await response.json();
+        setLoading(false);
+        toast.error(error || message || "Failed to update document name");
+        return;
+      }
+
+      toast.success("Document name updated successfully!");
+
+      // Revalidate the dataroom documents cache
+      mutate(
+        `/api/teams/${teamInfo?.currentTeam?.id}/datarooms/${dataroomId}/documents`,
+      );
+      // Revalidate folder documents if the document is in a folder
+      if (currentFolderPath) {
+        mutate(
+          `/api/teams/${teamInfo?.currentTeam?.id}/datarooms/${dataroomId}/folders/documents/${currentFolderPath.join("/")}`,
+        );
+      }
+      // Revalidate the dataroom folders tree for sidebar
+      mutate(
+        `/api/teams/${teamInfo?.currentTeam?.id}/datarooms/${dataroomId}/folders?tree=true`,
+      );
+    } catch (error) {
+      setLoading(false);
+      toast.error("Error updating document name. Please try again.");
+      return;
+    } finally {
+      setLoading(false);
+      setOpen(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader className="text-start">
+          <DialogTitle>Rename Document</DialogTitle>
+          <DialogDescription>Enter a new document name.</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <Label htmlFor="document-name-update" className="opacity-80">
+            Document Name
+          </Label>
+          <Input
+            id="document-name-update"
+            value={name}
+            placeholder="document-name"
+            className="mb-4 mt-1 w-full"
+            onChange={(e) => setName(e.target.value)}
+          />
+          <DialogFooter>
+            <Button type="submit" className="h-9 w-full" loading={loading}>
+              Update name
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Add the ability to rename dataroom documents via the document card's three-dot menu to provide feature parity with folder renaming.

---
[Slack Thread](https://papermark.slack.com/archives/C095YUQAYRJ/p1770770737755689?thread_ts=1770770737.755689&cid=C095YUQAYRJ)

<p><a href="https://cursor.com/background-agent?bcId=bc-a86036e8-80ac-5ef4-8916-a7fd757499b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a86036e8-80ac-5ef4-8916-a7fd757499b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document Renaming: Added a Rename option to the document action menu within datarooms. Users can now update document names directly with input validation. All changes instantly propagate throughout the dataroom interface, automatically updating folder hierarchies, document lists, and sidebar navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->