### PR TITLE
Docx sanitizer additions

### DIFF
--- a/ee/features/conversions/python/docx-sanitizer.py
+++ b/ee/features/conversions/python/docx-sanitizer.py
@@ -101,6 +101,8 @@ NUMPAGES_FIELD_RE = re.compile(
 )
 
 PARA_RE = re.compile(r'<w:p[\s>].*?</w:p>', re.DOTALL)
+PPR_RE = re.compile(r'<w:pPr\b[^>]*/>', re.DOTALL)
+PPR_BLOCK_RE = re.compile(r'<w:pPr\b.*?</w:pPr>', re.DOTALL)
 
 
 def strip_numpages_fields_in_hf(tmp_dir: str) -> int:
@@ -132,7 +134,9 @@ def strip_numpages_fields_in_hf(tmp_dir: str) -> int:
                 para = m.group(0)
                 if NUMPAGES_FIELD_RE.search(para):
                     count += 1
-                    return '<w:p><w:pPr><w:pStyle w:val="Footer"/></w:pPr></w:p>'
+                    ppr = PPR_BLOCK_RE.search(para) or PPR_RE.search(para)
+                    ppr_xml = ppr.group(0) if ppr else '<w:pPr/>'
+                    return f'<w:p>{ppr_xml}</w:p>'
                 return para
 
             new_content = PARA_RE.sub(_replace_para, content)

--- a/ee/features/conversions/python/docx-sanitizer.py
+++ b/ee/features/conversions/python/docx-sanitizer.py
@@ -32,8 +32,11 @@ import zipfile
 import tempfile
 import argparse
 import shutil
+import xml.etree.ElementTree as ET
 
 log = logging.getLogger("docx-sanitizer")
+
+W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'
 
 
 def has_rtl_content(doc_content: str) -> bool:
@@ -100,9 +103,17 @@ NUMPAGES_FIELD_RE = re.compile(
     re.IGNORECASE,
 )
 
-PARA_RE = re.compile(r'<w:p[\s>].*?</w:p>', re.DOTALL)
-PPR_RE = re.compile(r'<w:pPr\b[^>]*/>', re.DOTALL)
-PPR_BLOCK_RE = re.compile(r'<w:pPr\b.*?</w:pPr>', re.DOTALL)
+_NUMPAGES_TEXT_RE = re.compile(r'\b(?:numpages|sectionpages)\b', re.IGNORECASE)
+
+
+def _register_all_namespaces(path: str):
+    """Register every namespace prefix declared in *path* so ET.write() preserves them."""
+    for _event, ns in ET.iterparse(path, events=['start-ns']):
+        prefix, uri = ns
+        try:
+            ET.register_namespace(prefix, uri)
+        except ValueError:
+            pass
 
 
 def strip_numpages_fields_in_hf(tmp_dir: str) -> int:
@@ -115,7 +126,9 @@ def strip_numpages_fields_in_hf(tmp_dir: str) -> int:
 
     The fix: for each header/footer XML, find <w:p> elements whose field
     instructions mention NUMPAGES or SECTIONPAGES, and replace them with an
