### PR TITLE
Dataroom download content

### DIFF
--- a/lib/dataroom/build-folder-hierarchy.ts
+++ b/lib/dataroom/build-folder-hierarchy.ts
@@ -1,0 +1,73 @@
+import slugify from "@sindresorhus/slugify";
+
+export interface FolderInput {
+  id: string;
+  name: string;
+  parentId: string | null;
+}
+
+/**
+ * Builds a map of folder ID -> computed path based on the parentId hierarchy.
+ *
+ * This ensures the download folder structure matches what the UI shows
+ * (which uses parentId to build the tree), rather than relying on the
+ * materialized `path` field which can become stale after renames/moves.
+ *
+ * @param folders - Array of folders with id, name, and parentId
+ * @returns Map of folderId -> computed slugified path (e.g., "/02-company-background/docs")
+ */
+export function buildFolderPathsFromHierarchy(
+  folders: FolderInput[],
+): Map<string, string> {
+  const folderById = new Map(folders.map((f) => [f.id, f]));
+  const pathCache = new Map<string, string>();
+
+  function computePath(folderId: string, visited: Set<string>): string {
+    if (pathCache.has(folderId)) return pathCache.get(folderId)!;
+
+    // Prevent infinite loops from circular parentId references
+    if (visited.has(folderId)) {
+      const folder = folderById.get(folderId);
+      const fallbackPath = `/${slugify(folder?.name ?? folderId)}`;
+      pathCache.set(folderId, fallbackPath);
+      return fallbackPath;
+    }
+    visited.add(folderId);
+
+    const folder = folderById.get(folderId);
+    if (!folder) return "";
+
+    let parentPath = "";
+    if (folder.parentId && folderById.has(folder.parentId)) {
+      parentPath = computePath(folder.parentId, visited);
+    }
+
+    const path = `${parentPath}/${slugify(folder.name)}`;
+    pathCache.set(folderId, path);
+    return path;
+  }
+
+  for (const folder of folders) {
+    computePath(folder.id, new Set());
+  }
+
+  return pathCache;
+}
+
+/**
+ * Builds a folder name map from computed paths.
+ * Maps computedPath -> { name, id } for looking up display names.
+ */
+export function buildFolderNameMap(
+  folders: FolderInput[],
+  pathMap: Map<string, string>,
+): Map<string, { name: string; id: string }> {
+  const nameMap = new Map<string, { name: string; id: string }>();
+  for (const folder of folders) {
+    const computedPath = pathMap.get(folder.id);
+    if (computedPath) {
+      nameMap.set(computedPath, { name: folder.name, id: folder.id });
+    }
+  }
+  return nameMap;
+}

--- a/pages/api/links/download/bulk.ts
+++ b/pages/api/links/download/bulk.ts
@@ -202,22 +202,26 @@ export default async function handle(
         });
       }
 
-      const permittedFolderIds = groupPermissions
-        .filter(
-          (permission) => permission.itemType === ItemType.DATAROOM_FOLDER,
-        )
-        .map((permission) => permission.itemId);
-      const permittedDocumentIds = groupPermissions
-        .filter(
-          (permission) => permission.itemType === ItemType.DATAROOM_DOCUMENT,
-        )
-        .map((permission) => permission.itemId);
+      const permittedFolderIds = new Set(
+        groupPermissions
+          .filter(
+            (permission) => permission.itemType === ItemType.DATAROOM_FOLDER,
+          )
+          .map((permission) => permission.itemId),
+      );
+      const permittedDocumentIds = new Set(
+        groupPermissions
+          .filter(
+            (permission) => permission.itemType === ItemType.DATAROOM_DOCUMENT,
+          )
+          .map((permission) => permission.itemId),
+      );
 
       downloadFolders = downloadFolders.filter((folder) =>
-        permittedFolderIds.includes(folder.id),
+        permittedFolderIds.has(folder.id),
       );
       downloadDocuments = downloadDocuments.filter((doc) =>
-        permittedDocumentIds.includes(doc.id),
+        permittedDocumentIds.has(doc.id),
       );
     }
 

--- a/pages/api/links/download/bulk.ts
+++ b/pages/api/links/download/bulk.ts
@@ -353,13 +353,21 @@ export default async function handle(
         );
       });
 
