### PR TITLE
Trial dataroom recreation

### DIFF
--- a/components/datarooms/add-dataroom-modal.tsx
+++ b/components/datarooms/add-dataroom-modal.tsx
@@ -83,7 +83,7 @@ export function AddDataroomModal({
   const [editingFolderName, setEditingFolderName] = useState<string>("");
 
   const teamInfo = useTeam();
-  const { isFree, isPro } = usePlan();
+  const { isFree, isPro, isTrial } = usePlan();
   const analytics = useAnalytics();
 
   const useTemplate = activeTab === "generate";
@@ -346,8 +346,7 @@ export function AddDataroomModal({
     }
   };
 
-  // If the team is on a free plan, show the upgrade modal
-  if (isFree || isPro) {
+  if ((isFree || isPro) && !isTrial) {
     if (children) {
       return (
         <UpgradePlanModal

--- a/ee/features/templates/api/datarooms/generate.ts
+++ b/ee/features/templates/api/datarooms/generate.ts
@@ -49,7 +49,6 @@ export default async function handle(
         where: {
           id: teamId,
           plan: {
-            // exclude all teams not on `business`, `datarooms`, `datarooms-plus`, `datarooms-premium`, `business+old`, `datarooms+old`, `datarooms-plus+old`, `datarooms-premium+old` plan
             in: [
               "business",
               "datarooms",
@@ -59,6 +58,7 @@ export default async function handle(
               "datarooms+old",
               "datarooms-plus+old",
               "datarooms-premium+old",
+              "free+drtrial",
               "datarooms+drtrial",
               "business+drtrial",
               "datarooms-plus+drtrial",

--- a/ee/limits/server.ts
+++ b/ee/limits/server.ts
@@ -114,6 +114,7 @@ export async function getLimits({
         usage: { documents: documentCount, links: linkCount, users: userCount },
         ...(isTrial && {
           users: 3,
+          datarooms: Math.max(parsedData.datarooms ?? defaultLimits?.datarooms ?? 0, 1),
         }),
       };
     } else {
@@ -138,6 +139,7 @@ export async function getLimits({
       usage: { documents: documentCount, links: linkCount, users: userCount },
       ...(isTrial && {
         users: 3,
+        datarooms: Math.max(defaultLimits?.datarooms ?? 0, 1),
       }),
     };
   }

--- a/pages/api/teams/[teamId]/datarooms/index.ts
+++ b/pages/api/teams/[teamId]/datarooms/index.ts
@@ -229,7 +229,6 @@ export default async function handle(
         where: {
           id: teamId,
           plan: {
-            // exclude all teams not on `business`, `datarooms`, `datarooms-plus`, `datarooms-premium`, `business+old`, `datarooms+old`, `datarooms-plus+old`, `datarooms-premium+old` plan
             in: [
               "business",
               "datarooms",
@@ -239,6 +238,7 @@ export default async function handle(
               "datarooms+old",
               "datarooms-plus+old",
               "datarooms-premium+old",
+              "free+drtrial",
               "datarooms+drtrial",
               "business+drtrial",
               "datarooms-plus+drtrial",

--- a/pages/datarooms/[id]/settings/index.tsx
+++ b/pages/datarooms/[id]/settings/index.tsx
@@ -34,7 +34,7 @@ export default function Settings() {
   const teamId = teamInfo?.currentTeam?.id;
   const [isCopied, setIsCopied] = useState(false);
 
-  const { isBusiness, isDatarooms, isDataroomsPlus } = usePlan();
+  const { isBusiness, isDatarooms, isDataroomsPlus, isTrial } = usePlan();
 
   if (!dataroom) {
     return <div>Loading...</div>;
@@ -219,7 +219,7 @@ export default function Settings() {
               </CardFooter>
             </Card>
 
-            {isBusiness || isDatarooms || isDataroomsPlus ? (
+            {isBusiness || isDatarooms || isDataroomsPlus || isTrial ? (
               <DeleteDataroom
                 dataroomId={dataroom.id}
                 dataroomName={dataroom.name}

--- a/pages/datarooms/index.tsx
+++ b/pages/datarooms/index.tsx
@@ -135,17 +135,29 @@ export default function DataroomsPage() {
                     })()}
                   </span>
                 </div>
-                <UpgradePlanModal
-                  clickedPlan={PlanEnum.DataRooms}
-                  trigger="datarooms"
-                >
-                  <Button
-                    className="group flex flex-1 items-center justify-start gap-x-3 px-3 text-left"
-                    title="Upgrade to Add Data Room"
+                {datarooms.length === 0 ? (
+                  <AddDataroomModal>
+                    <Button
+                      className="group flex flex-1 items-center justify-start gap-x-3 px-3 text-left"
+                      title="Create New Dataroom"
+                    >
+                      <PlusIcon className="h-5 w-5 shrink-0" aria-hidden="true" />
+                      <span>Create New Dataroom</span>
+                    </Button>
+                  </AddDataroomModal>
+                ) : (
+                  <UpgradePlanModal
+                    clickedPlan={PlanEnum.DataRooms}
+                    trigger="datarooms"
                   >
-                    <span>Upgrade to Add Data Room</span>
-                  </Button>
-                </UpgradePlanModal>
+                    <Button
+                      className="group flex flex-1 items-center justify-start gap-x-3 px-3 text-left"
+                      title="Upgrade to Add Data Room"
+                    >
+                      <span>Upgrade to Add Data Room</span>
+                    </Button>
+                  </UpgradePlanModal>
+                )}
               </div>
             ) : isBusiness || isDatarooms || isDataroomsPlus ? (
               <AddDataroomModal>

--- a/pages/datarooms/index.tsx
+++ b/pages/datarooms/index.tsx
@@ -135,7 +135,7 @@ export default function DataroomsPage() {
                     })()}
                   </span>
                 </div>
-                {datarooms.length === 0 ? (
+                {totalDatarooms < limitDatarooms ? (
                   <AddDataroomModal>
                     <Button
                       className="group flex flex-1 items-center justify-start gap-x-3 px-3 text-left"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Allow trial users to delete their single dataroom and create a new one, maintaining the limit of one dataroom.

---
<p><a href="https://cursor.com/agents/bc-b70b6bcf-f902-4f7c-89fc-bac707688511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b70b6bcf-f902-4f7c-89fc-bac707688511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trial plan users can now create and manage datarooms (trial entitlements recognized).
  * "Create New Dataroom" button with Plus icon appears when under the dataroom limit; upgrade prompt shown only when limit reached.
  * Delete dataroom option appears for users with trial entitlements.

* **Bug Fixes**
  * Ensures dataroom limits default to at least 1 in trial and fallback paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->