### PR TITLE
User settings billing popup

### DIFF
--- a/pages/account/general.tsx
+++ b/pages/account/general.tsx
@@ -1,5 +1,4 @@
 import { NextPage } from "next";
-import { useEffect, useState } from "react";
 
 import { useSession } from "next-auth/react";
 import { toast } from "sonner";
@@ -7,45 +6,16 @@ import { toast } from "sonner";
 import { AccountHeader } from "@/components/account/account-header";
 import { UpdateMailSubscribe } from "@/components/account/update-subscription";
 import UploadAvatar from "@/components/account/upload-avatar";
-import { UpgradePlanModal } from "@/components/billing/upgrade-plan-modal";
 import AppLayout from "@/components/layouts/app";
 import { Form } from "@/components/ui/form";
-import { PlanEnum } from "@/ee/stripe/constants";
 
-import { usePlan } from "@/lib/swr/use-billing";
 import { validateEmail } from "@/lib/utils/validate-email";
 
 const ProfilePage: NextPage = () => {
   const { data: session, update } = useSession();
-  const { plan: teamPlan, isAnnualPlan, isFree } = usePlan();
-  const [showUpgradeModal, setShowUpgradeModal] = useState(false);
-
-  // Determine the next plan to highlight
-  const getNextPlan = () => {
-    if (isFree) return PlanEnum.Pro;
-    if (teamPlan === "pro") return PlanEnum.Business;
-    if (teamPlan === "business") return PlanEnum.DataRooms;
-    return PlanEnum.Business; // Default
-  };
-
-  const nextPlan = getNextPlan();
-
-  // Show modal for monthly subscribers and free users when opening account
-  useEffect(() => {
-    if (!isAnnualPlan) {
-      // Show modal for monthly subscribers and free users
-      setShowUpgradeModal(true);
-    }
-  }, [isAnnualPlan]);
 
   return (
     <AppLayout>
-      <UpgradePlanModal
-        clickedPlan={nextPlan}
-        trigger="account_page"
-        open={showUpgradeModal}
-        setOpen={setShowUpgradeModal}
-      />
       <main className="relative mx-2 mb-10 mt-4 space-y-8 overflow-hidden px-1 sm:mx-3 md:mx-5 md:mt-5 lg:mx-7 lg:mt-8 xl:mx-10">
         <AccountHeader />
         <div className="space-y-6">


### PR DESCRIPTION
Remove the auto-opening upgrade modal from the User Settings page.

A customer reported a disruptive "upgrade to data rooms" popup appearing every time they visited User Settings, which was caused by a `useEffect` hook in `pages/account/general.tsx` that automatically opened an `UpgradePlanModal` for non-annual plan users. This change removes the modal and related logic to prevent this unrelated billing popup on the settings page.

---
<p><a href="https://cursor.com/agents/bc-804da780-e41f-4467-9c41-69f83d1bcdfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-804da780-e41f-4467-9c41-69f83d1bcdfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic billing upgrade prompts from the account settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->