### PR TITLE
Dataroom root document visibility

### DIFF
--- a/pages/api/teams/[teamId]/datarooms/[id]/apply-permissions.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/apply-permissions.ts
@@ -145,6 +145,53 @@ async function applyPermissionStrategy(
   }
 }
 
+/**
+ * Given a list of access control entries (itemId + itemType), batch-queries
+ * the referenced DataroomFolders and DataroomDocuments to find which ones
+ * are non-root (folder.parentId !== null or document.folderId !== null).
+ * Returns the set of non-root itemIds.
+ */
+async function getNonRootItemIds(
+  accessControls: { itemId: string; itemType: ItemType }[],
+): Promise<Set<string>> {
+  if (accessControls.length === 0) return new Set();
+
+  const folderItemIds = [
+    ...new Set(
+      accessControls
+        .filter((ac) => ac.itemType === ItemType.DATAROOM_FOLDER)
+        .map((ac) => ac.itemId),
+    ),
+  ];
+  const documentItemIds = [
+    ...new Set(
+      accessControls
+        .filter((ac) => ac.itemType === ItemType.DATAROOM_DOCUMENT)
+        .map((ac) => ac.itemId),
+    ),
+  ];
+
+  const [nonRootFolders, nonRootDocuments] = await Promise.all([
+    folderItemIds.length > 0
+      ? prisma.dataroomFolder.findMany({
+          where: { id: { in: folderItemIds }, parentId: { not: null } },
+          select: { id: true },
+        })
+      : Promise.resolve([]),
+    documentItemIds.length > 0
+      ? prisma.dataroomDocument.findMany({
+          where: { id: { in: documentItemIds }, folderId: { not: null } },
+          select: { id: true },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  return new Set([
+    ...nonRootFolders.map((f) => f.id),
+    ...nonRootDocuments.map((d) => d.id),
+  ]);
+}
+
 async function applyRootLevelPermissions(
   dataroomId: string,
   dataroomDocuments: {
@@ -153,33 +200,52 @@ async function applyRootLevelPermissions(
     folderId: string | null;
   }[],
 ) {
-  // Get both ViewerGroups and PermissionGroups along with their existing access control counts.
-  // Groups that already have granular permissions configured should NOT automatically
-  // receive access to new root-level items, since the admin has intentionally curated
-  // what those groups can see.
+  // Fetch groups together with their existing access controls so we can
+  // distinguish "admin-curated granular" groups from groups that only have
+  // previously auto-granted root-level permissions.
   const [viewerGroups, permissionGroups] = await Promise.all([
     prisma.viewerGroup.findMany({
       where: { dataroomId },
       select: {
         id: true,
-        _count: { select: { accessControls: true } },
+        accessControls: {
+          select: { itemId: true, itemType: true },
+        },
       },
     }),
     prisma.permissionGroup.findMany({
       where: { dataroomId },
       select: {
         id: true,
-        _count: { select: { accessControls: true } },
+        accessControls: {
+          select: { itemId: true, itemType: true },
+        },
       },
     }),
   ]);
 
+  // Collect every access-control entry across all groups and resolve which
+  // referenced items live inside a subfolder (non-root).
+  const allAccessControls = [
+    ...viewerGroups.flatMap((g) => g.accessControls),
+    ...permissionGroups.flatMap((g) => g.accessControls),
+  ];
+  const nonRootItemIds = await getNonRootItemIds(allAccessControls);
+
+  // A group is considered admin-curated when it has at least one access
+  // control pointing at a non-root item (subfolder or document inside a
+  // folder). Groups that only have root-level access controls were
+  // auto-granted and should continue to receive new root auto-grants.
+  const hasCuratedPermissions = (
+    acs: { itemId: string; itemType: ItemType }[],
+  ) => acs.some((ac) => nonRootItemIds.has(ac.itemId));
+
   const viewerGroupPermissionsToCreate: any[] = [];
   const permissionGroupPermissionsToCreate: any[] = [];
 
-  // ViewerGroup permissions - only groups without existing granular permissions get auto-access
+  // ViewerGroup permissions – skip groups with admin-curated non-root access
   viewerGroups
-    .filter((group) => group._count.accessControls === 0)
+    .filter((group) => !hasCuratedPermissions(group.accessControls))
     .forEach((group) => {
       dataroomDocuments.forEach((doc) => {
         viewerGroupPermissionsToCreate.push({
@@ -192,9 +258,9 @@ async function applyRootLevelPermissions(
       });
     });
 
-  // PermissionGroup permissions - only groups without existing granular permissions get auto-access
+  // PermissionGroup permissions – skip groups with admin-curated non-root access
   permissionGroups
-    .filter((group) => group._count.accessControls === 0)
+    .filter((group) => !hasCuratedPermissions(group.accessControls))
     .forEach((group) => {
       dataroomDocuments.forEach((doc) => {
         permissionGroupPermissionsToCreate.push({
@@ -210,7 +276,6 @@ async function applyRootLevelPermissions(
 
   // Apply permissions in a transaction
   await prisma.$transaction(async (tx) => {
-    // Create new permissions
     if (viewerGroupPermissionsToCreate.length > 0) {
       await tx.viewerGroupAccessControls.createMany({
         data: viewerGroupPermissionsToCreate,

--- a/pages/api/teams/[teamId]/datarooms/[id]/folders/index.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/folders/index.ts
@@ -21,11 +21,60 @@ async function applyFolderPermissions(
   }
 }
 
+/**
+ * Given a list of access control entries (itemId + itemType), batch-queries
+ * the referenced DataroomFolders and DataroomDocuments to find which ones
+ * are non-root (folder.parentId !== null or document.folderId !== null).
+ * Returns the set of non-root itemIds.
+ */
+async function getNonRootItemIds(
+  accessControls: { itemId: string; itemType: ItemType }[],
+): Promise<Set<string>> {
+  if (accessControls.length === 0) return new Set();
+
+  const folderItemIds = [
+    ...new Set(
+      accessControls
+        .filter((ac) => ac.itemType === ItemType.DATAROOM_FOLDER)
+        .map((ac) => ac.itemId),
+    ),
+  ];
+  const documentItemIds = [
+    ...new Set(
+      accessControls
+        .filter((ac) => ac.itemType === ItemType.DATAROOM_DOCUMENT)
+        .map((ac) => ac.itemId),
+    ),
+  ];
+
+  const [nonRootFolders, nonRootDocuments] = await Promise.all([
+    folderItemIds.length > 0
+      ? prisma.dataroomFolder.findMany({
+          where: { id: { in: folderItemIds }, parentId: { not: null } },
+          select: { id: true },
+        })
+      : Promise.resolve([]),
+    documentItemIds.length > 0
+      ? prisma.dataroomDocument.findMany({
+          where: { id: { in: documentItemIds }, folderId: { not: null } },
+          select: { id: true },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  return new Set([
+    ...nonRootFolders.map((f) => f.id),
+    ...nonRootDocuments.map((d) => d.id),
+  ]);
+}
+
 async function applyDefaultFolderPermissions(
   dataroomId: string,
   folderId: string,
   folderPath?: string,
 ) {
+  // Fetch groups with their access controls so we can distinguish
+  // admin-curated groups from groups with only auto-granted root permissions.
   const [dataroom, viewerGroups, permissionGroups] = await Promise.all([
     prisma.dataroom.findUnique({
       where: { id: dataroomId },
@@ -38,7 +87,9 @@ async function applyDefaultFolderPermissions(
       where: { dataroomId },
       select: {
         id: true,
-        _count: { select: { accessControls: true } },
+        accessControls: {
+          select: { itemId: true, itemType: true },
+        },
       },
     }),
     prisma.permissionGroup.findMany({
@@ -46,7 +97,9 @@ async function applyDefaultFolderPermissions(
       select: {
         id: true,
         name: true,
-        _count: { select: { accessControls: true } },
+        accessControls: {
+          select: { itemId: true, itemType: true },
+        },
       },
     }),
   ]);
@@ -63,10 +116,23 @@ async function applyDefaultFolderPermissions(
     return;
   }
 
-  // Fallback to default behavior (for root folders or non-inherit strategies)
-  // Groups that already have granular permissions configured should NOT automatically
-  // receive access to new root-level folders, since the admin has intentionally curated
-  // what those groups can see.
+  // Resolve which existing access-control items are non-root so we can tell
+  // apart admin-curated groups from groups that only received prior
+  // auto-granted root-level permissions.
+  const allAccessControls = [
+    ...viewerGroups.flatMap((g) => g.accessControls),
+    ...permissionGroups.flatMap((g) => g.accessControls),
+  ];
+  const nonRootItemIds = await getNonRootItemIds(allAccessControls);
+
+  const hasCuratedPermissions = (
+    acs: { itemId: string; itemType: ItemType }[],
+  ) => acs.some((ac) => nonRootItemIds.has(ac.itemId));
+
+  // Fallback to default behavior (for root folders or non-inherit strategies).
+  // Groups with admin-curated non-root permissions are excluded – new root
+  // folders should not be auto-granted to groups the admin intentionally
+  // restricted to specific subfolders.
   const allPermissionGroupData: {
     groupId: string;
     itemId: string;
@@ -82,7 +148,7 @@ async function applyDefaultFolderPermissions(
       DefaultPermissionStrategy.INHERIT_FROM_PARENT
     ) {
       permissionGroups
-        .filter((group) => group._count.accessControls === 0)
+        .filter((group) => !hasCuratedPermissions(group.accessControls))
         .forEach((group) => {
           allPermissionGroupData.push({
             groupId: group.id,
@@ -97,9 +163,9 @@ async function applyDefaultFolderPermissions(
     // For other strategies (ASK_EVERY_TIME, HIDDEN_BY_DEFAULT), don't auto-create permissions
   }
 
-  // Only auto-grant root folder access to viewer groups that don't have existing granular permissions
+  // Only auto-grant root folder access to viewer groups without curated non-root permissions
   const viewerGroupData = viewerGroups
-    .filter((group) => group._count.accessControls === 0)
+    .filter((group) => !hasCuratedPermissions(group.accessControls))
     .map((group) => ({
       groupId: group.id,
       itemId: folderId,


### PR DESCRIPTION
Prevent granular permission groups from automatically gaining access to new root-level documents and folders to maintain intended access restrictions.

When a dataroom uses the `INHERIT_FROM_PARENT` strategy, new root-level documents and folders were being automatically granted view access to *all* permission groups. This incorrectly exposed these new items to groups that were specifically configured with granular permissions (e.g., only access to a single subfolder), thereby breaking the intended access control. This change ensures that groups with existing granular access controls are skipped during the auto-permission assignment for new root items.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-7f1c3c46-54db-4b68-a877-2e1d2e6f3a0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f1c3c46-54db-4b68-a877-2e1d2e6f3a0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-assigned root permissions no longer override existing curated non-root access controls; preserves custom group permissions.

* **New Features**
  * Added non-root awareness to permission logic so only groups without curated non-root permissions receive new root-level grants.
  * Improved detection of curated groups by examining folder/document access controls before applying defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->