### PR TITLE
Visitor link download failure

### DIFF
--- a/components/view/dataroom/document-card.tsx
+++ b/components/view/dataroom/document-card.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 
 import { timeAgo } from "@/lib/utils";
 import { cn } from "@/lib/utils";
+import { triggerBlobDownload } from "@/lib/utils/trigger-download";
 import { fileIcon } from "@/lib/utils/get-file-icon";
 import {
   HIERARCHICAL_DISPLAY_STYLE,
@@ -151,27 +152,16 @@ export default function DocumentCard({
         return "File downloaded successfully";
       }
 
-      // For all other files, use the iframe method
+      // For all other files, fetch as blob for reliable cross-browser download
       if (contentType?.includes("application/json")) {
         const data = await response.json();
-        const downloadUrl = data.isDirectDownload
-          ? data.downloadUrl
-          : response.url;
 
-        // Create a hidden iframe for download
-        const iframe = window.document.createElement("iframe");
-        iframe.style.display = "none";
-        window.document.body.appendChild(iframe);
-        iframe.src = downloadUrl;
+        await triggerBlobDownload(
+          data.downloadUrl,
+          data.fileName || document.name,
+        );
 
-        // Clean up the iframe after a delay
-        setTimeout(() => {
-          if (iframe && iframe.parentNode) {
-            window.document.body.removeChild(iframe);
-          }
-        }, 5000);
-
-        return "Download started";
+        return "File downloaded successfully";
       }
 
       throw new Error("Unexpected response format");

--- a/components/view/nav.tsx
+++ b/components/view/nav.tsx
@@ -18,6 +18,7 @@ import {
 import { toast } from "sonner";
 
 import { determineTextColor } from "@/lib/utils/determine-text-color";
+import { triggerBlobDownload } from "@/lib/utils/trigger-download";
 
 import {
   DropdownMenu,
@@ -179,17 +180,12 @@ export default function Nav({
         }, 100);
       } else {
         // Handle JSON response with downloadUrl (non-watermarked files)
-        const { downloadUrl } = await response.json();
+        const { downloadUrl, fileName } = await response.json();
 
-        const link = document.createElement("a");
-        link.href = downloadUrl;
-        link.rel = "noopener noreferrer";
-        document.body.appendChild(link);
-        link.click();
-
-        setTimeout(() => {
-          document.body.removeChild(link);
-        }, 100);
+        await triggerBlobDownload(
+          downloadUrl,
+          fileName || "document",
+        );
       }
 
       return "File downloaded successfully";

--- a/components/view/viewer/download-only-viewer.tsx
+++ b/components/view/viewer/download-only-viewer.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 
 import { useSafePageViewTracker } from "@/lib/tracking/safe-page-view-tracker";
 import { getTrackingOptions } from "@/lib/tracking/tracking-config";
+import { triggerBlobDownload } from "@/lib/utils/trigger-download";
 
 import { Button } from "@/components/ui/button";
 
@@ -233,8 +234,12 @@ export default function DownloadOnlyViewer({
         }, 100);
       } else {
         // Handle JSON response with downloadUrl (non-watermarked files)
-        const { downloadUrl } = await response.json();
-        window.open(downloadUrl, "_blank");
+        const { downloadUrl, fileName } = await response.json();
+
+        await triggerBlobDownload(
+          downloadUrl,
+          fileName || documentName || "document",
+        );
       }
 
       return "File downloaded successfully";

--- a/lib/utils/trigger-download.ts
+++ b/lib/utils/trigger-download.ts
@@ -1,0 +1,40 @@
+/**
+ * Triggers a reliable file download that works across all browsers,
+ * including iOS Safari, Chrome, and Brave.
+ *
+ * The standard approach of creating an <a> element and calling click()
+ * with a cross-origin URL fails on many browsers (especially mobile)
+ * because:
+ * 1. The `download` attribute is ignored for cross-origin URLs
+ * 2. `window.open()` is blocked by popup blockers in async callbacks
+ * 3. iOS WebKit requires user activation for navigation, which expires
+ *    after an async operation like fetch()
+ *
+ * This utility fetches the file as a blob and creates a same-origin
+ * blob URL, which always respects the `download` attribute.
+ */
+export async function triggerBlobDownload(
+  url: string,
+  fileName: string,
+): Promise<void> {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch file: ${response.statusText}`);
+  }
+
+  const blob = await response.blob();
+  const blobUrl = URL.createObjectURL(blob);
+
+  const link = document.createElement("a");
+  link.href = blobUrl;
+  link.download = fileName;
+  link.rel = "noopener noreferrer";
+  document.body.appendChild(link);
+  link.click();
+
+  setTimeout(() => {
+    URL.revokeObjectURL(blobUrl);
+    document.body.removeChild(link);
+  }, 100);
+}

--- a/pages/api/links/download/index.ts
+++ b/pages/api/links/download/index.ts
@@ -209,7 +209,9 @@ export default async function handle(
         return res.send(Buffer.from(pdfBuffer));
       }
 
-      return res.status(200).json({ downloadUrl });
+      return res
+        .status(200)
+        .json({ downloadUrl, fileName: view.document!.name });
     } catch (error) {
       return res.status(500).json({
         message: "Internal Server Error",


### PR DESCRIPTION
Fixes silent failure of file downloads on visitor links by implementing a robust blob-based download method.

Previous download methods (`a.click()` on cross-origin URLs without a `download` attribute and `window.open()` from async callbacks) failed silently across various browsers (Chrome, Brave, iOS/iPad) due to security restrictions and loss of user gesture context. The new approach fetches the file as a blob, creates a same-origin blob URL, and uses an `<a>` element with the `download` attribute, which reliably triggers downloads. The API was also updated to return the `fileName` for correct file naming.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ebdae8b5-5e61-48de-942b-0ee9f75faccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ebdae8b5-5e61-48de-942b-0ee9f75faccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file download reliability and cross-browser compatibility for documents.
  * Enhanced download functionality consistency throughout the application's document viewing areas.
  * File names are now properly preserved during all download operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->