### PR TITLE
Duplicated link properties

### DIFF
--- a/pages/api/links/[id]/duplicate.ts
+++ b/pages/api/links/[id]/duplicate.ts
@@ -71,6 +71,8 @@ export default async function handle(
               accessControls: true,
             },
           },
+          customFields: true,
+          visitorGroups: true,
         },
       });
 
@@ -82,7 +84,14 @@ export default async function handle(
         return res.status(404).json({ error: "Link has been deleted" });
       }
 
-      const { tags, permissionGroup, permissionGroupId, ...rest } = link;
+      const {
+        tags,
+        permissionGroup,
+        permissionGroupId,
+        customFields,
+        visitorGroups,
+        ...rest
+      } = link;
       const linkTags = tags.map((t) => t.tag.id);
 
       const newLinkName = link.name
@@ -131,6 +140,34 @@ export default async function handle(
             updatedAt: undefined,
             permissionGroupId: newPermissionGroupId,
             ownerId: userId,
+            ...(customFields.length > 0 && {
+              customFields: {
+                createMany: {
+                  data: customFields.map((field) => ({
+                    type: field.type,
+                    identifier: field.identifier,
+                    label: field.label,
+                    placeholder: field.placeholder,
+                    required: field.required,
+                    disabled: field.disabled,
+                    orderIndex: field.orderIndex,
+                  })),
+                },
+              },
+            }),
+            ...(visitorGroups.length > 0 && {
+              visitorGroups: {
+                createMany: {
+                  data: visitorGroups.map((vg) => ({
+                    visitorGroupId: vg.visitorGroupId,
+                  })),
+                },
+              },
+            }),
+          },
+          include: {
+            customFields: true,
+            visitorGroups: true,
           },
         });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Duplicate custom form fields and visitor groups when duplicating a link to ensure all link properties are copied.

---
<p><a href="https://cursor.com/agents/bc-7a64173c-d093-4209-8880-aa10ee38a49a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a64173c-d093-4209-8880-aa10ee38a49a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Link duplication now copies custom fields and visitor groups alongside the main link configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->