### PR TITLE
fix: hide datarooms+ badge on premium

### DIFF
--- a/components/sidebar/app-sidebar.tsx
+++ b/components/sidebar/app-sidebar.tsx
@@ -251,7 +251,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               ) : null}
             </span>
           ) : null}
-          {isDataroomsPlus ? (
+          {isDataroomsPlus && !isDataroomsPremium ? (
             <span className="relative ml-4 inline-flex items-center rounded-full bg-background px-2.5 py-1 text-xs tracking-normal text-foreground ring-1 ring-gray-800">
               Datarooms+
               {isPaused ? (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected badge display logic in the sidebar to prevent the Datarooms+ badge from displaying when the Premium badge is active, ensuring only the relevant badge appears based on your account status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->