### PR TITLE
Domain validation data leak

### DIFF
--- a/components/domains/add-domain-modal.tsx
+++ b/components/domains/add-domain-modal.tsx
@@ -43,7 +43,6 @@ const sanitizeDomain = (value: string) =>
 
 type DomainStatus =
   | "checking"
-  | "conflict"
   | "has site"
   | "available"
   | "idle"
@@ -67,11 +66,6 @@ const STATUS_CONFIG: Record<
     suffix: "...",
     icon: LoadingSpinner,
     className: "bg-neutral-100 text-neutral-500",
-  },
-  conflict: {
-    suffix: "is already in use.",
-    icon: AlertTriangleIcon,
-    className: "bg-rose-100 text-rose-600",
   },
   "has site": {
     suffix:
@@ -180,7 +174,7 @@ export function AddDomainModal({
         const nextStatus = data?.status as DomainStatus | undefined;
         if (
           nextStatus &&
-          ["invalid", "conflict", "has site", "available"].includes(nextStatus)
+          ["invalid", "has site", "available"].includes(nextStatus)
         ) {
           setDomainStatus(nextStatus);
         } else {
@@ -354,7 +348,7 @@ export function AddDomainModal({
                 </div>
                 <div className="flex items-center justify-between gap-4 p-2 text-sm">
                   <p>
-                    {["checking", "conflict", "has site", "available"].includes(
+                    {["checking", "has site", "available"].includes(
                       domainStatus,
                     ) ? (
                       <>

--- a/pages/api/teams/[teamId]/domains/[domain]/validate.ts
+++ b/pages/api/teams/[teamId]/domains/[domain]/validate.ts
@@ -13,7 +13,6 @@ import { authOptions } from "../../../../auth/[...nextauth]";
 
 type DomainValidationStatus =
   | "invalid"
-  | "conflict"
   | "has site"
   | "available";
 
@@ -74,8 +73,10 @@ export default async function handle(
     });
 
     if (existingDomain) {
+      // Return "has site" instead of "conflict" to avoid leaking information
+      // about which domains are already registered on Papermark
       return res.status(200).json({
-        status: "conflict" as DomainValidationStatus,
+        status: "has site" as DomainValidationStatus,
       });
     }
 

--- a/pages/api/teams/[teamId]/domains/[domain]/validate.ts
+++ b/pages/api/teams/[teamId]/domains/[domain]/validate.ts
@@ -73,8 +73,6 @@ export default async function handle(
     });
 
     if (existingDomain) {
-      // Return "has site" instead of "conflict" to avoid leaking information
-      // about which domains are already registered on Papermark
       return res.status(200).json({
         status: "has site" as DomainValidationStatus,
       });

--- a/pages/api/teams/[teamId]/domains/index.ts
+++ b/pages/api/teams/[teamId]/domains/index.ts
@@ -99,7 +99,9 @@ export default async function handle(
       });
 
       if (existingDomain) {
-        return res.status(400).json({ message: "Domain already exists" });
+        return res
+          .status(400)
+          .json({ message: "Unable to add this domain. Please try a different one." });
       }
 
       const response = await prisma.domain.create({


### PR DESCRIPTION
Prevent data leakage by showing a generic message when a domain is already registered by another account on Papermark.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f230a138-cbbe-4dfd-8d05-c1fbfb4be9a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f230a138-cbbe-4dfd-8d05-c1fbfb4be9a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the redundant "conflict" domain status to simplify validation and display
  * Existing domains now report as "has site" instead of "conflict"
  * Clarified the error message shown when attempting to add a duplicate domain
<!-- end of auto-generated comment: release notes by coderabbit.ai -->