### PR TITLE
Dataroom viewer background color

### DIFF
--- a/components/datarooms/folders/view-tree.tsx
+++ b/components/datarooms/folders/view-tree.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
 
 import { memo, useMemo } from "react";
+import type { CSSProperties } from "react";
 
 import { DataroomFolder } from "@prisma/client";
 import { HomeIcon } from "lucide-react";
@@ -12,6 +13,7 @@ import {
 } from "@/lib/utils/hierarchical-display";
 
 import { FileTree } from "@/components/ui/nextra-filetree";
+import { useViewerSurfaceTheme } from "@/components/view/viewer/viewer-surface-theme";
 
 import { buildNestedFolderStructureWithDocs } from "./utils";
 
@@ -182,15 +184,31 @@ const HomeLink = memo(
     folderId: string | null;
     setFolderId: React.Dispatch<React.SetStateAction<string | null>>;
   }) => {
+    const { usesLightText, palette } = useViewerSurfaceTheme();
+
     return (
       <li
         className={cn(
           "flex list-none",
-          "rounded-md text-foreground transition-all duration-200 ease-in-out",
-          "hover:bg-gray-100 hover:shadow-sm hover:dark:bg-muted",
+          "rounded-md transition-all duration-200 ease-in-out",
+          usesLightText
+            ? "text-[var(--viewer-text)] hover:bg-[var(--viewer-control-bg)]"
+            : "text-foreground hover:bg-gray-100 hover:shadow-sm hover:dark:bg-muted",
           "px-3 py-1.5 leading-6",
-          folderId === null && "bg-gray-100 font-semibold dark:bg-muted",
+          folderId === null &&
+            (usesLightText
+              ? "bg-[var(--viewer-panel-active)] font-semibold"
+              : "bg-gray-100 font-semibold dark:bg-muted"),
         )}
+        style={
+          usesLightText
+            ? ({
+                "--viewer-text": palette.textColor,
+                "--viewer-control-bg": palette.controlBgColor,
+                "--viewer-panel-active": palette.panelActiveBgColor,
+              } as CSSProperties)
+            : undefined
+        }
       >
         <span
           className="inline-flex w-full cursor-pointer items-center"
@@ -223,6 +241,8 @@ const SidebarFolders = ({
   setFolderId: React.Dispatch<React.SetStateAction<string | null>>;
   dataroomIndexEnabled?: boolean;
 }) => {
+  const { usesLightText, palette } = useViewerSurfaceTheme();
+
   const nestedFolders = useMemo(() => {
     if (folders) {
       return buildNestedFolderStructureWithDocs(folders, documents);
@@ -243,10 +263,22 @@ const SidebarFolders = ({
     }
 
     return null;
-  }, [folders, documents, folderId]);
+  }, [nestedFolders, folderId]);
 
   return (
-    <FileTree>
+    <FileTree
+      prefersLightText={usesLightText}
+      style={
+        usesLightText
+          ? ({
+              "--viewer-text": palette.textColor,
+              "--viewer-muted-text": palette.mutedTextColor,
+              "--viewer-control-bg": palette.controlBgColor,
+              "--viewer-panel-active": palette.panelActiveBgColor,
+            } as CSSProperties)
+          : undefined
+      }
+    >
       <HomeLink folderId={folderId} setFolderId={setFolderId} />
       {nestedFolders.map((folder) => (
         <FolderComponent

--- a/components/shared/icons/eye-off.tsx
+++ b/components/shared/icons/eye-off.tsx
@@ -1,4 +1,9 @@
-export default function EyeOff({ className }: { className?: string }) {
+import type { SVGProps } from "react";
+
+export default function EyeOff({
+  className,
+  ...props
+}: SVGProps<SVGSVGElement>) {
   return (
     <svg
       width="14"
@@ -11,6 +16,7 @@ export default function EyeOff({ className }: { className?: string }) {
       strokeLinejoin="round"
       shapeRendering="geometricPrecision"
       className={className}
+      {...props}
     >
       <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
       <path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68" />

--- a/components/shared/icons/eye.tsx
+++ b/components/shared/icons/eye.tsx
@@ -1,4 +1,6 @@
-export default function Eye({ className }: { className?: string }) {
+import type { SVGProps } from "react";
+
+export default function Eye({ className, ...props }: SVGProps<SVGSVGElement>) {
   return (
     <svg
       width="14"
@@ -11,6 +13,7 @@ export default function Eye({ className }: { className?: string }) {
       strokeLinejoin="round"
       shapeRendering="geometricPrecision"
       className={className}
+      {...props}
     >
       <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
       <circle cx="12" cy="12" r="3" />

--- a/components/ui/input-otp.tsx
+++ b/components/ui/input-otp.tsx
@@ -4,7 +4,7 @@ import { OTPInput, OTPInputContext } from "input-otp";
 import { Dot } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { determineTextColor } from "@/lib/utils/determine-text-color";
+import { createAdaptiveSurfacePalette } from "@/lib/utils/create-adaptive-surface-palette";
 
 // Create a context to pass accentColor to InputOTPSlot components
 const AccentColorContext = React.createContext<string | null | undefined>(
@@ -50,7 +50,8 @@ const InputOTPSlot = React.forwardRef<
   const inputOTPContext = React.useContext(OTPInputContext);
   const { char, hasFakeCaret, isActive } = inputOTPContext.slots[index];
   const accentColor = React.useContext(AccentColorContext);
-  const textColor = determineTextColor(accentColor);
+  const otpPalette = createAdaptiveSurfacePalette(accentColor);
+  const textColor = otpPalette.textColor;
 
   return (
     <div

--- a/components/ui/nextra-filetree.tsx
+++ b/components/ui/nextra-filetree.tsx
@@ -6,6 +6,7 @@
  *
  */
 import React, {
+  CSSProperties,
   createContext,
   memo,
   useCallback,
@@ -25,9 +26,14 @@ import {
 import { cn } from "@/lib/utils";
 
 const ctx = createContext(0);
+const prefersLightTextCtx = createContext(false);
 
 function useIndent() {
   return useContext(ctx);
+}
+
+export function usePrefersLightText() {
+  return useContext(prefersLightTextCtx);
 }
 
 interface FolderProps {
@@ -50,11 +56,24 @@ interface FileProps {
   onToggle?: (active: boolean) => void;
 }
 
-function Tree({ children }: { children: ReactNode }): ReactElement {
+function Tree({
+  children,
+  prefersLightText,
+  style,
+}: {
+  children: ReactNode;
+  prefersLightText?: boolean;
+  style?: CSSProperties;
+}): ReactElement {
   return (
-    <div className={cn("nextra-filetree !mt-0 w-full select-none text-sm")}>
-      <div className="block space-y-1 rounded-lg">{children}</div>
-    </div>
+    <prefersLightTextCtx.Provider value={prefersLightText ?? false}>
+      <div
+        className={cn("nextra-filetree !mt-0 w-full select-none text-sm")}
+        style={style}
+      >
+        <div className="block space-y-1 rounded-lg">{children}</div>
+      </div>
+    </prefersLightTextCtx.Provider>
   );
 }
 
@@ -83,6 +102,7 @@ const Folder = memo<FolderProps>(
     disable,
   }) => {
     const indent = useIndent();
+    const prefersLightText = usePrefersLightText();
     const [isOpen, setIsOpen] = useState(defaultOpen || childActive);
 
     useEffect(() => {
@@ -121,9 +141,15 @@ const Folder = memo<FolderProps>(
           title={name}
           className={cn(
             "inline-flex w-full cursor-pointer items-center overflow-hidden",
-            "rounded-md text-foreground duration-100 hover:bg-gray-100 hover:dark:bg-muted",
+            "rounded-md duration-100",
+            prefersLightText
+              ? "text-[var(--viewer-text)] hover:bg-[var(--viewer-control-bg)]"
+              : "text-foreground hover:bg-gray-100 hover:dark:bg-muted",
             "px-3 py-1.5 leading-6",
-            active && "bg-gray-100 font-semibold dark:bg-muted",
+            active &&
+              (prefersLightText
+                ? "bg-[var(--viewer-panel-active)] font-semibold"
+                : "bg-gray-100 font-semibold dark:bg-muted"),
             disable && "pointer-events-none cursor-auto opacity-50",
             className,
           )}
@@ -169,17 +195,24 @@ Folder.displayName = "Folder";
 
 const File = memo<FileProps>(({ label, name, active, onToggle }) => {
   const indent = useIndent();
+  const prefersLightText = usePrefersLightText();
   const toggle = useCallback(() => {
     onToggle?.(!active);
-  }, [onToggle]);
+  }, [active, onToggle]);
 
   return (
     <li
       className={cn(
         "flex list-none",
-        "rounded-md text-foreground duration-100 hover:bg-gray-100 hover:dark:bg-muted",
+        "rounded-md duration-100",
+        prefersLightText
+          ? "text-[var(--viewer-muted-text)] hover:bg-[var(--viewer-control-bg)]"
+          : "text-foreground hover:bg-gray-100 hover:dark:bg-muted",
         "px-3 py-1.5 leading-6",
-        active && "bg-gray-100 font-semibold dark:bg-muted",
+        active &&
+          (prefersLightText
+            ? "bg-[var(--viewer-panel-active)] text-[var(--viewer-text)] font-semibold"
+            : "bg-gray-100 font-semibold dark:bg-muted"),
       )}
     >
       <span

--- a/components/view/access-form/access-form-theme.tsx
+++ b/components/view/access-form/access-form-theme.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+
+import { createAdaptiveSurfacePalette } from "@/lib/utils/create-adaptive-surface-palette";
+
+export type AccessFormTheme = ReturnType<typeof createAdaptiveSurfacePalette>;
+
+const defaultTheme = createAdaptiveSurfacePalette(undefined);
+
+const AccessFormThemeContext = createContext<AccessFormTheme>(defaultTheme);
+
+export function createAccessFormTheme(accentColor: string | null | undefined) {
+  return createAdaptiveSurfacePalette(accentColor || "#000000");
+}
+
+export function AccessFormThemeProvider({
+  value,
+  children,
+}: {
+  value: AccessFormTheme;
+  children: ReactNode;
+}) {
+  return (
+    <AccessFormThemeContext.Provider value={value}>
+      {children}
+    </AccessFormThemeContext.Provider>
+  );
+}
+
+export function useAccessFormTheme() {
+  return useContext(AccessFormThemeContext);
+}

--- a/components/view/access-form/agreement-section.tsx
+++ b/components/view/access-form/agreement-section.tsx
@@ -2,11 +2,10 @@ import { Dispatch, SetStateAction } from "react";
 
 import { Brand, DataroomBrand } from "@prisma/client";
 
-import { determineTextColor } from "@/lib/utils/determine-text-color";
-
 import { Checkbox } from "@/components/ui/checkbox";
 
 import { DEFAULT_ACCESS_FORM_TYPE } from ".";
+import { useAccessFormTheme } from "./access-form-theme";
 
 export default function AgreementSection({
   data,
@@ -25,8 +24,14 @@ export default function AgreementSection({
   brand?: Partial<Brand> | Partial<DataroomBrand> | null;
   useCustomAccessForm?: boolean;
 }) {
+  const theme = useAccessFormTheme();
+  const isChecked = !!data.hasConfirmedAgreement;
+
   const handleCheckChange = (checked: boolean) => {
     setData((prevData) => ({ ...prevData, hasConfirmedAgreement: checked }));
+  };
+  const toggleAgreement = () => {
+    handleCheckChange(!isChecked);
   };
 
   const isTextContent = agreementContentType === "TEXT";
@@ -35,39 +40,47 @@ export default function AgreementSection({
     <div className="relative flex items-start space-x-2 pt-5">
       <Checkbox
         id="agreement"
+        checked={isChecked}
         onCheckedChange={handleCheckChange}
-        className="border border-gray-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-300 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-[var(--dynamic-accent-color)] data-[state=checked]:bg-[var(--dynamic-accent-color)] data-[state=checked]:text-[var(--dynamic-accent-color)]"
+        className="border border-gray-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-300 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-[var(--agreement-checked-bg)] data-[state=checked]:bg-[var(--agreement-checked-bg)] data-[state=checked]:text-[var(--agreement-check-color)]"
         style={
           {
-            borderColor: determineTextColor(brand?.accentColor),
-            color: brand?.accentColor || undefined,
-            "--dynamic-accent-color": determineTextColor(brand?.accentColor),
+            borderColor: theme.controlBorderStrongColor,
+            color: theme.backgroundColor || undefined,
+            "--agreement-checked-bg": theme.textColor,
+            "--agreement-check-color": theme.inverseTextColor,
           } as React.CSSProperties
         }
       />
       <label
         className="text-sm font-normal leading-5 text-white peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-        style={{
-          color: determineTextColor(brand?.accentColor),
-        }}
+        style={{ color: theme.textColor }}
       >
         {isTextContent ? (
-          <span className="whitespace-pre-line">{agreementContent}</span>
+          <span
+            className="cursor-pointer whitespace-pre-line"
+            onClick={toggleAgreement}
+          >
+            {agreementContent}
+          </span>
         ) : (
           <>
-            I have reviewed and agree to the terms of this{" "}
+            <span className="cursor-pointer" onClick={toggleAgreement}>
+              I have reviewed and agree to the terms of this{" "}
+            </span>
             <a
               href={`${agreementContent}`}
               target="_blank"
               rel="noreferrer noopener"
               className="underline hover:text-gray-200"
-              style={{
-                color: determineTextColor(brand?.accentColor),
-              }}
+              onClick={(e) => e.stopPropagation()}
+              style={{ color: theme.textColor }}
             >
               {agreementName}
             </a>
-            .
+            <span className="cursor-pointer" onClick={toggleAgreement}>
+              .
+            </span>
           </>
         )}
       </label>

--- a/components/view/access-form/custom-fields-section.tsx
+++ b/components/view/access-form/custom-fields-section.tsx
@@ -141,13 +141,16 @@ export default function CustomFieldsSection({
                       "notranslate flex w-full cursor-text rounded-md border-0 bg-black py-1.5 text-gray-500 shadow-sm ring-1 ring-inset ring-gray-600 placeholder:text-[var(--access-placeholder)] focus:ring-2 focus:ring-inset focus:ring-[var(--access-input-focus)] sm:text-sm sm:leading-6",
                       isLongText && "min-h-[100px] resize-none",
                     )}
-                    style={{
-                      backgroundColor: theme.controlBgColor,
-                      borderColor: theme.controlBorderColor,
-                      "--access-placeholder": theme.controlPlaceholderColor,
-                      "--access-input-focus": theme.controlBorderStrongColor,
-                      color: theme.textColor,
-                    }}
+                    style={
+                      {
+                        backgroundColor: theme.controlBgColor,
+                        borderColor: theme.controlBorderColor,
+                        "--access-placeholder":
+                          theme.controlPlaceholderColor,
+                        "--access-input-focus": theme.controlBorderStrongColor,
+                        color: theme.textColor,
+                      } as React.CSSProperties
+                    }
                     value={value}
                     placeholder={field.placeholder || ""}
                     onChange={(e) => handleInputChange(e, field.identifier!)}

--- a/components/view/access-form/custom-fields-section.tsx
+++ b/components/view/access-form/custom-fields-section.tsx
@@ -2,12 +2,12 @@ import { Brand, CustomField, DataroomBrand } from "@prisma/client";
 import { E164Number } from "libphonenumber-js";
 
 import { cn } from "@/lib/utils";
-import { determineTextColor } from "@/lib/utils/determine-text-color";
 
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { PhoneInput } from "@/components/ui/phone-input";
 import { Textarea } from "@/components/ui/textarea";
+import { useAccessFormTheme } from "./access-form-theme";
 
 export default function CustomFieldsSection({
   fields,
@@ -20,6 +20,8 @@ export default function CustomFieldsSection({
   setData: (data: { [key: string]: string }) => void;
   brand?: Partial<Brand> | Partial<DataroomBrand> | null;
 }) {
+  const theme = useAccessFormTheme();
+
   const handleInputChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
     identifier: string,
@@ -53,9 +55,7 @@ export default function CustomFieldsSection({
               <label
                 htmlFor={field.identifier}
                 className="block text-sm font-medium leading-6 text-white"
-                style={{
-                  color: determineTextColor(brand?.accentColor),
-                }}
+                style={{ color: theme.textColor }}
               >
                 {field.label}
               </label>
@@ -73,17 +73,13 @@ export default function CustomFieldsSection({
                     "border-gray-600 data-[state=checked]:bg-gray-300 data-[state=checked]:text-black",
                   )}
                   style={{
-                    borderColor: brand?.accentColor
-                      ? determineTextColor(brand.accentColor)
-                      : undefined,
+                    borderColor: theme.controlBorderColor,
                   }}
                 />
                 <label
                   htmlFor={field.identifier}
                   className="cursor-pointer text-sm font-medium leading-none text-white peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                  style={{
-                    color: determineTextColor(brand?.accentColor),
-                  }}
+                  style={{ color: theme.textColor }}
                 >
                   {field.label}
                   {field.required && (
@@ -103,15 +99,13 @@ export default function CustomFieldsSection({
                 disabled={field.disabled}
                 translate="no"
                 className={cn(
-                  "notranslate flex w-full rounded-md border-0 bg-black text-gray-500 placeholder:text-gray-400 sm:text-sm sm:leading-6",
+                  "notranslate flex w-full cursor-text rounded-md border-0 bg-black text-gray-500 placeholder:text-[var(--access-placeholder)] sm:text-sm sm:leading-6",
                 )}
                 style={
                   {
-                    "--phone-input-bg":
-                      brand && brand.accentColor ? brand.accentColor : "black",
-                    "--phone-input-color": determineTextColor(
-                      brand?.accentColor,
-                    ),
+                    "--phone-input-bg": theme.controlBgColor,
+                    "--phone-input-color": theme.textColor,
+                    "--access-placeholder": theme.controlPlaceholderColor,
                   } as React.CSSProperties
                 }
               />
@@ -144,15 +138,15 @@ export default function CustomFieldsSection({
                     disabled={field.disabled}
                     translate="no"
                     className={cn(
-                      "notranslate flex w-full rounded-md border-0 bg-black py-1.5 text-gray-500 shadow-sm ring-1 ring-inset ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-gray-300 sm:text-sm sm:leading-6",
+                      "notranslate flex w-full cursor-text rounded-md border-0 bg-black py-1.5 text-gray-500 shadow-sm ring-1 ring-inset ring-gray-600 placeholder:text-[var(--access-placeholder)] focus:ring-2 focus:ring-inset focus:ring-[var(--access-input-focus)] sm:text-sm sm:leading-6",
                       isLongText && "min-h-[100px] resize-none",
                     )}
                     style={{
-                      backgroundColor:
-                        brand && brand.accentColor
-                          ? brand.accentColor
-                          : "black",
-                      color: determineTextColor(brand?.accentColor),
+                      backgroundColor: theme.controlBgColor,
+                      borderColor: theme.controlBorderColor,
+                      "--access-placeholder": theme.controlPlaceholderColor,
+                      "--access-input-focus": theme.controlBorderStrongColor,
+                      color: theme.textColor,
                     }}
                     value={value}
                     placeholder={field.placeholder || ""}

--- a/components/view/access-form/email-section.tsx
+++ b/components/view/access-form/email-section.tsx
@@ -1,13 +1,20 @@
-import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
+import {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 
 import { Brand, DataroomBrand } from "@prisma/client";
 import { useDebouncedCallback } from "use-debounce";
 
 import { cn } from "@/lib/utils";
-import { determineTextColor } from "@/lib/utils/determine-text-color";
 import { validateEmail } from "@/lib/utils/validate-email";
 
 import { DEFAULT_ACCESS_FORM_TYPE } from ".";
+import { useAccessFormTheme } from "./access-form-theme";
 
 export default function EmailSection({
   data,
@@ -25,6 +32,7 @@ export default function EmailSection({
   onValidationChange: (isValid: boolean) => void;
 }) {
   const { email } = data;
+  const theme = useAccessFormTheme();
   const [emailError, setEmailError] = useState<string | null>(null);
   const [isDirty, setIsDirty] = useState(false);
 
@@ -95,9 +103,7 @@ export default function EmailSection({
       <label
         htmlFor="email"
         className="block text-sm font-medium leading-6 text-white"
-        style={{
-          color: determineTextColor(brand?.accentColor),
-        }}
+        style={{ color: theme.textColor }}
       >
         Email address
       </label>
@@ -111,16 +117,18 @@ export default function EmailSection({
         required
         translate="no"
         className={cn(
-          "notranslate flex w-full rounded-md border-0 bg-black py-1.5 text-gray-500 shadow-sm ring-1 ring-inset ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-gray-300 sm:text-sm sm:leading-6",
+          "notranslate flex w-full cursor-text rounded-md border-0 bg-black py-1.5 text-gray-500 shadow-sm ring-1 ring-inset ring-gray-600 placeholder:text-[var(--access-placeholder)] focus:ring-2 focus:ring-inset focus:ring-[var(--access-input-focus)] sm:text-sm sm:leading-6",
           emailError && isDirty && "ring-red-500",
         )}
         style={{
-          backgroundColor:
-            brand && brand.accentColor ? brand.accentColor : "black",
+          backgroundColor: theme.controlBgColor,
+          borderColor: theme.controlBorderColor,
+          "--access-placeholder": theme.controlPlaceholderColor,
+          "--access-input-focus": theme.controlBorderStrongColor,
           color: disableEditEmail
-            ? "hsl(var(--muted-foreground))"
-            : determineTextColor(brand?.accentColor),
-        }}
+            ? theme.subtleTextColor
+            : theme.textColor,
+        } as CSSProperties}
         value={email || ""}
         placeholder="Enter email"
         onChange={handleEmailChange}
@@ -136,14 +144,12 @@ export default function EmailSection({
         <p
           id="email-error"
           className="mt-1 text-sm text-red-500"
-          style={{
-            color: determineTextColor(brand?.accentColor),
-          }}
+          style={{ color: theme.textColor }}
         >
           {emailError}
         </p>
       )}
-      <p className="text-sm text-gray-500">
+      <p className="text-sm" style={{ color: theme.subtleTextColor }}>
         {useCustomAccessForm
           ? "This data will be shared with the content provider."
           : "This data will be shared with the sender."}

--- a/components/view/access-form/email-verification-form.tsx
+++ b/components/view/access-form/email-verification-form.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 
 import { Brand, DataroomBrand } from "@prisma/client";
 
-import { determineTextColor } from "@/lib/utils/determine-text-color";
 import { useMediaQuery } from "@/lib/utils/use-media-query";
 
 import { Button } from "@/components/ui/button";
@@ -12,6 +11,7 @@ import {
   InputOTPSlot,
 } from "@/components/ui/input-otp";
 import { DEFAULT_ACCESS_FORM_TYPE } from "@/components/view/access-form";
+import { createAccessFormTheme } from "@/components/view/access-form/access-form-theme";
 
 const REGEXP_ONLY_DIGITS = "^\\d+$";
 
@@ -35,6 +35,7 @@ export default function EmailVerificationMessage({
   brand?: Partial<Brand> | Partial<DataroomBrand> | null;
 }) {
   const { isMobile } = useMediaQuery();
+  const theme = createAccessFormTheme(brand?.accentColor);
   const [isResendLoading, setIsResendLoading] = useState(false);
   const [delaySeconds, setDelaySeconds] = useState(60);
 
@@ -54,24 +55,19 @@ export default function EmailVerificationMessage({
       <div
         className="flex h-screen flex-1 flex-col px-6 py-12 lg:px-8"
         style={{
-          backgroundColor:
-            brand && brand.accentColor ? brand.accentColor : "black",
+          backgroundColor: theme.backgroundColor,
         }}
       >
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
           <h2
             className="mt-10 text-2xl font-bold leading-9 tracking-tight"
-            style={{
-              color: determineTextColor(brand?.accentColor),
-            }}
+            style={{ color: theme.textColor }}
           >
             Verify your email address
           </h2>
           <p
             className="text-pretty text-sm leading-6"
-            style={{
-              color: determineTextColor(brand?.accentColor),
-            }}
+            style={{ color: theme.textColor }}
           >
             Enter the six digit verification code sent to{" "}
             <strong className="font-medium" title={data.email ?? ""}>
@@ -110,8 +106,8 @@ export default function EmailVerificationMessage({
               loading={isLoading && !isResendLoading}
               className="hover:opacity-90"
               style={{
-                backgroundColor: determineTextColor(brand?.accentColor),
-                color: brand && brand.accentColor ? brand.accentColor : "black",
+                backgroundColor: theme.ctaBgColor,
+                color: theme.ctaTextColor,
               }}
             >
               {isLoading && !isResendLoading ? "Verifying..." : "Continue"}
@@ -122,12 +118,7 @@ export default function EmailVerificationMessage({
             <div className="flex items-center">
               <p
                 className="text-xs"
-                style={{
-                  color:
-                    determineTextColor(brand?.accentColor) === "white"
-                      ? "rgb(75, 85, 99)"
-                      : "rgb(107, 114, 128)",
-                }}
+                style={{ color: theme.subtleTextColor }}
               >
                 Didn&apos;t receive the email?
               </p>{" "}
@@ -135,12 +126,7 @@ export default function EmailVerificationMessage({
                 variant="link"
                 size="sm"
                 className="text-xs font-normal"
-                style={{
-                  color:
-                    determineTextColor(brand?.accentColor) === "white"
-                      ? "rgb(107, 114, 128)"
-                      : "rgb(156, 163, 175)",
-                }}
+                style={{ color: theme.mutedTextColor }}
                 disabled={isLoading || delaySeconds > 0}
                 onClick={(e) => {
                   e.preventDefault();

--- a/components/view/access-form/index.tsx
+++ b/components/view/access-form/index.tsx
@@ -3,11 +3,13 @@ import { useEffect, useState } from "react";
 import { Brand, CustomField, DataroomBrand } from "@prisma/client";
 import { ArrowUpRightIcon } from "lucide-react";
 
-import { determineTextColor } from "@/lib/utils/determine-text-color";
-
 import { Button } from "@/components/ui/button";
 
 import AgreementSection from "./agreement-section";
+import {
+  AccessFormThemeProvider,
+  createAccessFormTheme,
+} from "./access-form-theme";
 import CustomFieldsSection from "./custom-fields-section";
 import EmailSection from "./email-section";
 import NameSection from "./name-section";
@@ -68,6 +70,7 @@ export default function AccessForm({
   linkWelcomeMessage?: string | null;
 }) {
   const [isEmailValid, setIsEmailValid] = useState(true);
+  const accessFormTheme = createAccessFormTheme(brand?.accentColor);
 
   useEffect(() => {
     const userEmail = email;
@@ -77,7 +80,7 @@ export default function AccessForm({
         email: userEmail || prevData.email,
       }));
     }
-  }, [email]);
+  }, [email, setData]);
 
   const isFormValid = () => {
     if (requireEmail) {
@@ -115,13 +118,14 @@ export default function AccessForm({
   };
 
   return (
-    <div
-      className="flex h-full min-h-dvh flex-col justify-between pb-4"
-      style={{
-        backgroundColor:
-          brand && brand.accentColor ? brand.accentColor : "black",
-      }}
-    >
+    <AccessFormThemeProvider value={accessFormTheme}>
+      <div
+        className="flex h-full min-h-dvh flex-col justify-between pb-4"
+        style={{
+          backgroundColor: accessFormTheme.backgroundColor,
+          color: accessFormTheme.textColor,
+        }}
+      >
       {/* Light Navbar */}
       {logoOnAccessForm && brand && brand.logo && (
         <nav
@@ -144,9 +148,7 @@ export default function AccessForm({
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
           <h1
             className="mt-10 text-2xl font-bold leading-9 tracking-tight text-white"
-            style={{
-              color: determineTextColor(brand?.accentColor),
-            }}
+            style={{ color: accessFormTheme.textColor }}
           >
             {linkWelcomeMessage ||
               (brand && "welcomeMessage" in brand && brand.welcomeMessage) ||
@@ -195,9 +197,8 @@ export default function AccessForm({
                 className="w-1/3 min-w-fit bg-white text-gray-950 hover:bg-white/90"
                 loading={isLoading}
                 style={{
-                  backgroundColor: determineTextColor(brand?.accentColor),
-                  color:
-                    brand && brand.accentColor ? brand.accentColor : "black",
+                  backgroundColor: accessFormTheme.ctaBgColor,
+                  color: accessFormTheme.ctaTextColor,
                 }}
               >
                 Continue
@@ -208,25 +209,33 @@ export default function AccessForm({
       </div>
       {!useCustomAccessForm ? (
         <div className="flex flex-col items-center gap-0.5">
-          <p className="text-center text-sm tracking-tight text-gray-500">
+          <p
+            className="text-center text-sm tracking-tight"
+            style={{ color: accessFormTheme.subtleTextColor }}
+          >
             This document is securely shared with you using{" "}
             <a
               href="https://www.papermark.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="font-medium hover:text-gray-600"
+              className="font-medium"
+              style={{ color: accessFormTheme.mutedTextColor }}
             >
               Papermark
             </a>
             .
           </p>
-          <p className="text-center text-sm tracking-tight text-gray-500">
+          <p
+            className="text-center text-sm tracking-tight"
+            style={{ color: accessFormTheme.subtleTextColor }}
+          >
             See how we protect your data in our{" "}
             <a
               href={`${process.env.NEXT_PUBLIC_MARKETING_URL}/privacy`}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-0.5 hover:text-gray-600"
+              className="inline-flex items-center gap-0.5"
+              style={{ color: accessFormTheme.mutedTextColor }}
             >
               <span>Privacy Policy</span>
               <ArrowUpRightIcon className="h-3 w-3" />
@@ -234,6 +243,7 @@ export default function AccessForm({
           </p>
         </div>
       ) : null}
-    </div>
+      </div>
+    </AccessFormThemeProvider>
   );
 }

--- a/components/view/access-form/name-section.tsx
+++ b/components/view/access-form/name-section.tsx
@@ -1,10 +1,10 @@
 import { Dispatch, SetStateAction, useEffect } from "react";
+import type { CSSProperties } from "react";
 
 import { Brand, DataroomBrand } from "@prisma/client";
 
-import { determineTextColor } from "@/lib/utils/determine-text-color";
-
 import { DEFAULT_ACCESS_FORM_TYPE } from ".";
+import { useAccessFormTheme } from "./access-form-theme";
 
 export default function NameSection({
   data,
@@ -16,6 +16,7 @@ export default function NameSection({
   brand?: Partial<Brand> | Partial<DataroomBrand> | null;
 }) {
   const { name } = data;
+  const theme = useAccessFormTheme();
 
   useEffect(() => {
     // Load name from localStorage when the component mounts
@@ -41,9 +42,7 @@ export default function NameSection({
       <label
         htmlFor="name"
         className="block text-sm font-medium leading-6 text-white"
-        style={{
-          color: determineTextColor(brand?.accentColor),
-        }}
+        style={{ color: theme.textColor }}
       >
         Name
       </label>
@@ -55,12 +54,14 @@ export default function NameSection({
         autoComplete="off"
         autoFocus
         translate="no"
-        className="notranslate flex w-full rounded-md border-0 bg-black py-1.5 text-white shadow-sm ring-1 ring-inset ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-gray-300 sm:text-sm sm:leading-6"
+        className="notranslate flex w-full cursor-text rounded-md border-0 bg-black py-1.5 text-white shadow-sm ring-1 ring-inset ring-gray-600 placeholder:text-[var(--access-placeholder)] focus:ring-2 focus:ring-inset focus:ring-[var(--access-input-focus)] sm:text-sm sm:leading-6"
         style={{
-          backgroundColor:
-            brand && brand.accentColor ? brand.accentColor : "black",
-          color: determineTextColor(brand?.accentColor),
-        }}
+          backgroundColor: theme.controlBgColor,
+          borderColor: theme.controlBorderColor,
+          "--access-placeholder": theme.controlPlaceholderColor,
+          "--access-input-focus": theme.controlBorderStrongColor,
+          color: theme.textColor,
+        } as CSSProperties}
         value={name || ""}
         placeholder="Enter your full name"
         onChange={handleNameChange}

--- a/components/view/access-form/password-section.tsx
+++ b/components/view/access-form/password-section.tsx
@@ -1,13 +1,13 @@
 import { Dispatch, SetStateAction, useState } from "react";
+import type { CSSProperties } from "react";
 
 import { Brand, DataroomBrand } from "@prisma/client";
-
-import { determineTextColor } from "@/lib/utils/determine-text-color";
 
 import Eye from "@/components/shared/icons/eye";
 import EyeOff from "@/components/shared/icons/eye-off";
 
 import { DEFAULT_ACCESS_FORM_TYPE } from ".";
+import { useAccessFormTheme } from "./access-form-theme";
 
 export default function PasswordSection({
   data,
@@ -19,6 +19,7 @@ export default function PasswordSection({
   brand?: Partial<Brand> | Partial<DataroomBrand> | null;
 }) {
   const { password } = data;
+  const theme = useAccessFormTheme();
   const [showPassword, setShowPassword] = useState<boolean>(false);
 
   return (
@@ -26,9 +27,7 @@ export default function PasswordSection({
       <label
         htmlFor="password"
         className="block text-sm font-medium leading-6 text-white"
-        style={{
-          color: determineTextColor(brand?.accentColor),
-        }}
+        style={{ color: theme.textColor }}
       >
         Passcode
       </label>
@@ -40,12 +39,14 @@ export default function PasswordSection({
           autoCorrect="off"
           autoComplete="off"
           translate="no"
-          className="notranslate flex w-full rounded-md border-0 bg-black py-1.5 text-white shadow-sm ring-1 ring-inset ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-gray-300 sm:text-sm sm:leading-6"
+          className="notranslate flex w-full cursor-text rounded-md border-0 bg-black py-1.5 text-white shadow-sm ring-1 ring-inset ring-gray-600 placeholder:text-[var(--access-placeholder)] focus:ring-2 focus:ring-inset focus:ring-[var(--access-input-focus)] sm:text-sm sm:leading-6"
           style={{
-            backgroundColor:
-              brand && brand.accentColor ? brand.accentColor : "black",
-            color: determineTextColor(brand?.accentColor),
-          }}
+            backgroundColor: theme.controlBgColor,
+            borderColor: theme.controlBorderColor,
+            "--access-placeholder": theme.controlPlaceholderColor,
+            "--access-input-focus": theme.controlBorderStrongColor,
+            color: theme.textColor,
+          } as CSSProperties}
           value={password || ""}
           placeholder="Enter passcode"
           onChange={(e) => {
@@ -60,9 +61,17 @@ export default function PasswordSection({
           className="absolute inset-y-0 right-0 flex items-center pr-3"
         >
           {showPassword ? (
-            <Eye className="h-4 w-4 text-gray-400" aria-hidden="true" />
+            <Eye
+              className="h-4 w-4"
+              style={{ color: theme.controlIconColor }}
+              aria-hidden="true"
+            />
           ) : (
-            <EyeOff className="h-4 w-4 text-gray-400" aria-hidden="true" />
+            <EyeOff
+              className="h-4 w-4"
+              style={{ color: theme.controlIconColor }}
+              aria-hidden="true"
+            />
           )}
         </button>
       </div>

--- a/components/view/annotations/annotation-panel.tsx
+++ b/components/view/annotations/annotation-panel.tsx
@@ -6,7 +6,7 @@ import { Brand, DataroomBrand } from "@prisma/client";
 import { ChevronDown, ChevronRight } from "lucide-react";
 
 import { useViewerAnnotations } from "@/lib/swr/use-annotations";
-import { determineTextColor } from "@/lib/utils/determine-text-color";
+import { createAdaptiveSurfacePalette } from "@/lib/utils/create-adaptive-surface-palette";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -41,6 +41,7 @@ export function AnnotationPanel({
   isVisible,
   onResize,
 }: AnnotationPanelProps) {
+  const palette = createAdaptiveSurfacePalette(brand?.accentColor);
   const { annotations, loading } = useViewerAnnotations(
     linkId,
     documentId,
@@ -182,7 +183,7 @@ export function AnnotationPanel({
             <div className="flex items-center justify-center py-6">
               <div
                 className="text-xs opacity-70"
-                style={{ color: determineTextColor(brand?.accentColor) }}
+                style={{ color: palette.textColor }}
               >
                 Loading annotations...
               </div>
@@ -191,7 +192,7 @@ export function AnnotationPanel({
             <div className="flex flex-col items-center justify-center py-6 text-center">
               <p
                 className="mb-1 text-xs opacity-70"
-                style={{ color: determineTextColor(brand?.accentColor) }}
+                style={{ color: palette.textColor }}
               >
                 No annotations on this page
               </p>

--- a/components/view/dataroom/dataroom-view.tsx
+++ b/components/view/dataroom/dataroom-view.tsx
@@ -278,7 +278,14 @@ export default function DataroomView({
 
   if (submitted) {
     return (
-      <div className="bg-gray-950">
+      <div
+        className="bg-gray-950"
+        style={
+          brand?.accentColor
+            ? { backgroundColor: brand.accentColor }
+            : undefined
+        }
+      >
         <DataroomViewer
           accessControls={link.accessControls || group?.accessControls || []}
           brand={brand!}
@@ -307,7 +314,14 @@ export default function DataroomView({
   }
 
   return (
-    <div className="bg-gray-950">
+    <div
+      className="bg-gray-950"
+      style={
+        brand?.accentColor
+          ? { backgroundColor: brand.accentColor }
+          : undefined
+      }
+    >
       <div className="flex h-screen items-center justify-center">
         <LoadingSpinner className="h-20 w-20" />
       </div>

--- a/components/view/dataroom/dataroom-view.tsx
+++ b/components/view/dataroom/dataroom-view.tsx
@@ -109,6 +109,11 @@ export default function DataroomView({
 
   const [code, setCode] = useState<string | null>(null);
   const [isInvalidCode, setIsInvalidCode] = useState<boolean>(false);
+  const shouldApplyAccentToDataroomView = !!(brand as any)
+    ?.applyAccentColorToDataroomView;
+  const dataroomViewBackgroundColor = shouldApplyAccentToDataroomView
+    ? brand?.accentColor
+    : "#ffffff";
 
   const handleSubmission = async (): Promise<void> => {
     setIsLoading(true);
@@ -279,12 +284,8 @@ export default function DataroomView({
   if (submitted) {
     return (
       <div
-        className="bg-gray-950"
-        style={
-          brand?.accentColor
-            ? { backgroundColor: brand.accentColor }
-            : undefined
-        }
+        className="bg-white"
+        style={{ backgroundColor: dataroomViewBackgroundColor }}
       >
         <DataroomViewer
           accessControls={link.accessControls || group?.accessControls || []}
@@ -315,12 +316,8 @@ export default function DataroomView({
 
   return (
     <div
-      className="bg-gray-950"
-      style={
-        brand?.accentColor
-          ? { backgroundColor: brand.accentColor }
-          : undefined
-      }
+      className="bg-white"
+      style={{ backgroundColor: dataroomViewBackgroundColor }}
     >
       <div className="flex h-screen items-center justify-center">
         <LoadingSpinner className="h-20 w-20" />

--- a/components/view/dataroom/dataroom-view.tsx
+++ b/components/view/dataroom/dataroom-view.tsx
@@ -285,7 +285,7 @@ export default function DataroomView({
     return (
       <div
         className="bg-white"
-        style={{ backgroundColor: dataroomViewBackgroundColor }}
+        style={{ backgroundColor: dataroomViewBackgroundColor ?? undefined }}
       >
         <DataroomViewer
           accessControls={link.accessControls || group?.accessControls || []}
@@ -317,7 +317,7 @@ export default function DataroomView({
   return (
     <div
       className="bg-white"
-      style={{ backgroundColor: dataroomViewBackgroundColor }}
+      style={{ backgroundColor: dataroomViewBackgroundColor ?? undefined }}
     >
       <div className="flex h-screen items-center justify-center">
         <LoadingSpinner className="h-20 w-20" />

--- a/components/view/dataroom/document-card.tsx
+++ b/components/view/dataroom/document-card.tsx
@@ -182,7 +182,7 @@ export default function DocumentCard({
   return (
     <div
       className={cn(
-        "group/row relative flex items-center justify-between rounded-lg border-0 p-3 ring-1 ring-gray-200 transition-all hover:bg-secondary hover:ring-gray-300 dark:bg-secondary dark:ring-gray-700 hover:dark:ring-gray-500 sm:p-4",
+        "group/row relative flex items-center justify-between rounded-lg border-0 bg-white p-3 ring-1 ring-gray-200 transition-all hover:bg-gray-50 hover:ring-gray-300 dark:bg-secondary dark:ring-gray-700 hover:dark:ring-gray-500 sm:p-4",
         isProcessing && "cursor-not-allowed opacity-60",
       )}
     >

--- a/components/view/dataroom/document-card.tsx
+++ b/components/view/dataroom/document-card.tsx
@@ -22,6 +22,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useViewerSurfaceTheme } from "@/components/view/viewer/viewer-surface-theme";
 
 import { DocumentVersion } from "../viewer/dataroom-viewer";
 
@@ -57,6 +58,7 @@ export default function DocumentCard({
   showLastUpdated = true,
 }: DocumentsCardProps) {
   const { theme, systemTheme } = useTheme();
+  const { palette } = useViewerSurfaceTheme();
   const canDownload = document.canDownload && allowDownload;
 
   const isLight =
@@ -182,9 +184,25 @@ export default function DocumentCard({
   return (
     <div
       className={cn(
-        "group/row relative flex items-center justify-between rounded-lg border-0 bg-white p-3 ring-1 ring-gray-200 transition-all hover:bg-gray-50 hover:ring-gray-300 dark:bg-secondary dark:ring-gray-700 hover:dark:ring-gray-500 sm:p-4",
+        "group/row relative flex items-center justify-between rounded-lg border p-3 transition-all sm:p-4",
+        "bg-[var(--viewer-panel-bg)] hover:bg-[var(--viewer-panel-bg-hover)]",
+        "border-[var(--viewer-panel-border)] hover:border-[var(--viewer-panel-border-hover)]",
         isProcessing && "cursor-not-allowed opacity-60",
       )}
+      style={
+        {
+          "--viewer-panel-bg": palette.panelBgColor,
+          "--viewer-panel-bg-hover": palette.panelHoverBgColor,
+          "--viewer-panel-border": palette.panelBorderColor,
+          "--viewer-panel-border-hover": palette.panelBorderHoverColor,
+          "--viewer-text": palette.textColor,
+          "--viewer-muted-text": palette.mutedTextColor,
+          "--viewer-control-bg": palette.controlBgColor,
+          "--viewer-control-border": palette.controlBorderColor,
+          "--viewer-control-border-strong": palette.controlBorderStrongColor,
+          "--viewer-control-icon": palette.controlIconColor,
+        } as React.CSSProperties
+      }
     >
       {/* Click target - outside of text hierarchy to fix Safari truncation issue */}
       <button
@@ -205,19 +223,23 @@ export default function DocumentCard({
         <div className="min-w-0 flex-1 flex-col">
           <div className="flex items-center">
             <h2
-              className="truncate text-sm font-semibold leading-6 text-foreground"
+              className="truncate text-sm font-semibold leading-6 text-[var(--viewer-text)]"
               style={HIERARCHICAL_DISPLAY_STYLE}
             >
               {displayName}
               {isProcessing && (
-                <span className="ml-2 text-xs text-muted-foreground">
+                <span
+                  className="ml-2 text-xs text-[var(--viewer-muted-text)]"
+                >
                   (Processing...)
                 </span>
               )}
             </h2>
           </div>
           {showLastUpdated && (
-            <div className="mt-1 flex items-center space-x-1 text-xs leading-5 text-muted-foreground">
+            <div
+              className="mt-1 flex items-center space-x-1 text-xs leading-5 text-[var(--viewer-muted-text)]"
+            >
               <p className="truncate">
                 Updated {timeAgo(document.versions[0].updatedAt)}
               </p>
@@ -232,7 +254,11 @@ export default function DocumentCard({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8 p-0 text-gray-500 ring-1 ring-gray-100 hover:bg-gray-200 group-hover/row:text-foreground group-hover/row:ring-gray-300"
+                className={cn(
+                  "h-8 w-8 border bg-transparent p-0",
+                  "text-[var(--viewer-control-icon)] border-[var(--viewer-control-border)] hover:bg-[var(--viewer-control-bg)]",
+                  "group-hover/row:text-[var(--viewer-text)] group-hover/row:border-[var(--viewer-control-border-strong)]",
+                )}
                 aria-label="Open menu"
               >
                 <MoreVerticalIcon className="h-4 w-4" />

--- a/components/view/dataroom/folder-card.tsx
+++ b/components/view/dataroom/folder-card.tsx
@@ -68,7 +68,7 @@ export default function FolderCard({
   };
 
   return (
-    <div className="group/row relative flex items-center justify-between rounded-lg border-0 p-3 ring-1 ring-gray-400 transition-all hover:bg-secondary hover:ring-gray-500 dark:bg-secondary dark:ring-gray-500 hover:dark:ring-gray-400 sm:p-4">
+    <div className="group/row relative flex items-center justify-between rounded-lg border-0 bg-white p-3 ring-1 ring-gray-400 transition-all hover:bg-gray-50 hover:ring-gray-500 dark:bg-secondary dark:ring-gray-500 hover:dark:ring-gray-400 sm:p-4">
       {/* Click target - outside of text hierarchy to fix Safari truncation issue */}
       <button
         onClick={() => setFolderId(folder.id)}

--- a/components/view/dataroom/folder-card.tsx
+++ b/components/view/dataroom/folder-card.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
+import type { CSSProperties } from "react";
 
 import { DataroomFolder } from "@prisma/client";
 import { Download, MoreVerticalIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import { getFolderColorClasses, getFolderIcon } from "@/lib/constants/folder-constants";
-import { timeAgo } from "@/lib/utils";
+import { cn, timeAgo } from "@/lib/utils";
 import {
   HIERARCHICAL_DISPLAY_STYLE,
   getHierarchicalDisplayName,
@@ -19,6 +20,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useViewerSurfaceTheme } from "@/components/view/viewer/viewer-surface-theme";
 
 type FolderCardProps = {
   folder: DataroomFolder;
@@ -43,6 +45,7 @@ export default function FolderCard({
   showLastUpdated = true,
 }: FolderCardProps) {
   const [open, setOpen] = useState(false);
+  const { palette } = useViewerSurfaceTheme();
 
   // Get hierarchical display name
   const displayName = getHierarchicalDisplayName(
@@ -68,7 +71,27 @@ export default function FolderCard({
   };
 
   return (
-    <div className="group/row relative flex items-center justify-between rounded-lg border-0 bg-white p-3 ring-1 ring-gray-400 transition-all hover:bg-gray-50 hover:ring-gray-500 dark:bg-secondary dark:ring-gray-500 hover:dark:ring-gray-400 sm:p-4">
+    <div
+      className={cn(
+        "group/row relative flex items-center justify-between rounded-lg border p-3 transition-all sm:p-4",
+        "bg-[var(--viewer-panel-bg)] hover:bg-[var(--viewer-panel-bg-hover)]",
+        "border-[var(--viewer-panel-border)] hover:border-[var(--viewer-panel-border-hover)]",
+      )}
+      style={
+        {
+          "--viewer-panel-bg": palette.panelBgColor,
+          "--viewer-panel-bg-hover": palette.panelHoverBgColor,
+          "--viewer-panel-border": palette.panelBorderColor,
+          "--viewer-panel-border-hover": palette.panelBorderHoverColor,
+          "--viewer-text": palette.textColor,
+          "--viewer-muted-text": palette.mutedTextColor,
+          "--viewer-control-bg": palette.controlBgColor,
+          "--viewer-control-border": palette.controlBorderColor,
+          "--viewer-control-border-strong": palette.controlBorderStrongColor,
+          "--viewer-control-icon": palette.controlIconColor,
+        } as CSSProperties
+      }
+    >
       {/* Click target - outside of text hierarchy to fix Safari truncation issue */}
       <button
         onClick={() => setFolderId(folder.id)}
@@ -92,14 +115,16 @@ export default function FolderCard({
         <div className="min-w-0 flex-1 flex-col">
           <div className="flex items-center">
             <h2
-              className="truncate text-sm font-semibold leading-6 text-foreground"
+              className="truncate text-sm font-semibold leading-6 text-[var(--viewer-text)]"
               style={HIERARCHICAL_DISPLAY_STYLE}
             >
               {displayName}
             </h2>
           </div>
           {showLastUpdated && (
-            <div className="mt-1 flex items-center space-x-1 text-xs leading-5 text-muted-foreground">
+            <div
+              className="mt-1 flex items-center space-x-1 text-xs leading-5 text-[var(--viewer-muted-text)]"
+            >
               <p className="truncate">Updated {timeAgo(folder.updatedAt)}</p>
             </div>
           )}
@@ -112,7 +137,11 @@ export default function FolderCard({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8 p-0 text-gray-500 ring-1 ring-gray-100 hover:bg-gray-200 group-hover/row:text-foreground group-hover/row:ring-gray-300"
+                className={cn(
+                  "h-8 w-8 border bg-transparent p-0",
+                  "text-[var(--viewer-control-icon)] border-[var(--viewer-control-border)] hover:bg-[var(--viewer-control-bg)]",
+                  "group-hover/row:text-[var(--viewer-text)] group-hover/row:border-[var(--viewer-control-border-strong)]",
+                )}
                 aria-label="Open menu"
               >
                 <MoreVerticalIcon className="h-4 w-4" />

--- a/components/view/nav.tsx
+++ b/components/view/nav.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
-import { determineTextColor } from "@/lib/utils/determine-text-color";
+import { createAdaptiveSurfacePalette } from "@/lib/utils/create-adaptive-surface-palette";
 
 import {
   DropdownMenu,
@@ -117,6 +117,7 @@ export default function Nav({
   } = navData;
 
   const [showConversations, setShowConversations] = useState(false);
+  const navColorPalette = createAdaptiveSurfacePalette(brand?.brandColor);
 
   // Extract the dataroom path from the URL
   // This regex captures everything before "/d/" in the path
@@ -272,7 +273,7 @@ export default function Nav({
                       className="cursor-pointer underline underline-offset-4 hover:font-medium"
                       href={`${dataroomPath}${isPreview ? "?previewToken=" + previewToken + "&preview=" + preview : ""}`}
                       style={{
-                        color: determineTextColor(brand?.brandColor),
+                        color: navColorPalette.textColor,
                       }}
                     >
                       Home

--- a/components/view/question.tsx
+++ b/components/view/question.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
+import type { CSSProperties } from "react";
 
 import { ThumbsDownIcon, ThumbsUpIcon } from "lucide-react";
 import { motion } from "motion/react";
 
 import { STAGGER_CHILD_VARIANTS } from "@/lib/constants";
 import { cn } from "@/lib/utils";
-import { determineTextColor } from "@/lib/utils/determine-text-color";
+import { createAdaptiveSurfacePalette } from "@/lib/utils/create-adaptive-surface-palette";
 
 export default function Question({
   feedback,
@@ -23,6 +24,7 @@ export default function Question({
   accentColor?: string | null;
 }) {
   const [answer, setAnswer] = useState<"yes" | "no" | "">("");
+  const palette = createAdaptiveSurfacePalette(accentColor);
 
   const handleQuestionSubmit = async (answer: string) => {
     if (answer === "") return;
@@ -75,9 +77,7 @@ export default function Question({
         >
           <h1
             className="font-display max-w-lg text-3xl font-semibold transition-colors sm:text-4xl"
-            style={{
-              color: accentColor ? determineTextColor(accentColor) : "white",
-            }}
+            style={{ color: palette.textColor }}
           >
             Thanks for your feedback!
           </h1>
@@ -110,9 +110,7 @@ export default function Question({
       >
         <h1
           className="font-display max-w-xl text-3xl font-semibold transition-colors sm:text-4xl"
-          style={{
-            color: accentColor ? determineTextColor(accentColor) : "white",
-          }}
+          style={{ color: palette.textColor }}
         >
           {feedback.data.question}
         </h1>
@@ -121,25 +119,22 @@ export default function Question({
         variants={STAGGER_CHILD_VARIANTS}
         className="grid w-full max-w-sm grid-cols-1 divide-y rounded-md border border-border md:grid-cols-2 md:divide-x md:divide-y-0"
         style={{
-          color: accentColor ? determineTextColor(accentColor) : "white",
-          borderColor: accentColor
-            ? determineTextColor(accentColor)
-            : "hsl(var(--border))",
+          color: palette.textColor,
+          borderColor: palette.panelBorderColor,
         }}
       >
         <button
           onClick={() => handleQuestionSubmit("yes")}
           className={cn(
-            "flex min-h-[200px] flex-col items-center justify-center space-y-5 overflow-hidden p-5 transition-colors md:p-10",
-            determineTextColor(accentColor) === "black"
-              ? "hover:bg-gray-800 hover:text-gray-200"
-              : "hover:bg-gray-200 hover:text-gray-800",
-            answer === "yes"
-              ? determineTextColor(accentColor) === "black"
-                ? "bg-gray-800 text-gray-200"
-                : "bg-gray-200 text-gray-800"
-              : "",
+            "flex min-h-[200px] flex-col items-center justify-center space-y-5 overflow-hidden p-5 transition-colors hover:bg-[var(--feedback-hover-bg)] md:p-10",
+            answer === "yes" ? "bg-[var(--feedback-active-bg)]" : "",
           )}
+          style={
+            {
+              "--feedback-hover-bg": palette.panelHoverBgColor,
+              "--feedback-active-bg": palette.panelActiveBgColor,
+            } as CSSProperties
+          }
         >
           <ThumbsUpIcon
             className="pointer-events-none h-auto w-12 sm:w-12"
@@ -150,16 +145,15 @@ export default function Question({
         <button
           onClick={() => handleQuestionSubmit("no")}
           className={cn(
-            "flex min-h-[200px] flex-col items-center justify-center space-y-5 overflow-hidden p-5 transition-colors md:p-10",
-            determineTextColor(accentColor) === "black"
-              ? "hover:bg-gray-800 hover:text-gray-200"
-              : "hover:bg-gray-200 hover:text-gray-800",
-            answer === "no"
-              ? determineTextColor(accentColor) === "black"
-                ? "bg-gray-800 text-gray-200"
-                : "bg-gray-200 text-gray-800"
-              : "",
+            "flex min-h-[200px] flex-col items-center justify-center space-y-5 overflow-hidden p-5 transition-colors hover:bg-[var(--feedback-hover-bg)] md:p-10",
+            answer === "no" ? "bg-[var(--feedback-active-bg)]" : "",
           )}
+          style={
+            {
+              "--feedback-hover-bg": palette.panelHoverBgColor,
+              "--feedback-active-bg": palette.panelActiveBgColor,
+            } as CSSProperties
+          }
         >
           <ThumbsDownIcon
             className="pointer-events-none h-auto w-12 sm:w-12"

--- a/components/view/viewer/dataroom-viewer.tsx
+++ b/components/view/viewer/dataroom-viewer.tsx
@@ -19,6 +19,7 @@ import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { PanelLeftIcon, XIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { determineTextColor } from "@/lib/utils/determine-text-color";
 import {
   HIERARCHICAL_DISPLAY_STYLE,
   getHierarchicalDisplayName,
@@ -379,6 +380,11 @@ export default function DataroomViewer({
     );
   };
 
+  const viewerBgColor = brand?.accentColor || undefined;
+  const isViewerBgDark = viewerBgColor
+    ? determineTextColor(viewerBgColor) === "white"
+    : false;
+
   // Prepare documents for chat context
   const documentsForChat = documents.map((doc) => ({
     dataroomDocumentId: doc.dataroomDocumentId,
@@ -414,10 +420,16 @@ export default function DataroomViewer({
         isTeamMember={viewData.isTeamMember}
       />
       <ViewerChatLayout>
-        <div className="relative flex flex-1 items-center overflow-hidden bg-white dark:bg-black">
+        <div
+          className="relative flex flex-1 items-center overflow-hidden bg-white dark:bg-black"
+          style={viewerBgColor ? { backgroundColor: viewerBgColor } : undefined}
+        >
           <div className="relative mx-auto flex h-full w-full items-start justify-center">
             {/* Tree view */}
-            <div className="hidden h-full w-1/4 space-y-8 overflow-auto px-3 pb-4 pt-4 md:flex md:px-6 md:pt-6 lg:px-8 lg:pt-9 xl:px-14">
+            <div
+              className="hidden h-full w-1/4 space-y-8 overflow-auto px-3 pb-4 pt-4 md:flex md:px-6 md:pt-6 lg:px-8 lg:pt-9 xl:px-14"
+              style={isViewerBgDark ? { color: "white" } : undefined}
+            >
               <ScrollArea showScrollbar className="w-full">
                 <ViewFolderTree
                   folders={folders}
@@ -436,13 +448,19 @@ export default function DataroomViewer({
               showScrollbar
               className="h-full flex-grow overflow-auto"
             >
-              <div className="h-full px-3 pb-4 pt-4 md:px-6 md:pt-6 lg:px-8 lg:pt-9 xl:px-14">
+              <div
+                className="h-full px-3 pb-4 pt-4 md:px-6 md:pt-6 lg:px-8 lg:pt-9 xl:px-14"
+                style={isViewerBgDark ? { color: "white" } : undefined}
+              >
                 <div className="flex items-center gap-x-2">
                   {/* sidebar for mobile */}
                   <div className="flex md:hidden">
                     <Sheet>
                       <SheetTrigger asChild>
-                        <button className="text-muted-foreground lg:hidden">
+                        <button className={cn(
+                          "lg:hidden",
+                          isViewerBgDark ? "text-white/70" : "text-muted-foreground",
+                        )}>
                           <PanelLeftIcon
                             className="h-5 w-5"
                             aria-hidden="true"
@@ -482,7 +500,10 @@ export default function DataroomViewer({
                         <BreadcrumbItem key={"root"}>
                           <BreadcrumbLink
                             onClick={() => setFolderId(null)}
-                            className="cursor-pointer"
+                            className={cn(
+                              "cursor-pointer",
+                              isViewerBgDark && "text-white/80 hover:text-white",
+                            )}
                           >
                             Home
                           </BreadcrumbLink>
@@ -531,12 +552,23 @@ export default function DataroomViewer({
 
                 {/* Search results banner */}
                 {searchQuery && (
-                  <div className="mt-4 rounded-md border border-muted/50 bg-muted px-4 py-3">
+                  <div className={cn(
+                    "mt-4 rounded-md border px-4 py-3",
+                    isViewerBgDark
+                      ? "border-white/20 bg-white/10"
+                      : "border-muted/50 bg-muted",
+                  )}>
                     <div className="flex items-center gap-2">
-                      <div className="text-sm font-medium text-muted-foreground">
+                      <div className={cn(
+                        "text-sm font-medium",
+                        isViewerBgDark ? "text-white/80" : "text-muted-foreground",
+                      )}>
                         Search results for &quot;{searchQuery}&quot;
                       </div>
-                      <div className="text-xs text-muted-foreground">
+                      <div className={cn(
+                        "text-xs",
+                        isViewerBgDark ? "text-white/60" : "text-muted-foreground",
+                      )}>
                         ({mixedItems.length} result
                         {mixedItems.length !== 1 ? "s" : ""} across all folders)
                       </div>
@@ -546,7 +578,10 @@ export default function DataroomViewer({
 
                 <ul role="list" className="-mx-4 space-y-4 overflow-auto p-4">
                   {mixedItems.length === 0 ? (
-                    <li className="py-6 text-center text-muted-foreground">
+                    <li className={cn(
+                      "py-6 text-center",
+                      isViewerBgDark ? "text-white/60" : "text-muted-foreground",
+                    )}>
                       {searchQuery
                         ? "No documents match your search."
                         : "No items available."}

--- a/components/view/viewer/notion-page.tsx
+++ b/components/view/viewer/notion-page.tsx
@@ -14,7 +14,7 @@ import { useSafePageViewTracker } from "@/lib/tracking/safe-page-view-tracker";
 import { getTrackingOptions } from "@/lib/tracking/tracking-config";
 import { NotionTheme } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { determineTextColor } from "@/lib/utils/determine-text-color";
+import { createAdaptiveSurfacePalette } from "@/lib/utils/create-adaptive-surface-palette";
 
 import {
   BreadcrumbItem,
@@ -137,6 +137,7 @@ export const NotionPage = ({
   navData: TNavData;
 }) => {
   const { isPreview, linkId, documentId, viewId, brand } = navData;
+  const navPalette = createAdaptiveSurfacePalette(brand?.brandColor);
   const [pageNumber, setPageNumber] = useState<number>(1); // start on first page
   const [loading, setLoading] = useState<boolean>(false);
   const [subPageId, setSubPageId] = useQueryState("pageid", {
@@ -509,7 +510,7 @@ export const NotionPage = ({
               className="cursor-pointer underline underline-offset-4"
               onClick={() => setSubPageId(null)}
               style={{
-                color: determineTextColor(brand?.brandColor),
+                color: navPalette.textColor,
               }}
             >
               {title}
@@ -524,7 +525,7 @@ export const NotionPage = ({
                 <BreadcrumbPage
                   className="font-medium"
                   style={{
-                    color: determineTextColor(brand?.brandColor),
+                    color: navPalette.textColor,
                   }}
                 >
                   {subTitle}

--- a/components/view/viewer/viewer-surface-theme.tsx
+++ b/components/view/viewer/viewer-surface-theme.tsx
@@ -14,11 +14,8 @@ export type ViewerSurfaceTheme = {
   usesLightText: boolean;
 };
 
-const DEFAULT_VIEWER_SURFACE_THEME: ViewerSurfaceTheme = {
-  palette: createAdaptiveSurfacePalette(undefined),
-  textTone: "dark",
-  usesLightText: false,
-};
+const DEFAULT_VIEWER_SURFACE_THEME: ViewerSurfaceTheme =
+  createViewerSurfaceTheme(null);
 
 const ViewerSurfaceThemeContext = createContext<ViewerSurfaceTheme>(
   DEFAULT_VIEWER_SURFACE_THEME,

--- a/components/view/viewer/viewer-surface-theme.tsx
+++ b/components/view/viewer/viewer-surface-theme.tsx
@@ -1,0 +1,55 @@
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+
+import {
+  AdaptiveSurfacePalette,
+  createAdaptiveSurfacePalette,
+} from "@/lib/utils/create-adaptive-surface-palette";
+
+type ViewerSurfaceTextTone = "light" | "dark";
+
+export type ViewerSurfaceTheme = {
+  palette: AdaptiveSurfacePalette;
+  textTone: ViewerSurfaceTextTone;
+  usesLightText: boolean;
+};
+
+const DEFAULT_VIEWER_SURFACE_THEME: ViewerSurfaceTheme = {
+  palette: createAdaptiveSurfacePalette(undefined),
+  textTone: "dark",
+  usesLightText: false,
+};
+
+const ViewerSurfaceThemeContext = createContext<ViewerSurfaceTheme>(
+  DEFAULT_VIEWER_SURFACE_THEME,
+);
+
+export function createViewerSurfaceTheme(
+  backgroundColor: string | null | undefined,
+): ViewerSurfaceTheme {
+  const palette = createAdaptiveSurfacePalette(backgroundColor || "#ffffff");
+
+  return {
+    palette,
+    textTone: palette.usesLightText ? "light" : "dark",
+    usesLightText: palette.usesLightText,
+  };
+}
+
+export function ViewerSurfaceThemeProvider({
+  value,
+  children,
+}: {
+  value: ViewerSurfaceTheme;
+  children: ReactNode;
+}) {
+  return (
+    <ViewerSurfaceThemeContext.Provider value={value}>
+      {children}
+    </ViewerSurfaceThemeContext.Provider>
+  );
+}
+
+export function useViewerSurfaceTheme() {
+  return useContext(ViewerSurfaceThemeContext);
+}

--- a/lib/api/links/link-data.ts
+++ b/lib/api/links/link-data.ts
@@ -300,6 +300,7 @@ export async function fetchDataroomLinkData({
       banner: true,
       brandColor: true,
       accentColor: true,
+      applyAccentColorToDataroomView: true,
       welcomeMessage: true,
     },
   });
@@ -311,6 +312,7 @@ export async function fetchDataroomLinkData({
       banner: true,
       brandColor: true,
       accentColor: true,
+      applyAccentColorToDataroomView: true,
       welcomeMessage: true,
     },
   });
@@ -320,6 +322,10 @@ export async function fetchDataroomLinkData({
     banner: dataroomBrand?.banner || teamBrand?.banner || null,
     brandColor: dataroomBrand?.brandColor || teamBrand?.brandColor,
     accentColor: dataroomBrand?.accentColor || teamBrand?.accentColor,
+    applyAccentColorToDataroomView:
+      dataroomBrand?.applyAccentColorToDataroomView ??
+      teamBrand?.applyAccentColorToDataroomView ??
+      false,
     welcomeMessage: dataroomBrand?.welcomeMessage || teamBrand?.welcomeMessage,
   };
 
@@ -440,6 +446,7 @@ export async function fetchDataroomDocumentLinkData({
       banner: true,
       brandColor: true,
       accentColor: true,
+      applyAccentColorToDataroomView: true,
       welcomeMessage: true,
     },
   });
@@ -451,6 +458,7 @@ export async function fetchDataroomDocumentLinkData({
       banner: true,
       brandColor: true,
       accentColor: true,
+      applyAccentColorToDataroomView: true,
       welcomeMessage: true,
     },
   });
@@ -460,6 +468,10 @@ export async function fetchDataroomDocumentLinkData({
     banner: dataroomBrand?.banner || teamBrand?.banner || null,
     brandColor: dataroomBrand?.brandColor || teamBrand?.brandColor,
     accentColor: dataroomBrand?.accentColor || teamBrand?.accentColor,
+    applyAccentColorToDataroomView:
+      dataroomBrand?.applyAccentColorToDataroomView ??
+      teamBrand?.applyAccentColorToDataroomView ??
+      false,
     welcomeMessage: dataroomBrand?.welcomeMessage || teamBrand?.welcomeMessage,
   };
 

--- a/lib/utils/create-adaptive-surface-palette.ts
+++ b/lib/utils/create-adaptive-surface-palette.ts
@@ -1,0 +1,190 @@
+type Rgb = { r: number; g: number; b: number };
+
+export type AdaptiveSurfacePalette = {
+  backgroundColor?: string;
+  rgb: Rgb;
+  usesLightText: boolean;
+  isDefaultLightSurface: boolean;
+  textColor: string;
+  mutedTextColor: string;
+  subtleTextColor: string;
+  inverseTextColor: string;
+  panelBgColor: string;
+  panelHoverBgColor: string;
+  panelActiveBgColor: string;
+  panelBorderColor: string;
+  panelBorderHoverColor: string;
+  controlBgColor: string;
+  controlBorderColor: string;
+  controlBorderStrongColor: string;
+  controlIconColor: string;
+  controlPlaceholderColor: string;
+  ctaBgColor: string;
+  ctaTextColor: string;
+};
+
+const LIGHT_TEXT: Rgb = { r: 248, g: 250, b: 252 };
+const DARK_TEXT: Rgb = { r: 15, g: 23, b: 42 };
+const FALLBACK_BG: Rgb = { r: 3, g: 7, b: 18 };
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function hexToRgb(hex: string): Rgb | null {
+  if (!hex.startsWith("#")) return null;
+  const compact = hex.trim();
+
+  if (compact.length === 4) {
+    const r = parseInt(compact[1] + compact[1], 16);
+    const g = parseInt(compact[2] + compact[2], 16);
+    const b = parseInt(compact[3] + compact[3], 16);
+    return { r, g, b };
+  }
+
+  if (compact.length === 7) {
+    const r = parseInt(compact.slice(1, 3), 16);
+    const g = parseInt(compact.slice(3, 5), 16);
+    const b = parseInt(compact.slice(5, 7), 16);
+    return { r, g, b };
+  }
+
+  return null;
+}
+
+function rgbStringToRgb(input: string): Rgb | null {
+  const match = input
+    .trim()
+    .match(/^rgba?\(\s*([0-9.]+)[,\s]+([0-9.]+)[,\s]+([0-9.]+)/i);
+  if (!match) return null;
+
+  return {
+    r: clamp(Math.round(Number(match[1])), 0, 255),
+    g: clamp(Math.round(Number(match[2])), 0, 255),
+    b: clamp(Math.round(Number(match[3])), 0, 255),
+  };
+}
+
+function parseToRgb(color: string | null | undefined): Rgb {
+  if (!color) return FALLBACK_BG;
+  return hexToRgb(color) || rgbStringToRgb(color) || FALLBACK_BG;
+}
+
+function toCssRgb(rgb: Rgb) {
+  return `rgb(${rgb.r} ${rgb.g} ${rgb.b})`;
+}
+
+function mixRgb(background: Rgb, foreground: Rgb, amount: number): Rgb {
+  const weight = clamp(amount, 0, 1);
+  return {
+    r: Math.round(background.r + (foreground.r - background.r) * weight),
+    g: Math.round(background.g + (foreground.g - background.g) * weight),
+    b: Math.round(background.b + (foreground.b - background.b) * weight),
+  };
+}
+
+function toLinearChannel(channel: number) {
+  const value = channel / 255;
+  return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+}
+
+function luminance(rgb: Rgb) {
+  return (
+    0.2126 * toLinearChannel(rgb.r) +
+    0.7152 * toLinearChannel(rgb.g) +
+    0.0722 * toLinearChannel(rgb.b)
+  );
+}
+
+function contrastRatio(a: Rgb, b: Rgb) {
+  const l1 = luminance(a);
+  const l2 = luminance(b);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function saturation(rgb: Rgb) {
+  const r = rgb.r / 255;
+  const g = rgb.g / 255;
+  const b = rgb.b / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  if (max === min) return 0;
+  const lightness = (max + min) / 2;
+  const delta = max - min;
+  return delta / (1 - Math.abs(2 * lightness - 1));
+}
+
+export function createAdaptiveSurfacePalette(
+  backgroundColor: string | null | undefined,
+): AdaptiveSurfacePalette {
+  const rgb = parseToRgb(backgroundColor);
+  const bgLuminance = luminance(rgb);
+  const lightContrast = contrastRatio(rgb, LIGHT_TEXT);
+  const darkContrast = contrastRatio(rgb, DARK_TEXT);
+  const usesLightText = lightContrast >= darkContrast;
+  const isDefaultLightSurface =
+    bgLuminance >= 0.97 &&
+    saturation(rgb) <= 0.08 &&
+    (!backgroundColor || backgroundColor.toLowerCase() !== "black");
+
+  const textRgb = usesLightText ? LIGHT_TEXT : DARK_TEXT;
+  const inverseTextRgb = usesLightText ? DARK_TEXT : LIGHT_TEXT;
+  const sat = saturation(rgb);
+  const saturationNormalizer = clamp(1 - sat * 0.35, 0.65, 1);
+
+  const mix = (value: number) => clamp(value * saturationNormalizer, 0, 0.95);
+  const panelBase = usesLightText ? 0.13 : 0.08;
+
+  return {
+    backgroundColor: backgroundColor || undefined,
+    rgb,
+    usesLightText,
+    isDefaultLightSurface,
+    textColor: toCssRgb(textRgb),
+    mutedTextColor: toCssRgb(mixRgb(rgb, textRgb, usesLightText ? 0.7 : 0.62)),
+    subtleTextColor: toCssRgb(mixRgb(rgb, textRgb, usesLightText ? 0.58 : 0.5)),
+    inverseTextColor: toCssRgb(inverseTextRgb),
+    panelBgColor: isDefaultLightSurface
+      ? "transparent"
+      : toCssRgb(mixRgb(rgb, textRgb, mix(panelBase))),
+    panelHoverBgColor: isDefaultLightSurface
+      ? "rgb(248 250 252)"
+      : toCssRgb(
+          mixRgb(rgb, textRgb, mix(panelBase + (usesLightText ? 0.06 : 0.04))),
+        ),
+    panelActiveBgColor: isDefaultLightSurface
+      ? "rgb(241 245 249)"
+      : toCssRgb(
+          mixRgb(rgb, textRgb, mix(panelBase + (usesLightText ? 0.1 : 0.07))),
+        ),
+    panelBorderColor: isDefaultLightSurface
+      ? "rgb(226 232 240)"
+      : toCssRgb(mixRgb(rgb, textRgb, mix(usesLightText ? 0.25 : 0.17))),
+    panelBorderHoverColor: isDefaultLightSurface
+      ? "rgb(203 213 225)"
+      : toCssRgb(mixRgb(rgb, textRgb, mix(usesLightText ? 0.34 : 0.24))),
+    controlBgColor: toCssRgb(
+      mixRgb(
+        rgb,
+        usesLightText ? textRgb : LIGHT_TEXT,
+        mix(usesLightText ? 0.1 : 0.16),
+      ),
+    ),
+    controlBorderColor: toCssRgb(
+      mixRgb(rgb, textRgb, mix(usesLightText ? 0.24 : 0.15)),
+    ),
+    controlBorderStrongColor: toCssRgb(
+      mixRgb(rgb, textRgb, mix(usesLightText ? 0.34 : 0.23)),
+    ),
+    controlIconColor: toCssRgb(
+      mixRgb(rgb, textRgb, usesLightText ? 0.64 : 0.58),
+    ),
+    controlPlaceholderColor: toCssRgb(
+      mixRgb(rgb, textRgb, usesLightText ? 0.56 : 0.68),
+    ),
+    ctaBgColor: toCssRgb(textRgb),
+    ctaTextColor: toCssRgb(rgb),
+  };
+}

--- a/pages/api/teams/[teamId]/branding.ts
+++ b/pages/api/teams/[teamId]/branding.ts
@@ -59,11 +59,19 @@ export default async function handle(
     return res.status(200).json(brand);
   } else if (req.method === "POST") {
     // POST /api/teams/:teamId/branding
-    const { logo, banner, brandColor, accentColor, welcomeMessage } = req.body as {
+    const {
+      logo,
+      banner,
+      brandColor,
+      accentColor,
+      applyAccentColorToDataroomView,
+      welcomeMessage,
+    } = req.body as {
       logo?: string;
       banner?: string;
       brandColor?: string;
       accentColor?: string;
+      applyAccentColorToDataroomView?: boolean;
       welcomeMessage?: string;
     };
 
@@ -74,6 +82,7 @@ export default async function handle(
         banner,
         brandColor,
         accentColor,
+        applyAccentColorToDataroomView: !!applyAccentColorToDataroomView,
         welcomeMessage,
         teamId: teamId,
       },
@@ -87,11 +96,19 @@ export default async function handle(
     return res.status(200).json(brand);
   } else if (req.method === "PUT") {
     // PUT /api/teams/:teamId/branding
-    const { logo, banner, brandColor, accentColor, welcomeMessage } = req.body as {
+    const {
+      logo,
+      banner,
+      brandColor,
+      accentColor,
+      applyAccentColorToDataroomView,
+      welcomeMessage,
+    } = req.body as {
       logo?: string;
       banner?: string;
       brandColor?: string;
       accentColor?: string;
+      applyAccentColorToDataroomView?: boolean;
       welcomeMessage?: string;
     };
 
@@ -105,6 +122,7 @@ export default async function handle(
         banner,
         brandColor,
         accentColor,
+        applyAccentColorToDataroomView: !!applyAccentColorToDataroomView,
         welcomeMessage,
         teamId: teamId,
       },
@@ -113,6 +131,7 @@ export default async function handle(
         banner,
         brandColor,
         accentColor,
+        applyAccentColorToDataroomView: !!applyAccentColorToDataroomView,
         welcomeMessage,
       },
     });

--- a/pages/api/teams/[teamId]/datarooms/[id]/branding.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/branding.ts
@@ -70,11 +70,19 @@ export default async function handle(
     return res.status(200).json(brand);
   } else if (req.method === "POST") {
     // POST /api/teams/:teamId/datarooms/:id/branding
-    const { logo, banner, brandColor, accentColor, welcomeMessage } = req.body as {
+    const {
+      logo,
+      banner,
+      brandColor,
+      accentColor,
+      applyAccentColorToDataroomView,
+      welcomeMessage,
+    } = req.body as {
       logo?: string;
       banner?: string;
       brandColor?: string;
       accentColor?: string;
+      applyAccentColorToDataroomView?: boolean;
       welcomeMessage?: string;
     };
 
@@ -85,6 +93,7 @@ export default async function handle(
         banner,
         brandColor,
         accentColor,
+        applyAccentColorToDataroomView: !!applyAccentColorToDataroomView,
         welcomeMessage,
         dataroomId,
       },
@@ -93,11 +102,19 @@ export default async function handle(
     return res.status(200).json(brand);
   } else if (req.method === "PUT") {
     // PUT /api/teams/:teamId/datarooms/:id/branding
-    const { logo, banner, brandColor, accentColor, welcomeMessage } = req.body as {
+    const {
+      logo,
+      banner,
+      brandColor,
+      accentColor,
+      applyAccentColorToDataroomView,
+      welcomeMessage,
+    } = req.body as {
       logo?: string;
       banner?: string;
       brandColor?: string;
       accentColor?: string;
+      applyAccentColorToDataroomView?: boolean;
       welcomeMessage?: string;
     };
 
@@ -110,6 +127,7 @@ export default async function handle(
         banner,
         brandColor,
         accentColor,
+        applyAccentColorToDataroomView: !!applyAccentColorToDataroomView,
         welcomeMessage,
       },
     });

--- a/pages/api/teams/[teamId]/datarooms/[id]/duplicate.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/duplicate.ts
@@ -234,6 +234,9 @@ export default async function handle(
               banner: dataroomContents.brand?.banner,
               logo: dataroomContents.brand?.logo,
               accentColor: dataroomContents.brand?.accentColor,
+              applyAccentColorToDataroomView:
+                (dataroomContents.brand as any)?.applyAccentColorToDataroomView ??
+                false,
               brandColor: dataroomContents.brand?.brandColor,
             },
           },

--- a/pages/branding.tsx
+++ b/pages/branding.tsx
@@ -20,6 +20,7 @@ import AppLayout from "@/components/layouts/app";
 import { NavMenu } from "@/components/navigation-menu";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import LoadingSpinner from "@/components/ui/loading-spinner";
 import {
@@ -47,6 +48,8 @@ export default function Branding() {
   const [welcomeMessage, setWelcomeMessage] = useState<string>(
     "Your action is requested to continue",
   );
+  const [applyAccentColorToDataroomView, setApplyAccentColorToDataroomView] =
+    useState<boolean>(false);
   const [debouncedBrandColor] = useDebounce(brandColor, 300);
   const [debouncedAccentColor] = useDebounce(accentColor, 300);
   const [debouncedWelcomeMessage] = useDebounce(welcomeMessage, 500);
@@ -147,6 +150,9 @@ export default function Branding() {
       setAccentColor(brand.accentColor || "#FFFFFF");
       setLogo(brand.logo || null);
       setBanner(brand.banner || null);
+      setApplyAccentColorToDataroomView(
+        (brand as any)?.applyAccentColorToDataroomView ?? false,
+      );
       const message =
         brand.welcomeMessage || "Your action is requested to continue";
       setWelcomeMessage(message);
@@ -196,6 +202,7 @@ export default function Branding() {
         welcomeMessage.trim() || "Your action is requested to continue",
       brandColor: brandColor,
       accentColor: accentColor,
+      applyAccentColorToDataroomView,
       logo: logoBlobUrl,
       // Only include banner if user has dataroom access (Business+)
       ...(hasDataroomAccess && { banner: bannerBlobUrl }),
@@ -241,6 +248,7 @@ export default function Branding() {
       setBanner(null);
       setBrandColor("#000000");
       setAccentColor("#030712");
+      setApplyAccentColorToDataroomView(false);
       setWelcomeMessage("Your action is requested to continue");
       setWelcomeMessageError(null);
       setIsLoading(false);
@@ -652,6 +660,35 @@ export default function Branding() {
                           )}
                         </div>
                       </div>
+                      {hasDataroomAccess && (
+                        <div className="rounded-md border border-border/70 p-3">
+                          <div className="flex items-start space-x-3">
+                            <Checkbox
+                              id="global-apply-accent-to-dataroom-view"
+                              checked={applyAccentColorToDataroomView}
+                              onCheckedChange={(checked) =>
+                                setApplyAccentColorToDataroomView(
+                                  checked === true,
+                                )
+                              }
+                              className="mt-0.5"
+                            />
+                            <div className="space-y-1">
+                              <Label
+                                htmlFor="global-apply-accent-to-dataroom-view"
+                                className="cursor-pointer text-sm font-medium"
+                              >
+                                Apply background color to dataroom view by
+                                default
+                              </Label>
+                              <p className="text-xs text-muted-foreground">
+                                Dataroom-specific branding can still override
+                                this.
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                      )}
                     </div>
                   </CardContent>
                 </Card>
@@ -876,10 +913,10 @@ export default function Branding() {
                           <div className="relative min-h-0 flex-1 overflow-x-auto">
                             <div className="relative h-full max-w-[1396px]">
                               <iframe
-                                key={`dataroom-view-${debouncedBrandColor}-${debouncedAccentColor}-${banner}`}
+                                key={`dataroom-view-${debouncedBrandColor}-${debouncedAccentColor}-${banner}-${applyAccentColorToDataroomView}`}
                                 name="dataroom-view"
                                 id="dataroom-view"
-                                src={`/room_ppreview_demo?brandColor=${encodeURIComponent(debouncedBrandColor)}&accentColor=${encodeURIComponent(debouncedAccentColor)}&brandLogo=${blobUrl ? encodeURIComponent(blobUrl) : logo ? encodeURIComponent(logo) : ""}&brandBanner=${banner === "no-banner" ? encodeURIComponent("no-banner") : bannerBlobUrl ? encodeURIComponent(bannerBlobUrl) : banner ? encodeURIComponent(banner) : ""}`}
+                                src={`/room_ppreview_demo?brandColor=${encodeURIComponent(debouncedBrandColor)}&accentColor=${encodeURIComponent(debouncedAccentColor)}&applyAccentColorToDataroomView=${applyAccentColorToDataroomView ? "1" : "0"}&brandLogo=${blobUrl ? encodeURIComponent(blobUrl) : logo ? encodeURIComponent(logo) : ""}&brandBanner=${banner === "no-banner" ? encodeURIComponent("no-banner") : bannerBlobUrl ? encodeURIComponent(bannerBlobUrl) : banner ? encodeURIComponent(banner) : ""}`}
                                 className="absolute left-0 top-0 h-full w-full origin-top-left scale-50 overflow-hidden rounded-b-lg border-0 bg-white"
                                 style={{
                                   width: "200%",

--- a/pages/datarooms/[id]/branding/index.tsx
+++ b/pages/datarooms/[id]/branding/index.tsx
@@ -19,6 +19,7 @@ import { DataroomNavigation } from "@/components/datarooms/dataroom-navigation";
 import AppLayout from "@/components/layouts/app";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import {
   Popover,
@@ -42,6 +43,8 @@ export default function DataroomBrandPage() {
 
   const [brandColor, setBrandColor] = useState<string>("#000000");
   const [accentColor, setAccentColor] = useState<string>("#FFFFFF");
+  const [applyAccentColorToDataroomView, setApplyAccentColorToDataroomView] =
+    useState<boolean>(false);
   const [logo, setLogo] = useState<string | null>(null);
   const [banner, setBanner] = useState<string | null>(null);
   const [originalBanner, setOriginalBanner] = useState<string | null>(null);
@@ -148,6 +151,11 @@ export default function DataroomBrandPage() {
       setAccentColor(
         dataroomBrand?.accentColor || globalBrand?.accentColor || "#FFFFFF",
       );
+      setApplyAccentColorToDataroomView(
+        (dataroomBrand as any)?.applyAccentColorToDataroomView ??
+          (globalBrand as any)?.applyAccentColorToDataroomView ??
+          false,
+      );
       setLogo(dataroomBrand?.logo || globalBrand?.logo || null);
       const bannerValue = dataroomBrand?.banner || globalBrand?.banner || null;
       setBanner(bannerValue);
@@ -216,6 +224,7 @@ export default function DataroomBrandPage() {
         welcomeMessage.trim() || "Your action is requested to continue",
       brandColor: brandColor,
       accentColor: accentColor,
+      applyAccentColorToDataroomView,
       logo: blobUrl,
       banner: bannerBlobUrl,
     };
@@ -258,6 +267,9 @@ export default function DataroomBrandPage() {
       setBanner(DEFAULT_BANNER_IMAGE);
       setOriginalBanner(DEFAULT_BANNER_IMAGE);
       setBrandColor("#000000");
+      setApplyAccentColorToDataroomView(
+        (globalBrand as any)?.applyAccentColorToDataroomView ?? false,
+      );
       setIsLoading(false);
       toast.success("Branding reset successfully");
       router.reload();
@@ -585,7 +597,7 @@ export default function DataroomBrandPage() {
                     <Label htmlFor="accent-color">
                       Background Color{" "}
                       <span className="font-normal text-muted-foreground">
-                        (dataroom &amp; front page)
+                        (front page &amp; document view)
                       </span>
                     </Label>
                     <div className="flex items-center space-x-3">
@@ -658,6 +670,26 @@ export default function DataroomBrandPage() {
                         {accentColor === "#030712" && (
                           <Check className="absolute left-1/2 top-1/2 h-5 w-5 -translate-x-1/2 -translate-y-1/2 text-white" />
                         )}
+                      </div>
+                    </div>
+                    <div className="flex items-start space-x-2 pt-2">
+                      <Checkbox
+                        id="apply-accent-to-dataroom-view"
+                        checked={applyAccentColorToDataroomView}
+                        onCheckedChange={(checked) =>
+                          setApplyAccentColorToDataroomView(checked === true)
+                        }
+                      />
+                      <div className="space-y-1">
+                        <Label
+                          htmlFor="apply-accent-to-dataroom-view"
+                          className="cursor-pointer"
+                        >
+                          Also apply this background color to dataroom view
+                        </Label>
+                        <p className="text-xs text-muted-foreground">
+                          When disabled, dataroom view stays white.
+                        </p>
                       </div>
                     </div>
                   </div>
@@ -798,7 +830,7 @@ export default function DataroomBrandPage() {
                             key={`dataroom-view-${debouncedBrandColor}-${debouncedAccentColor}-${banner}`}
                             name="dataroom-view"
                             id="dataroom-view"
-                            src={`/room_ppreview_demo?brandColor=${encodeURIComponent(debouncedBrandColor)}&accentColor=${encodeURIComponent(debouncedAccentColor)}&brandLogo=${blobUrl ? encodeURIComponent(blobUrl) : logo ? encodeURIComponent(logo) : ""}&brandBanner=${banner === "no-banner" ? encodeURIComponent("no-banner") : bannerBlobUrl ? encodeURIComponent(bannerBlobUrl) : banner ? encodeURIComponent(banner) : ""}`}
+                            src={`/room_ppreview_demo?brandColor=${encodeURIComponent(debouncedBrandColor)}&accentColor=${encodeURIComponent(debouncedAccentColor)}&applyAccentColorToDataroomView=${applyAccentColorToDataroomView ? "1" : "0"}&brandLogo=${blobUrl ? encodeURIComponent(blobUrl) : logo ? encodeURIComponent(logo) : ""}&brandBanner=${banner === "no-banner" ? encodeURIComponent("no-banner") : bannerBlobUrl ? encodeURIComponent(bannerBlobUrl) : banner ? encodeURIComponent(banner) : ""}`}
                             className="absolute left-0 top-0 h-full w-full origin-top-left scale-50 overflow-hidden rounded-b-lg border-0 bg-white"
                             style={{
                               width: "200%",

--- a/pages/datarooms/[id]/branding/index.tsx
+++ b/pages/datarooms/[id]/branding/index.tsx
@@ -585,7 +585,7 @@ export default function DataroomBrandPage() {
                     <Label htmlFor="accent-color">
                       Background Color{" "}
                       <span className="font-normal text-muted-foreground">
-                        (front page)
+                        (dataroom &amp; front page)
                       </span>
                     </Label>
                     <div className="flex items-center space-x-3">

--- a/pages/entrance_ppreview_demo.tsx
+++ b/pages/entrance_ppreview_demo.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
+import type { CSSProperties } from "react";
 
-import { determineTextColor } from "@/lib/utils/determine-text-color";
+import { createAdaptiveSurfacePalette } from "@/lib/utils/create-adaptive-surface-palette";
 
 import { Button } from "@/components/ui/button";
 
@@ -10,6 +11,7 @@ export default function ViewPage() {
     accentColor: string;
     welcomeMessage?: string;
   };
+  const palette = createAdaptiveSurfacePalette(accentColor);
 
   return (
     <div className="bg-gray-950" style={{ backgroundColor: accentColor }}>
@@ -21,7 +23,7 @@ export default function ViewPage() {
           <h1
             className="mt-16 text-2xl font-bold leading-9 tracking-tight text-white"
             style={{
-              color: determineTextColor(accentColor),
+              color: palette.textColor,
             }}
           >
             {welcomeMessage || "Your action is requested to continue"}
@@ -36,7 +38,7 @@ export default function ViewPage() {
                   htmlFor="email"
                   className="block text-sm font-medium leading-6 text-white"
                   style={{
-                    color: determineTextColor(accentColor),
+                    color: palette.textColor,
                   }}
                 >
                   Email address
@@ -48,13 +50,19 @@ export default function ViewPage() {
                   autoCorrect="off"
                   autoComplete="email"
                   autoFocus
-                  className="flex w-full rounded-md border-0 bg-black py-1.5 text-white shadow-sm ring-1 ring-inset ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-gray-300 sm:text-sm sm:leading-6"
-                  style={{ backgroundColor: accentColor }}
+                  className="flex w-full cursor-text rounded-md border-0 bg-black py-1.5 text-white shadow-sm ring-1 ring-inset ring-gray-600 placeholder:text-[var(--access-placeholder)] focus:ring-2 focus:ring-inset focus:ring-[var(--access-input-focus)] sm:text-sm sm:leading-6"
+                  style={{
+                    backgroundColor: palette.controlBgColor,
+                    borderColor: palette.controlBorderColor,
+                    "--access-placeholder": palette.controlPlaceholderColor,
+                    "--access-input-focus": palette.controlBorderStrongColor,
+                    color: palette.textColor,
+                  } as CSSProperties}
                   placeholder="Enter email"
                   aria-invalid="true"
                   data-1p-ignore
                 />
-                <p className="text-sm text-gray-500">
+                <p className="text-sm" style={{ color: palette.subtleTextColor }}>
                   This data will be shared with the sender.
                 </p>
               </div>

--- a/pages/room_ppreview_demo.tsx
+++ b/pages/room_ppreview_demo.tsx
@@ -1,30 +1,46 @@
 import { useRouter } from "next/router";
 
-import { determineTextColor } from "@/lib/utils/determine-text-color";
-
 import { ViewFolderTree } from "@/components/datarooms/folders";
 import DocumentCard from "@/components/view/dataroom/document-card";
 import FolderCard from "@/components/view/dataroom/folder-card";
+import {
+  ViewerSurfaceThemeProvider,
+  createViewerSurfaceTheme,
+} from "@/components/view/viewer/viewer-surface-theme";
 
 const DEFAULT_BANNER_IMAGE = "/_static/papermark-banner.png";
 
 export default function ViewPage() {
   const router = useRouter();
-  const { brandLogo, brandColor, brandBanner, accentColor } = router.query as {
+  const {
+    brandLogo,
+    brandColor,
+    brandBanner,
+    accentColor,
+    applyAccentColorToDataroomView,
+  } = router.query as {
     brandLogo: string;
     brandColor: string;
     brandBanner: string;
     accentColor: string;
+    applyAccentColorToDataroomView?: string;
   };
 
-  const isViewerBgDark = accentColor
-    ? determineTextColor(accentColor) === "white"
-    : false;
+  const shouldApplyAccentToDataroomView =
+    applyAccentColorToDataroomView === "1";
+  const dataroomViewBackgroundColor = shouldApplyAccentToDataroomView
+    ? accentColor
+    : "#ffffff";
+  const previewSurfaceTheme = createViewerSurfaceTheme(dataroomViewBackgroundColor);
 
   return (
     <div
       className="bg-white"
-      style={accentColor ? { backgroundColor: accentColor } : undefined}
+      style={
+        dataroomViewBackgroundColor
+          ? { backgroundColor: dataroomViewBackgroundColor }
+          : undefined
+      }
     >
       {/* Nav */}
       <nav
@@ -74,147 +90,147 @@ export default function ViewPage() {
       </nav>
 
       {/* Body */}
-      <div style={{ height: "calc(100vh - 64px)" }} className="relative flex">
-        {/* Tree view */}
-        <div
-          className="hidden h-full w-1/4 space-y-8 overflow-auto px-3 pb-4 pt-4 md:flex md:px-6 md:pt-6 lg:px-8 lg:pt-9 xl:px-14"
-          style={isViewerBgDark ? { color: "white" } : undefined}
-        >
-          <ViewFolderTree
-            folders={[
-              {
-                id: "1",
-                name: "Marketing",
-                parentId: null,
-                dataroomId: "1",
-                orderIndex: 0,
-                hierarchicalIndex: null,
-                path: "/",
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                icon: null,
-                color: null,
-              },
-              {
-                id: "2",
-                name: "Sales",
-                parentId: null,
-                dataroomId: "1",
-                orderIndex: 1,
-                hierarchicalIndex: null,
-                path: "/",
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                icon: null,
-                color: null,
-              },
-            ]}
-            documents={[
-              {
-                id: "1",
-                name: "Q4 Report.pdf",
-                dataroomDocumentId: "1",
-                folderId: null,
-                hierarchicalIndex: null,
-                versions: [
-                  {
-                    id: "1",
-                    versionNumber: 1,
-                    hasPages: true,
-                  },
-                ],
-              },
-            ]}
-            setFolderId={() => {}}
-            folderId={null}
-          />
-        </div>
-
-        {/* Detail view */}
-        <div className="flex-grow overflow-auto">
-          <div className="h-full space-y-8 px-3 pb-4 pt-4 md:px-6 md:pt-6 lg:px-8 lg:pt-9 xl:px-14">
-            <div className="space-y-4">
-              <div
-                className="text-sm"
-                style={isViewerBgDark ? { color: "rgba(255,255,255,0.7)" } : undefined}
-              >Home</div>
-              <ul className="grid gap-4">
-                <li key="1">
-                  <FolderCard
-                    folder={{
+      <ViewerSurfaceThemeProvider value={previewSurfaceTheme}>
+        <div style={{ height: "calc(100vh - 64px)" }} className="relative flex">
+          {/* Tree view */}
+          <div
+            className="hidden h-full w-1/4 space-y-8 overflow-auto px-3 pb-4 pt-4 md:flex md:px-6 md:pt-6 lg:px-8 lg:pt-9 xl:px-14"
+          >
+            <ViewFolderTree
+              folders={[
+                {
+                  id: "1",
+                  name: "Marketing",
+                  parentId: null,
+                  dataroomId: "1",
+                  orderIndex: 0,
+                  hierarchicalIndex: null,
+                  path: "/",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  icon: null,
+                  color: null,
+                },
+                {
+                  id: "2",
+                  name: "Sales",
+                  parentId: null,
+                  dataroomId: "1",
+                  orderIndex: 1,
+                  hierarchicalIndex: null,
+                  path: "/",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  icon: null,
+                  color: null,
+                },
+              ]}
+              documents={[
+                {
+                  id: "1",
+                  name: "Q4 Report.pdf",
+                  dataroomDocumentId: "1",
+                  folderId: null,
+                  hierarchicalIndex: null,
+                  versions: [
+                    {
                       id: "1",
-                      name: "Marketing",
-                      parentId: null,
-                      dataroomId: "1",
-                      orderIndex: 0,
-                      hierarchicalIndex: null,
-                      path: "/",
-                      createdAt: new Date(),
-                      updatedAt: new Date(),
-                      icon: null,
-                      color: null,
-                    }}
-                    dataroomId="1"
-                    setFolderId={() => {}}
-                    isPreview={false}
-                    linkId="1"
-                    allowDownload={false}
-                  />
-                </li>
+                      versionNumber: 1,
+                      hasPages: true,
+                    },
+                  ],
+                },
+              ]}
+              setFolderId={() => {}}
+              folderId={null}
+            />
+          </div>
 
-                <li key="2">
-                  <FolderCard
-                    folder={{
-                      id: "2",
-                      name: "Sales",
-                      parentId: null,
-                      dataroomId: "1",
-                      orderIndex: 1,
-                      hierarchicalIndex: null,
-                      path: "/",
-                      createdAt: new Date(),
-                      updatedAt: new Date(),
-                      icon: null,
-                      color: null,
-                    }}
-                    dataroomId="1"
-                    setFolderId={() => {}}
-                    isPreview={false}
-                    linkId="1"
-                    allowDownload={false}
-                  />
-                </li>
+          {/* Detail view */}
+          <div className="flex-grow overflow-auto">
+            <div className="h-full space-y-8 px-3 pb-4 pt-4 md:px-6 md:pt-6 lg:px-8 lg:pt-9 xl:px-14">
+              <div className="space-y-4">
+                <div
+                  className={`text-sm ${previewSurfaceTheme.usesLightText ? "text-white/70" : "text-muted-foreground"}`}
+                >Home</div>
+                <ul className="grid gap-4">
+                  <li key="1">
+                    <FolderCard
+                      folder={{
+                        id: "1",
+                        name: "Marketing",
+                        parentId: null,
+                        dataroomId: "1",
+                        orderIndex: 0,
+                        hierarchicalIndex: null,
+                        path: "/",
+                        createdAt: new Date(),
+                        updatedAt: new Date(),
+                        icon: null,
+                        color: null,
+                      }}
+                      dataroomId="1"
+                      setFolderId={() => {}}
+                      isPreview={false}
+                      linkId="1"
+                      allowDownload={false}
+                    />
+                  </li>
 
-                <li key="3">
-                  <DocumentCard
-                    document={{
-                      id: "1",
-                      name: "Q4 Report.pdf",
-                      dataroomDocumentId: "1",
-                      downloadOnly: false,
-                      canDownload: false,
-                      hierarchicalIndex: null,
-                      versions: [
-                        {
-                          id: "1",
-                          type: "pdf",
-                          versionNumber: 1,
-                          hasPages: true,
-                          isVertical: true,
-                          updatedAt: new Date(),
-                        },
-                      ],
-                    }}
-                    linkId="1"
-                    isPreview={false}
-                    allowDownload={false}
-                  />
-                </li>
-              </ul>
+                  <li key="2">
+                    <FolderCard
+                      folder={{
+                        id: "2",
+                        name: "Sales",
+                        parentId: null,
+                        dataroomId: "1",
+                        orderIndex: 1,
+                        hierarchicalIndex: null,
+                        path: "/",
+                        createdAt: new Date(),
+                        updatedAt: new Date(),
+                        icon: null,
+                        color: null,
+                      }}
+                      dataroomId="1"
+                      setFolderId={() => {}}
+                      isPreview={false}
+                      linkId="1"
+                      allowDownload={false}
+                    />
+                  </li>
+
+                  <li key="3">
+                    <DocumentCard
+                      document={{
+                        id: "1",
+                        name: "Q4 Report.pdf",
+                        dataroomDocumentId: "1",
+                        downloadOnly: false,
+                        canDownload: false,
+                        hierarchicalIndex: null,
+                        versions: [
+                          {
+                            id: "1",
+                            type: "pdf",
+                            versionNumber: 1,
+                            hasPages: true,
+                            isVertical: true,
+                            updatedAt: new Date(),
+                          },
+                        ],
+                      }}
+                      linkId="1"
+                      isPreview={false}
+                      allowDownload={false}
+                    />
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </ViewerSurfaceThemeProvider>
     </div>
   );
 }

--- a/pages/room_ppreview_demo.tsx
+++ b/pages/room_ppreview_demo.tsx
@@ -1,5 +1,7 @@
 import { useRouter } from "next/router";
 
+import { determineTextColor } from "@/lib/utils/determine-text-color";
+
 import { ViewFolderTree } from "@/components/datarooms/folders";
 import DocumentCard from "@/components/view/dataroom/document-card";
 import FolderCard from "@/components/view/dataroom/folder-card";
@@ -8,14 +10,22 @@ const DEFAULT_BANNER_IMAGE = "/_static/papermark-banner.png";
 
 export default function ViewPage() {
   const router = useRouter();
-  const { brandLogo, brandColor, brandBanner } = router.query as {
+  const { brandLogo, brandColor, brandBanner, accentColor } = router.query as {
     brandLogo: string;
     brandColor: string;
     brandBanner: string;
+    accentColor: string;
   };
 
+  const isViewerBgDark = accentColor
+    ? determineTextColor(accentColor) === "white"
+    : false;
+
   return (
-    <div className="bg-white">
+    <div
+      className="bg-white"
+      style={accentColor ? { backgroundColor: accentColor } : undefined}
+    >
       {/* Nav */}
       <nav
         className="bg-black"
@@ -66,7 +76,10 @@ export default function ViewPage() {
       {/* Body */}
       <div style={{ height: "calc(100vh - 64px)" }} className="relative flex">
         {/* Tree view */}
-        <div className="hidden h-full w-1/4 space-y-8 overflow-auto px-3 pb-4 pt-4 md:flex md:px-6 md:pt-6 lg:px-8 lg:pt-9 xl:px-14">
+        <div
+          className="hidden h-full w-1/4 space-y-8 overflow-auto px-3 pb-4 pt-4 md:flex md:px-6 md:pt-6 lg:px-8 lg:pt-9 xl:px-14"
+          style={isViewerBgDark ? { color: "white" } : undefined}
+        >
           <ViewFolderTree
             folders={[
               {
@@ -121,7 +134,10 @@ export default function ViewPage() {
         <div className="flex-grow overflow-auto">
           <div className="h-full space-y-8 px-3 pb-4 pt-4 md:px-6 md:pt-6 lg:px-8 lg:pt-9 xl:px-14">
             <div className="space-y-4">
-              <div className="text-sm text-muted-foreground">Home</div>
+              <div
+                className="text-sm"
+                style={isViewerBgDark ? { color: "rgba(255,255,255,0.7)" } : undefined}
+              >Home</div>
               <ul className="grid gap-4">
                 <li key="1">
                   <FolderCard

--- a/prisma/migrations/20260219171000_add_dataroom_bg_toggle_to_brand/migration.sql
+++ b/prisma/migrations/20260219171000_add_dataroom_bg_toggle_to_brand/migration.sql
@@ -1,0 +1,7 @@
+-- Add toggle to control whether accentColor applies to dataroom viewer
+ALTER TABLE "DataroomBrand"
+ADD COLUMN "applyAccentColorToDataroomView" BOOLEAN NOT NULL DEFAULT false;
+
+-- Add global toggle to control whether accentColor applies to dataroom viewer by default
+ALTER TABLE "Brand"
+ADD COLUMN "applyAccentColorToDataroomView" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema/dataroom.prisma
+++ b/prisma/schema/dataroom.prisma
@@ -114,6 +114,7 @@ model DataroomBrand {
   banner         String? // This should be a reference to where the file is stored (S3, Google Cloud Storage, etc.)
   brandColor     String? // This should be a reference to the brand color
   accentColor    String? // This should be a reference to the accent color
+  applyAccentColorToDataroomView Boolean @default(false) // When true, apply accentColor to dataroom list/tree viewer background
   welcomeMessage String? // This should be a reference to the welcome message
   dataroomId     String   @unique
   dataroom       Dataroom @relation(fields: [dataroomId], references: [id], onDelete: Cascade)

--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -78,6 +78,7 @@ model Brand {
   banner         String? // Banner image for dataroom view (fallback)
   brandColor     String? // This should be a reference to the brand color
   accentColor    String? // This should be a reference to the accent color
+  applyAccentColorToDataroomView Boolean @default(false) // Global default for whether accentColor applies to dataroom list/tree viewer background
   welcomeMessage String? // This should be a reference to the welcome message
   teamId         String  @unique
   team           Team    @relation(fields: [teamId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
Apply `DataroomBrand.accentColor` to the dataroom viewer background and ensure card visibility to fulfill a customer request for consistent background branding.

The `accentColor` was previously only applied to the document view background. This PR extends its application to the entire dataroom viewer, including the main content area, outer wrapper, and preview. To maintain readability, folder and document cards now have an explicit white background, and text colors adapt based on the background brightness. The branding settings page label has also been updated for clarity.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-506c11d8-0b51-4d37-a154-afa5ea7ef5ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-506c11d8-0b51-4d37-a154-afa5ea7ef5ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global adaptive theming across viewer, datarooms, file tree, and access forms
  * Branding toggle to apply accent/background color to dataroom views

* **Improvements**
  * Unified, theme-driven styling for cards, file tree, forms, and viewer UI
  * Better text/background contrast, placeholder/focus visuals, and interactive agreement controls
  * Minor UX refinements in search and input components (icons, caret, memoized rendering)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->