### PR TITLE
Dataroom document name revert

### DIFF
--- a/components/datarooms/edit-dataroom-document-modal.tsx
+++ b/components/datarooms/edit-dataroom-document-modal.tsx
@@ -49,12 +49,12 @@ function updateDocNameInFolderTree(
     folder: DataroomFolderWithDocuments,
   ): DataroomFolderWithDocuments => ({
     ...folder,
-    documents: folder.documents.map((doc) =>
+    documents: (folder.documents ?? []).map((doc) =>
       doc.document.id === docId
         ? { ...doc, document: { ...doc.document, name: newName } }
         : doc,
     ),
-    childFolders: folder.childFolders.map(updateFolder),
+    childFolders: (folder.childFolders ?? []).map(updateFolder),
   });
   return folders.map(updateFolder);
 }

--- a/components/datarooms/edit-dataroom-document-modal.tsx
+++ b/components/datarooms/edit-dataroom-document-modal.tsx
@@ -24,6 +24,19 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
+type DataroomIncludeDocumentsItem =
+  | DataroomFolderWithDocuments
+  | {
+      id: string;
+      folderId: string | null;
+      hierarchicalIndex: string | null;
+      document: {
+        id: string;
+        name: string;
+        type: string;
+      };
+    };
+
 function updateDocNameInDocuments(
   _: null,
   docs: DataroomFolderDocument[] | undefined,
@@ -57,6 +70,36 @@ function updateDocNameInFolderTree(
     childFolders: (folder.childFolders ?? []).map(updateFolder),
   });
   return folders.map(updateFolder);