-    empty paragraph so the layout loop is broken.
+    empty paragraph (preserving the original <w:pPr>) so the layout loop is
+    broken.  Uses proper XML tree parsing instead of regex to safely handle
+    arbitrarily nested paragraph-property structures.
     """
     import glob as _glob
 
@@ -124,25 +137,39 @@ def strip_numpages_fields_in_hf(tmp_dir: str) -> int:
     for pattern in ('header*.xml', 'footer*.xml'):
         for path in _glob.glob(os.path.join(word_dir, pattern)):
             with open(path, 'r', encoding='utf-8') as f:
-                content = f.read()
+                raw = f.read()
 
-            if not NUMPAGES_FIELD_RE.search(content):
+            if not NUMPAGES_FIELD_RE.search(raw):
                 continue
 
-            def _replace_para(m):
-                nonlocal count
-                para = m.group(0)
-                if NUMPAGES_FIELD_RE.search(para):
-                    count += 1
-                    ppr = PPR_BLOCK_RE.search(para) or PPR_RE.search(para)
-                    ppr_xml = ppr.group(0) if ppr else '<w:pPr/>'
-                    return f'<w:p>{ppr_xml}</w:p>'
-                return para
+            _register_all_namespaces(path)
+            tree = ET.parse(path)
+            root = tree.getroot()
+            modified = False
 
-            new_content = PARA_RE.sub(_replace_para, content)
-            if new_content != content:
-                with open(path, 'w', encoding='utf-8') as f:
-                    f.write(new_content)
+            for p_elem in root.iter(f'{{{W_NS}}}p'):
+                has_numpages = False
+                for instr in p_elem.iter(f'{{{W_NS}}}instrText'):
+                    if instr.text and _NUMPAGES_TEXT_RE.search(instr.text):
+                        has_numpages = True
+                        break
+                if not has_numpages:
+                    continue
+
+                count += 1
+                modified = True
+
+                ppr = p_elem.find(f'{{{W_NS}}}pPr')
+                for child in list(p_elem):
+                    p_elem.remove(child)
+
+                if ppr is not None:
+                    p_elem.insert(0, ppr)
+                else:
+                    ET.SubElement(p_elem, f'{{{W_NS}}}pPr')
+
+            if modified:
+                tree.write(path, xml_declaration=True, encoding='UTF-8')
                 log.info("Stripped NUMPAGES field paragraph(s) from %s",
                          os.path.basename(path))
 

--- a/ee/features/conversions/python/docx-sanitizer.py
+++ b/ee/features/conversions/python/docx-sanitizer.py
@@ -8,6 +8,8 @@ Supported fixes:
   - Glossary removal: Remove corrupt glossary parts (0-byte fontTable.xml etc.)
   - SDT unwrap: Unwrap <w:sdt> blocks from Google Docs exports that crash
     LibreOffice.
+  - Footer field fix: Strip nested IF/NUMPAGES field codes from headers/footers
+    that cause infinite layout loops in LibreOffice's UNO API.
 
 Usage:
     python docx-sanitizer.py input.docx [output.docx]
@@ -91,6 +93,56 @@ def remove_glossary(tmp_dir: str) -> bool:
             log.info("Removed glossary overrides from [Content_Types].xml")
 
     return True
+
+
+NUMPAGES_FIELD_RE = re.compile(
+    r'<w:instrText[^>]*>[^<]*\b(?:numpages|sectionpages)\b[^<]*</w:instrText>',
+    re.IGNORECASE,
+)
+
+PARA_RE = re.compile(r'<w:p[\s>].*?</w:p>', re.DOTALL)
+
+
+def strip_numpages_fields_in_hf(tmp_dir: str) -> int:
+    """Remove paragraphs in headers/footers that contain NUMPAGES-based fields.
+
+    Nested IF fields that reference NUMPAGES inside headers/footers cause an
+    infinite layout recalculation loop in LibreOffice's UNO API
+    (loadComponentFromURL hangs).  The CLI converter (--headless --convert-to)
+    caps its layout passes so it completes, but the UNO pathway does not.
+
+    The fix: for each header/footer XML, find <w:p> elements whose field
+    instructions mention NUMPAGES or SECTIONPAGES, and replace them with an
+    empty paragraph so the layout loop is broken.
+    """
+    import glob as _glob
+
+    count = 0
+    word_dir = os.path.join(tmp_dir, 'word')
+    for pattern in ('header*.xml', 'footer*.xml'):
+        for path in _glob.glob(os.path.join(word_dir, pattern)):
+            with open(path, 'r', encoding='utf-8') as f:
+                content = f.read()
+
+            if not NUMPAGES_FIELD_RE.search(content):
+                continue
+
+            def _replace_para(m):
+                nonlocal count
+                para = m.group(0)
+                if NUMPAGES_FIELD_RE.search(para):
+                    count += 1
+                    return '<w:p><w:pPr><w:pStyle w:val="Footer"/></w:pPr></w:p>'
+                return para
+
+            new_content = PARA_RE.sub(_replace_para, content)
+            if new_content != content:
+                with open(path, 'w', encoding='utf-8') as f:
+                    f.write(new_content)
+                log.info("Stripped NUMPAGES field paragraph(s) from %s",
+                         os.path.basename(path))
+
+    return count
 
 
 def unwrap_sdt(content: str) -> tuple:
@@ -185,6 +237,15 @@ def sanitize_docx(input_path: str, output_path: str, mode: str = 'all') -> bool:
                         log.info("No word/settings.xml found — skipping compat fix")
                 else:
                     log.info("No RTL content detected — skipping compat downgrade")
+
+            # --- Header/footer NUMPAGES field fix ---
+            if mode == 'all':
+                nf_count = strip_numpages_fields_in_hf(tmp)
+                if nf_count:
+                    log.info("Stripped %d NUMPAGES field paragraph(s) from headers/footers",
+                             nf_count)
+                else:
+                    log.info("No NUMPAGES fields found in headers/footers")
 
             # --- SDT unwrap ---
             if mode in ('sdt', 'all'):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a new fix to the DOCX sanitizer to strip NUMPAGES fields from headers/footers.

Nested IF fields referencing NUMPAGES in headers/footers can cause LibreOffice's UNO API to enter an infinite layout recalculation loop, leading to conversion failures or hangs. This change removes such paragraphs to prevent the issue.

---
<p><a href="https://cursor.com/agents/bc-bbe023dd-94f2-4647-aa7b-92a95ecd1450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbe023dd-94f2-4647-aa7b-92a95ecd1450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced document sanitizer strips page-count fields from headers and footers, preserves paragraph formatting, and logs how many were removed as part of normal sanitization.
* **Documentation**
  * Updated module docs to describe the new header/footer page-count field removal and its reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->