+    // Pre-index documents by folderId for O(1) lookup per folder
+    const docsByFolderId = new Map<string, typeof downloadDocuments>();
+    for (const doc of downloadDocuments) {
+      if (!doc.folderId) continue;
+      const list = docsByFolderId.get(doc.folderId) ?? [];
+      list.push(doc);
+      docsByFolderId.set(doc.folderId, list);
+    }
+
     // Add documents in folders
     downloadFolders.forEach((folder) => {
       // Use the computed path from parentId hierarchy instead of the stored path
       const folderPath = computedPathMap.get(folder.id) ?? folder.path;
 
-      const folderDocs = downloadDocuments
-        .filter((doc) => doc.folderId === folder.id)
+      const folderDocs = (docsByFolderId.get(folder.id) ?? [])
         .filter((doc) => doc.document.versions[0].type !== "notion")
         .filter(
           (doc) => doc.document.versions[0].storageType !== "VERCEL_BLOB",

--- a/pages/api/links/download/dataroom-folder.ts
+++ b/pages/api/links/download/dataroom-folder.ts
@@ -201,22 +201,26 @@ export default async function handler(
         });
       }
 
-      const permittedFolderIds = groupPermissions
-        .filter(
-          (permission) => permission.itemType === ItemType.DATAROOM_FOLDER,
-        )
-        .map((permission) => permission.itemId);
-      const permittedDocumentIds = groupPermissions
-        .filter(
-          (permission) => permission.itemType === ItemType.DATAROOM_DOCUMENT,
-        )
-        .map((permission) => permission.itemId);
+      const permittedFolderIds = new Set(
+        groupPermissions
+          .filter(
+            (permission) => permission.itemType === ItemType.DATAROOM_FOLDER,
+          )
+          .map((permission) => permission.itemId),
+      );
+      const permittedDocumentIds = new Set(
+        groupPermissions
+          .filter(
+            (permission) => permission.itemType === ItemType.DATAROOM_DOCUMENT,
+          )
+          .map((permission) => permission.itemId),
+      );
 
       allFolders = allFolders.filter((folder) =>
-        permittedFolderIds.includes(folder.id),
+        permittedFolderIds.has(folder.id),
       );
       allDocuments = allDocuments.filter((doc) =>
-        permittedDocumentIds.includes(doc.id),
+        permittedDocumentIds.has(doc.id),
       );
     }
 

--- a/pages/api/links/download/dataroom-folder.ts
+++ b/pages/api/links/download/dataroom-folder.ts
@@ -297,9 +297,18 @@ export default async function handler(
 
     const rootFolderInfo = { name: rootFolder.name, computedPath: computedRootPath };
 
+    // Pre-index documents by folderId for O(1) lookup per folder
+    const docsByFolderId = new Map<string, typeof allDocuments>();
+    for (const doc of allDocuments) {
+      if (!doc.folderId) continue;
+      const list = docsByFolderId.get(doc.folderId) ?? [];
+      list.push(doc);
+      docsByFolderId.set(doc.folderId, list);
+    }
+
     for (const folder of allFolders) {
       const folderPath = computedPathMap.get(folder.id) ?? folder.path;
-      const docs = allDocuments.filter((doc) => doc.folderId === folder.id);
+      const docs = docsByFolderId.get(folder.id) ?? [];
 
       if (docs.length === 0) {
         addFileToStructure(


### PR DESCRIPTION
Fix dataroom downloads to prevent "ghost" folders by building the folder hierarchy from `parentId` instead of the stale `path` field.

The download process was using the `path` field (a slugified materialized path) to construct folder structures, which could become stale after folder renames or moves. This led to discrepancies where folders that no longer existed in the actual dataroom hierarchy (which is based on `parentId`) would still appear in the downloaded ZIP. This PR introduces a shared utility to compute folder paths dynamically from the `parentId` chain, ensuring the downloaded structure consistently matches what users see in the UI.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-9249a268-a393-450b-bbcd-d537bf6a8982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9249a268-a393-450b-bbcd-d537bf6a8982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic folder path computation from parent/child relationships for robust hierarchy handling.
  * Utilities to collect descendant folders and map folder names/paths for downstream features.

* **Improvements**
  * Bulk downloads and exports use computed paths, producing correct nested structures and including all descendants.
  * Folder rename operations update descendant paths atomically to avoid inconsistencies.

* **Bug Fixes**
  * Cycle detection and missing-folder handling added to path computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->