+}
+
+function updateDocNameInIncludeDocumentsTree(
+  _: null,
+  items: DataroomIncludeDocumentsItem[] | undefined,
+  docId: string,
+  newName: string,
+): DataroomIncludeDocumentsItem[] | undefined {
+  if (!items) return items;
+  const updateFolder = (
+    folder: DataroomFolderWithDocuments,
+  ): DataroomFolderWithDocuments => ({
+    ...folder,
+    documents: (folder.documents ?? []).map((doc) =>
+      doc.document.id === docId
+        ? { ...doc, document: { ...doc.document, name: newName } }
+        : doc,
+    ),
+    childFolders: (folder.childFolders ?? []).map(updateFolder),
+  });
+
+  return items.map((item) => {
+    if ("childFolders" in item) {
+      return updateFolder(item);
+    }
+
+    return item.document.id === docId
+      ? { ...item, document: { ...item.document, name: newName } }
+      : item;
+  });
 }
 
 export function EditDataroomDocumentModal({
@@ -94,14 +137,14 @@ export function EditDataroomDocumentModal({
     event.preventDefault();
     event.stopPropagation();
 
-    const validation = editDocumentNameSchema.safeParse({ name });
+    const trimmedName = name.trim();
+    const validation = editDocumentNameSchema.safeParse({ name: trimmedName });
     if (!validation.success) {
       return toast.error(validation.error.errors[0].message);
     }
 
     setLoading(true);
 
-    const trimmedName = name.trim();
     const teamId = teamInfo?.currentTeam?.id;
     const baseKey = `/api/teams/${teamId}/datarooms/${dataroomId}`;
 
@@ -152,8 +195,13 @@ export function EditDataroomDocumentModal({
         revalidate: false,
       });
       mutate(`${baseKey}/folders?include_documents=true`, null, {
-        populateCache: (_, folders) =>
-          updateDocNameInFolderTree(_, folders, documentId, trimmedName),
+        populateCache: (_, items) =>
+          updateDocNameInIncludeDocumentsTree(
+            _,
+            items,
+            documentId,
+            trimmedName,
+          ),
         revalidate: false,
       });
     } catch (error) {

--- a/components/datarooms/edit-dataroom-document-modal.tsx
+++ b/components/datarooms/edit-dataroom-document-modal.tsx
@@ -7,6 +7,11 @@ import { toast } from "sonner";
 import { mutate } from "swr";
 import { z } from "zod";
 
+import {
+  type DataroomFolderDocument,
+  type DataroomFolderWithDocuments,
+} from "@/lib/swr/use-dataroom";
+
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -18,6 +23,41 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+
+function updateDocNameInDocuments(
+  _: null,
+  docs: DataroomFolderDocument[] | undefined,
+  docId: string,
+  newName: string,
+): DataroomFolderDocument[] | undefined {
+  if (!docs) return docs;
+  return docs.map((doc) =>
+    doc.document.id === docId
+      ? { ...doc, document: { ...doc.document, name: newName } }
+      : doc,
+  );
+}
+
+function updateDocNameInFolderTree(
+  _: null,
+  folders: DataroomFolderWithDocuments[] | undefined,
+  docId: string,
+  newName: string,
+): DataroomFolderWithDocuments[] | undefined {
+  if (!folders) return folders;
+  const updateFolder = (
+    folder: DataroomFolderWithDocuments,
+  ): DataroomFolderWithDocuments => ({
+    ...folder,
+    documents: folder.documents.map((doc) =>
+      doc.document.id === docId
+        ? { ...doc, document: { ...doc.document, name: newName } }
+        : doc,
+    ),
+    childFolders: folder.childFolders.map(updateFolder),
+  });
+  return folders.map(updateFolder);
+}
 
 export function EditDataroomDocumentModal({
   open,
@@ -61,16 +101,20 @@ export function EditDataroomDocumentModal({
 
     setLoading(true);
 
+    const trimmedName = name.trim();
+    const teamId = teamInfo?.currentTeam?.id;
+    const baseKey = `/api/teams/${teamId}/datarooms/${dataroomId}`;
+
     try {
       const response = await fetch(
-        `/api/teams/${teamInfo?.currentTeam?.id}/documents/${documentId}/update-name`,
+        `/api/teams/${teamId}/documents/${documentId}/update-name`,
         {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            name: name.trim(),
+            name: trimmedName,
           }),
         },
       );
@@ -84,20 +128,34 @@ export function EditDataroomDocumentModal({
 
       toast.success("Document name updated successfully!");
 
-      // Revalidate the dataroom documents cache
-      mutate(
-        `/api/teams/${teamInfo?.currentTeam?.id}/datarooms/${dataroomId}/documents`,
-      );
-      // Revalidate folder documents if the document is in a folder
+      mutate(`${baseKey}/documents`, null, {
+        populateCache: (_, docs) =>
+          updateDocNameInDocuments(_, docs, documentId, trimmedName),
+        revalidate: false,
+      });
+
       if (currentFolderPath) {
         mutate(
-          `/api/teams/${teamInfo?.currentTeam?.id}/datarooms/${dataroomId}/folders/documents/${currentFolderPath.join("/")}`,
+          `${baseKey}/folders/documents/${currentFolderPath.join("/")}`,
+          null,
+          {
+            populateCache: (_, docs) =>
+              updateDocNameInDocuments(_, docs, documentId, trimmedName),
+            revalidate: false,
+          },
         );
       }
-      // Revalidate the dataroom folders tree for sidebar
-      mutate(
-        `/api/teams/${teamInfo?.currentTeam?.id}/datarooms/${dataroomId}/folders?tree=true`,
-      );
+
+      mutate(`${baseKey}/folders`, null, {
+        populateCache: (_, folders) =>
+          updateDocNameInFolderTree(_, folders, documentId, trimmedName),
+        revalidate: false,
+      });
+      mutate(`${baseKey}/folders?include_documents=true`, null, {
+        populateCache: (_, folders) =>
+          updateDocNameInFolderTree(_, folders, documentId, trimmedName),
+        revalidate: false,
+      });
     } catch (error) {
       setLoading(false);
       toast.error("Error updating document name. Please try again.");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement optimistic SWR cache updates for document renames to fix a bug where name changes visually reverted.

The previous implementation failed to invalidate the sidebar tree cache due to an incorrect SWR key and only triggered background revalidation for other caches, causing a visible "revert" flicker. This PR introduces `populateCache` to optimistically update the document name across all relevant SWR caches: root documents, current folder documents, sidebar folder tree, and folder tree with documents.

---
<p><a href="https://cursor.com/agents/bc-91393d1a-6b55-4898-b793-6423b36298cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91393d1a-6b55-4898-b793-6423b36298cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document name updates to consistently reflect changes across all dataroom views, folders, and nested structures
  * Added error notifications to inform users when document renaming fails
  * Improved dialog behavior to properly close after submission and maintain accurate loading states during the update process
  * Trimmed document names before validation/submission to prevent accidental whitespace errors

* **Performance**
  * Faster UI updates by applying targeted in-memory cache updates instead of full revalidation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->