### PR TITLE
fix: link permission groups not taking effect (stale ISR pages)

### DIFF
--- a/lib/api/links/revalidate.ts
+++ b/lib/api/links/revalidate.ts
@@ -1,0 +1,67 @@
+import prisma from "@/lib/prisma";
+
+/**
+ * Trigger ISR revalidation for a single link by ID.
+ */
+export async function revalidateLinkById(linkId: string): Promise<void> {
+  try {
+    const link = await prisma.link.findUnique({
+      where: { id: linkId },
+      select: { id: true, domainId: true },
+    });
+
+    if (!link) return;
+
+    const revalidateUrl = process.env.NEXTAUTH_URL;
+    const revalidateToken = process.env.REVALIDATE_TOKEN;
+    if (!revalidateUrl || !revalidateToken) return;
+
+    await fetch(
+      `${revalidateUrl}/api/revalidate?secret=${revalidateToken}&linkId=${link.id}&hasDomain=${link.domainId ? "true" : "false"}`,
+    );
+  } catch (error) {
+    console.error(`Error revalidating link ${linkId}:`, error);
+  }
+}
+
+/**
+ * Trigger ISR revalidation for all non-deleted links using a specific permission group.
+ * Call this after creating, updating, or deleting a permission group.
+ */
+export async function revalidateLinksForPermissionGroup(
+  permissionGroupId: string,
+): Promise<void> {
+  try {
+    const links = await prisma.link.findMany({
+      where: {
+        permissionGroupId: permissionGroupId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        domainId: true,
+      },
+    });
+
+    if (links.length === 0) return;
+
+    const revalidateUrl = process.env.NEXTAUTH_URL;
+    const revalidateToken = process.env.REVALIDATE_TOKEN;
+    if (!revalidateUrl || !revalidateToken) return;
+
+    await Promise.all(
+      links.map((link) =>
+        fetch(
+          `${revalidateUrl}/api/revalidate?secret=${revalidateToken}&linkId=${link.id}&hasDomain=${link.domainId ? "true" : "false"}`,
+        ).catch((error) => {
+          console.error(`Error revalidating link ${link.id}:`, error);
+        }),
+      ),
+    );
+  } catch (error) {
+    console.error(
+      `Error revalidating links for permission group ${permissionGroupId}:`,
+      error,
+    );
+  }
+}

--- a/pages/api/teams/[teamId]/datarooms/[id]/apply-permissions.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/apply-permissions.ts
@@ -8,6 +8,43 @@ import { errorhandler } from "@/lib/errorHandler";
 import prisma from "@/lib/prisma";
 import { CustomUser } from "@/lib/types";
 
