### PR TITLE
Viewer link content responsiveness

### DIFF
--- a/components/view/viewer/pages-horizontal-viewer.tsx
+++ b/components/view/viewer/pages-horizontal-viewer.tsx
@@ -633,8 +633,16 @@ export default function PagesHorizontalViewer({
                   <div
                     className="mx-auto"
                     style={{
-                      width: scaledWidthPx ? `${scaledWidthPx}px` : "100%",
-                      height: scaledHeightPx ? `${scaledHeightPx}px` : "auto",
+                      // Keep default zoom responsive to viewport changes.
+                      // Only lock dimensions when zoomed in to preserve a stable scroll area.
+                      width:
+                        scale > 1 && scaledWidthPx
+                          ? `${scaledWidthPx}px`
+                          : "100%",
+                      height:
+                        scale > 1 && scaledHeightPx
+                          ? `${scaledHeightPx}px`
+                          : "auto",
                     }}
                   >
                     {/* Content is scaled; origin set to top-left so it grows into the sizer */}


### PR DESCRIPTION
Fixes horizontal viewer content not auto-fitting after browser resize from small to large.

Previously, the viewer would cache reduced image dimensions after a small viewport resize, preventing it from expanding when the viewport became large again. This change ensures the viewer uses responsive sizing at default zoom and only locks explicit pixel dimensions when zoomed in.

---
<p><a href="https://cursor.com/agents/bc-fa215ba1-9b99-4637-887e-0e295d64e275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa215ba1-9b99-4637-887e-0e295d64e275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal viewer scaling behavior: dimensions now lock correctly when zoomed in, while maintaining responsive defaults during normal viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->