### PR TITLE
Link allow list email update

### DIFF
--- a/components/links/link-sheet/allow-list-section.tsx
+++ b/components/links/link-sheet/allow-list-section.tsx
@@ -41,14 +41,14 @@ export default function AllowListSection({
   );
 
   useEffect(() => {
-    // Update the allowList in the data state when their inputs change
-    const newAllowList = sanitizeList(allowListInput);
-    setEnabled((prevEnabled) => prevEnabled && emailProtected);
-    setData((prevData) => ({
-      ...prevData,
-      allowList: emailProtected && enabled ? newAllowList : [],
-    }));
-  }, [allowListInput, emailProtected, enabled, setData]);
+    if (!emailProtected && enabled) {
+      setEnabled(false);
+      setData((prevData) => ({
+        ...prevData,
+        allowList: [],
+      }));
+    }
+  }, [emailProtected, enabled, setData]);
 
   useEffect(() => {
     if (isAllowed && presets?.allowList && presets.allowList.length > 0) {
@@ -79,7 +79,15 @@ export default function AllowListSection({
   const handleAllowListChange = (
     event: React.ChangeEvent<HTMLTextAreaElement>,
   ) => {
-    setAllowListInput(event.target.value);
+    const updatedAllowListInput = event.target.value;
+    setAllowListInput(updatedAllowListInput);
+
+    if (emailProtected && enabled) {
+      setData((prevData) => ({
+        ...prevData,
+        allowList: sanitizeList(updatedAllowListInput),
+      }));
+    }
   };
 
   return (

--- a/components/links/link-sheet/deny-list-section.tsx
+++ b/components/links/link-sheet/deny-list-section.tsx
@@ -40,14 +40,14 @@ export default function DenyListSection({
   );
 
   useEffect(() => {
-    // Update the denyList in the data state when their inputs change
-    const newDenyList = sanitizeList(denyListInput);
-    setEnabled((prevEnabled) => prevEnabled && emailProtected);
-    setData((prevData) => ({
-      ...prevData,
-      denyList: emailProtected && enabled ? newDenyList : [],
-    }));
-  }, [denyListInput, enabled, emailProtected, setData]);
+    if (!emailProtected && enabled) {
+      setEnabled(false);
+      setData((prevData) => ({
+        ...prevData,
+        denyList: [],
+      }));
+    }
+  }, [emailProtected, enabled, setData]);
 
   useEffect(() => {
     if (isAllowed && presets?.denyList && presets.denyList.length > 0) {
@@ -78,7 +78,15 @@ export default function DenyListSection({
   const handleDenyListChange = (
     event: React.ChangeEvent<HTMLTextAreaElement>,
   ) => {
-    setDenyListInput(event.target.value);
+    const updatedDenyListInput = event.target.value;
+    setDenyListInput(updatedDenyListInput);
+
+    if (emailProtected && enabled) {
+      setData((prevData) => ({
+        ...prevData,
+        denyList: sanitizeList(updatedDenyListInput),
+      }));
+    }
   };
 
   return (

--- a/components/links/link-sheet/link-options.tsx
+++ b/components/links/link-sheet/link-options.tsx
@@ -146,6 +146,7 @@ export const LinkOptions = ({
       {data.audienceType === LinkAudienceType.GENERAL ? (
         <>
           <AllowListSection
+            key={`allow-list-${data.id ?? "new"}`}
             {...{ data, setData }}
             isAllowed={
               isTrial ||
@@ -158,6 +159,7 @@ export const LinkOptions = ({
             presets={currentPreset}
           />
           <DenyListSection
+            key={`deny-list-${data.id ?? "new"}`}
             {...{ data, setData }}
             isAllowed={
               isTrial ||


### PR DESCRIPTION
Fixes a bug where changes to allow/deny lists on existing links were not saved.

The allow/deny list textareas updated local state first, then synced to the parent via `useEffect`. This could lead to stale data being sent if the user clicked "Update Link" quickly. Additionally, the allow/deny list sections did not reliably rehydrate local state when switching between existing links, causing them to display outdated information.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-1102ac8f-afe5-4a8c-bdcb-483cc0a372c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1102ac8f-afe5-4a8c-bdcb-483cc0a372c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed allow-list and deny-list synchronization to only update when email protection is enabled, preventing unintended data retention when the feature is disabled.
  * Improved component stability during email protection setting transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->