+async function revalidateLinksForDataroom(dataroomId: string): Promise<void> {
+  try {
+    const links = await prisma.link.findMany({
+      where: {
+        dataroomId,
+        deletedAt: null,
+        OR: [
+          { permissionGroupId: { not: null } },
+          { groupId: { not: null } },
+        ],
+      },
+      select: { id: true, domainId: true },
+    });
+
+    if (links.length === 0) return;
+
+    const revalidateUrl = process.env.NEXTAUTH_URL;
+    const revalidateToken = process.env.REVALIDATE_TOKEN;
+    if (!revalidateUrl || !revalidateToken) return;
+
+    await Promise.all(
+      links.map((link) =>
+        fetch(
+          `${revalidateUrl}/api/revalidate?secret=${revalidateToken}&linkId=${link.id}&hasDomain=${link.domainId ? "true" : "false"}`,
+        ).catch((err) =>
+          console.error(`Error revalidating link ${link.id}:`, err),
+        ),
+      ),
+    );
+  } catch (error) {
+    console.error(
+      `Error revalidating links for dataroom ${dataroomId}:`,
+      error,
+    );
+  }
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
@@ -106,6 +143,9 @@ export default async function handler(
       strategy,
       folderPath,
     );
+
+    // Revalidate ISR pages for links with permission restrictions
+    await revalidateLinksForDataroom(dataroomId);
 
     return res.status(200).json({
       message: "Permissions applied successfully",

--- a/pages/api/teams/[teamId]/datarooms/[id]/permission-groups/[permissionGroupId].ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/permission-groups/[permissionGroupId].ts
@@ -5,6 +5,7 @@ import { ItemType } from "@prisma/client";
 import { getServerSession } from "next-auth/next";
 import { z } from "zod";
 
+import { revalidateLinksForPermissionGroup } from "@/lib/api/links/revalidate";
 import { errorhandler } from "@/lib/errorHandler";
 import prisma from "@/lib/prisma";
 import { CustomUser } from "@/lib/types";
@@ -488,6 +489,9 @@ export default async function handle(
         validatedPermissions,
       );
 
+      // Revalidate ISR pages so viewers see the updated file list
+      await revalidateLinksForPermissionGroup(permissionGroupId);
+
       return res.status(200).json({ permissionGroup: updatedPermissionGroup });
     } catch (error) {
       return errorhandler(error, res);
@@ -551,12 +555,33 @@ export default async function handle(
         return res.status(404).json({ error: "Permission group not found" });
       }
 
+      // Find linked links before deletion (FK onDelete: SetNull clears the reference)
+      const linkedLinks = await prisma.link.findMany({
+        where: { permissionGroupId, deletedAt: null },
+        select: { id: true, domainId: true },
+      });
+
       // Delete the permission group (this will cascade delete access controls)
       await prisma.permissionGroup.delete({
         where: {
           id: permissionGroupId,
         },
       });
+
+      // Revalidate ISR pages so viewers see all files again (no restrictions)
+      const revalidateUrl = process.env.NEXTAUTH_URL;
+      const revalidateToken = process.env.REVALIDATE_TOKEN;
+      if (revalidateUrl && revalidateToken && linkedLinks.length > 0) {
+        await Promise.all(
+          linkedLinks.map((link) =>
+            fetch(
+              `${revalidateUrl}/api/revalidate?secret=${revalidateToken}&linkId=${link.id}&hasDomain=${link.domainId ? "true" : "false"}`,
+            ).catch((err) =>
+              console.error(`Error revalidating link ${link.id}:`, err),
+            ),
+          ),
+        );
+      }
 
       return res.status(200).json({ message: "Permission group deleted" });
     } catch (error) {

--- a/pages/api/teams/[teamId]/datarooms/[id]/permission-groups/index.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/permission-groups/index.ts
@@ -3,6 +3,10 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { ItemType } from "@prisma/client";
 import { getServerSession } from "next-auth/next";
 
+import {
+  revalidateLinkById,
+  revalidateLinksForPermissionGroup,
+} from "@/lib/api/links/revalidate";
 import { errorhandler } from "@/lib/errorHandler";
 import prisma from "@/lib/prisma";
 import { CustomUser } from "@/lib/types";
@@ -225,6 +229,14 @@ export default async function handle(
           accessControls,
         };
       });
+
+      // Revalidate ISR pages for the linked link so viewers see the correct files
+      if (linkId) {
+        await revalidateLinkById(linkId);
+      }
+      if (result.permissionGroup?.id) {
+        await revalidateLinksForPermissionGroup(result.permissionGroup.id);
+      }
 
       return res.status(200).json(result);
     } catch (error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users report that when they create a dataroom link with "Manage File Permissions" (permissionGroups), **all files show up** in the shared link despite only selecting specific files. The permitted files work, but restricted files show an error message when clicked.

## Root Cause

A **race condition between link creation and permission group creation** causes stale ISR (Incremental Static Regeneration) pages:

1. `POST /api/links` creates the link **without** `permissionGroupId` → triggers ISR revalidation → cached page shows ALL files
2. `POST .../permission-groups` creates the permission group and sets `permissionGroupId` on the link → **NO revalidation triggered**
3. Viewer opens the link → gets the stale ISR page showing ALL files
4. Per-document access checks in `views-dataroom` route correctly block unauthorized access → error messages

The same issue occurs when **updating** permissions on existing links:
1. `PUT /api/links/:id` updates the link → triggers ISR revalidation (with old access controls still in DB)
2. `PUT .../permission-groups/:id` updates the access controls → **NO revalidation**

## Fix

Add ISR page revalidation after all permission group CRUD operations:

- **`POST .../permission-groups`** (create) – revalidates the linked link
- **`PUT .../permission-groups/:id`** (update access controls) – revalidates all links using this permission group
- **`DELETE .../permission-groups/:id`** (remove restrictions) – captures linked links before deletion, then revalidates them
- **`POST .../apply-permissions`** (bulk apply) – revalidates all restricted links in the dataroom

A shared `lib/api/links/revalidate.ts` module provides reusable helpers (`revalidateLinkById`, `revalidateLinksForPermissionGroup`) to keep the pattern consistent.

## Changes

| File | Change |
|------|--------|
| `lib/api/links/revalidate.ts` | New shared helpers for ISR revalidation of links |
| `pages/api/teams/.../permission-groups/index.ts` | Revalidate after POST (create permission group) |
| `pages/api/teams/.../permission-groups/[permissionGroupId].ts` | Revalidate after PUT (update) and DELETE |
| `pages/api/teams/.../apply-permissions.ts` | Revalidate after bulk permission apply |

## Testing

- TypeScript compilation passes (only pre-existing SVG import errors remain)
- No existing automated tests in the repository
- Build requires environment variables (`NEXT_PUBLIC_WEBHOOK_BASE_HOST`) that are not available in this dev environment
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f220526-a8d4-472b-8e36-be2d2fa23b45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f220526-a8d4-472b-8e36-be2d2fa23b45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic cache refresh when permission groups are created, updated, or deleted to ensure data consistency
  * Added cache revalidation for dataroom permission applications and link updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->