### PR TITLE
fix: move folder

### DIFF
--- a/components/datarooms/folders/selection-tree.tsx
+++ b/components/datarooms/folders/selection-tree.tsx
@@ -16,13 +16,17 @@ const FolderComponentSelection = memo(
     selectedFolder,
     setSelectedFolder,
     disableId,
+    ancestorDisabled,
   }: {
     folder: DataroomFolderWithDocuments;
     disableId?: string[];
     selectedFolder: TSelectedFolder;
     setSelectedFolder: React.Dispatch<React.SetStateAction<TSelectedFolder>>;
+    ancestorDisabled?: boolean;
   }) => {
-    // Recursively render child folders if they exist
+    const isSelfDisabled = disableId?.includes(folder.id) ?? false;
+    const isDisabled = ancestorDisabled || isSelfDisabled;
+
     const childFolders = useMemo(
       () =>
         folder.childFolders.map((childFolder) => (
@@ -32,16 +36,22 @@ const FolderComponentSelection = memo(
             selectedFolder={selectedFolder}
             disableId={disableId}
             setSelectedFolder={setSelectedFolder}
+            ancestorDisabled={isDisabled}
           />
         )),
-      [folder.childFolders, selectedFolder, setSelectedFolder, disableId],
+      [
+        folder.childFolders,
+        selectedFolder,
+        setSelectedFolder,
+        disableId,
+        isDisabled,
+      ],
     );
 
     const isActive = folder.id === selectedFolder?.id;
     const isChildActive = folder.childFolders.some(
       (childFolder) => childFolder.id === selectedFolder?.id,
     );
-    const isDisabled = disableId?.includes(folder.id);
 
     return (
       <div

--- a/pages/api/teams/[teamId]/datarooms/[id]/folders/move.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/folders/move.ts
@@ -60,10 +60,36 @@ export default async function handle(
           },
         });
 
+        // Prevent moving a folder into itself or one of its descendants.
+        // Single query to fetch the full parentId map, then walk in memory.
+        if (selectedFolder) {
+          const allFolders = await prisma.dataroomFolder.findMany({
+            where: { dataroomId },
+            select: { id: true, parentId: true },
+          });
+          const parentMap = new Map(
+            allFolders.map((f) => [f.id, f.parentId]),
+          );
+          const folderIdSet = new Set(folderIds);
+          const visited = new Set<string>();
+          let currentId: string | null = selectedFolder;
+          while (currentId) {
+            if (folderIdSet.has(currentId)) {
+              return res.status(400).json({
+                message:
+                  "Cannot move a folder into itself or one of its subfolders",
+              });
+            }
+            if (visited.has(currentId)) break;
+            visited.add(currentId);
+            currentId = parentMap.get(currentId) ?? null;
+          }
+        }
+
         const existingFolders = await prisma.dataroomFolder.findMany({
           where: {
             dataroomId: dataroomId,
-            parentId: selectedFolder, // Check only inside the target folder can be null
+            parentId: selectedFolder,
           },
           select: { name: true },
         });

--- a/pages/api/teams/[teamId]/datarooms/[id]/folders/move.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/folders/move.ts
@@ -75,10 +75,7 @@ export default async function handle(
           let currentId: string | null = selectedFolder;
           while (currentId) {
             if (folderIdSet.has(currentId)) {
-              return res.status(400).json({
-                message:
-                  "Cannot move a folder into itself or one of its subfolders",
-              });
+              throw new Error("MOVE_INVALID_PARENT");
             }
             if (visited.has(currentId)) break;
             visited.add(currentId);
@@ -102,9 +99,9 @@ export default async function handle(
             .filter((name) => existingFolderNames.has(name));
 
           if (duplicateNames.length > 0) {
-            return res.status(409).json({
-              message: `Cannot move folders: Duplicate names found inside target folder - ${duplicateNames.join(", ")}`,
-            });
+            throw new Error(
+              `MOVE_DUPLICATE_NAMES:${duplicateNames.join(", ")}`,
+            );
           }
         }
         // Fetch all nested subfolders of the selected folders (excluding the folders themselves)
@@ -189,6 +186,20 @@ export default async function handle(
         newPath: folder?.path,
       });
     } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === "MOVE_INVALID_PARENT") {
+          return res.status(400).json({
+            message:
+              "Cannot move a folder into itself or one of its subfolders",
+          });
+        }
+        if (error.message.startsWith("MOVE_DUPLICATE_NAMES:")) {
+          const names = error.message.slice("MOVE_DUPLICATE_NAMES:".length);
+          return res.status(409).json({
+            message: `Cannot move folders: Duplicate names found inside target folder - ${names}`,
+          });
+        }
+      }
       console.error(error);
       return res.status(500).end("Failed to move folder");
     }

--- a/pages/api/teams/[teamId]/folders/move.ts
+++ b/pages/api/teams/[teamId]/folders/move.ts
@@ -50,6 +50,28 @@ export default async function handle(
           },
         });
 
+        // Prevent moving a folder into itself or one of its descendants.
+        if (selectedFolder) {
+          const allFolders = await prisma.folder.findMany({
+            where: { teamId },
+            select: { id: true, parentId: true },
+          });
+          const parentMap = new Map(
+            allFolders.map((f) => [f.id, f.parentId]),
+          );
+          const folderIdSet = new Set(folderIds);
+          const visited = new Set<string>();
+          let currentId: string | null = selectedFolder;
+          while (currentId) {
+            if (folderIdSet.has(currentId)) {
+              throw new Error("MOVE_INVALID_PARENT");
+            }
+            if (visited.has(currentId)) break;
+            visited.add(currentId);
+            currentId = parentMap.get(currentId) ?? null;
+          }
+        }
+
         const existingFolders = await prisma.folder.findMany({
           where: {
             teamId,
@@ -66,9 +88,9 @@ export default async function handle(
             .filter((name) => existingFolderNames.has(name));
 
           if (duplicateNames.length > 0) {
-            return res.status(409).json({
-              message: `Cannot move folders: Duplicate names found inside target folder - ${duplicateNames.join(", ")}`,
-            });
+            throw new Error(
+              `MOVE_DUPLICATE_NAMES:${duplicateNames.join(", ")}`,
+            );
           }
         }
         // Fetch all nested subfolders of the selected folders (excluding the folders themselves)
@@ -152,7 +174,22 @@ export default async function handle(
         newPath: folder?.path,
       });
     } catch (error) {
-      return res.status(500).end(error);
+      if (error instanceof Error) {
+        if (error.message === "MOVE_INVALID_PARENT") {
+          return res.status(400).json({
+            message:
+              "Cannot move a folder into itself or one of its subfolders",
+          });
+        }
+        if (error.message.startsWith("MOVE_DUPLICATE_NAMES:")) {
+          const names = error.message.slice("MOVE_DUPLICATE_NAMES:".length);
+          return res.status(409).json({
+            message: `Cannot move folders: Duplicate names found inside target folder - ${names}`,
+          });
+        }
+      }
+      console.error(error);
+      return res.status(500).end("Failed to move folder");
     }
   } else {
     // We only allow PATCH requests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Folder selection now supports hierarchical disabling, automatically disabling child folders when a parent is disabled.

* **Bug Fixes**
  * Prevented moving a folder into itself or any of its subfolders to avoid invalid folder structures.
  * Improved move operation error handling: name-conflict situations now return clear, specific error responses for duplicate folder names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->