### PR TITLE
Dataroom viewer background fill

### DIFF
--- a/components/view/dataroom/dataroom-view.tsx
+++ b/components/view/dataroom/dataroom-view.tsx
@@ -286,7 +286,7 @@ export default function DataroomView({
   if (submitted) {
     return (
       <div
-        className="bg-white"
+        className="min-h-screen bg-white"
         style={{ backgroundColor: dataroomViewBackgroundColor ?? undefined }}
       >
         <DataroomViewer
@@ -318,7 +318,7 @@ export default function DataroomView({
 
   return (
     <div
-      className="bg-white"
+      className="min-h-screen bg-white"
       style={{ backgroundColor: dataroomViewBackgroundColor ?? undefined }}
     >
       <div className="flex h-screen items-center justify-center">

--- a/pages/room_ppreview_demo.tsx
+++ b/pages/room_ppreview_demo.tsx
@@ -35,7 +35,7 @@ export default function ViewPage() {
 
   return (
     <div
-      className="bg-white"
+      className="min-h-screen bg-white"
       style={
         dataroomViewBackgroundColor
           ? { backgroundColor: dataroomViewBackgroundColor }


### PR DESCRIPTION
Add `min-h-screen` to dataroom view wrappers to ensure the accent background color fills the viewport.

When there wasn't enough content to fill the viewport, the background color applied by `applyAccentColorToDataroomView` didn't extend to the bottom, revealing a white background underneath. Adding `min-h-screen` ensures the wrapper always takes up at least the full viewport height, making the accent color cover the entire background.

---
<p><a href="https://cursor.com/agents?id=bc-0fae4e4f-3d66-4d51-befd-ac742887226e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fae4e4f-3d66-4d51-befd-ac742887226e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced layout consistency across the application by ensuring page containers properly extend to fill the full viewport height. This improvement provides more stable page layouts and a more polished visual presentation, eliminating potential empty white space and improving overall visual consistency across various page views throughout the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->