### PR TITLE
fix: use 1-hour signed URL expiration for MuPDF document conversion

### DIFF
--- a/lib/files/get-file.ts
+++ b/lib/files/get-file.ts
@@ -6,12 +6,15 @@ export type GetFileOptions = {
   type: DocumentStorageType;
   data: string;
   isDownload?: boolean;
+  /** Signed URL lifetime in milliseconds (server-side S3 only, capped at 1 hour) */
+  expiresIn?: number;
 };
 
 export const getFile = async ({
   type,
   data,
   isDownload = false,
+  expiresIn,
 }: GetFileOptions): Promise<string> => {
   const url = await match(type)
     .with(DocumentStorageType.VERCEL_BLOB, () => {
@@ -21,7 +24,9 @@ export const getFile = async ({
         return data;
       }
     })
-    .with(DocumentStorageType.S3_PATH, async () => getFileFromS3(data))
+    .with(DocumentStorageType.S3_PATH, async () =>
+      getFileFromS3(data, expiresIn),
+    )
     .exhaustive();
 
   return url;
@@ -31,11 +36,12 @@ const fetchPresignedUrl = async (
   endpoint: string,
   headers: Record<string, string>,
   key: string,
+  expiresIn?: number,
 ): Promise<string> => {
   const response = await fetch(endpoint, {
     method: "POST",
     headers,
-    body: JSON.stringify({ key }),
+    body: JSON.stringify({ key, ...(expiresIn && { expiresIn }) }),
   });
 
   if (!response.ok) {
@@ -65,7 +71,7 @@ const fetchPresignedUrl = async (
   return url;
 };
 
-const getFileFromS3 = async (key: string) => {
+const getFileFromS3 = async (key: string, expiresIn?: number) => {
   const isServer =
     typeof window === "undefined" && !!process.env.INTERNAL_API_KEY;
 
@@ -77,6 +83,7 @@ const getFileFromS3 = async (key: string) => {
         Authorization: `Bearer ${process.env.INTERNAL_API_KEY}`,
       },
       key,
+      expiresIn,
     );
   } else {
     return fetchPresignedUrl(

--- a/lib/trigger/pdf-to-image-route.ts
+++ b/lib/trigger/pdf-to-image-route.ts
@@ -1,5 +1,6 @@
 import { AbortTaskRunError, logger, task } from "@trigger.dev/sdk/v3";
 
+import { ONE_HOUR } from "@/lib/constants";
 import { isTrustedTeam } from "@/lib/edge-config/trusted-teams";
 import { getFile } from "@/lib/files/get-file";
 import prisma from "@/lib/prisma";
@@ -41,10 +42,11 @@ export const convertPdfToImageRoute = task({
     logger.info("Document version", { documentVersion });
     updateStatus({ progress: 10, text: "Retrieving file..." });
 
-    // 2. get signed url from file
+    // 2. get signed url from file with 1-hour expiration for long-running conversions
     const signedUrl = await getFile({
       type: documentVersion.storageType,
       data: documentVersion.file,
+      expiresIn: ONE_HOUR,
     });
 
     logger.info("Retrieved signed url", { signedUrl });

--- a/pages/api/file/s3/get-presigned-get-url.ts
+++ b/pages/api/file/s3/get-presigned-get-url.ts
@@ -4,7 +4,7 @@ import { GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl as getCloudfrontSignedUrl } from "@aws-sdk/cloudfront-signer";
 import { getSignedUrl as getS3SignedUrl } from "@aws-sdk/s3-request-presigner";
 
-import { ONE_SECOND, TWO_MINUTES } from "@/lib/constants";
+import { ONE_HOUR, ONE_SECOND, TWO_MINUTES } from "@/lib/constants";
 import { getTeamS3ClientAndConfig } from "@/lib/files/aws-client";
 import { log } from "@/lib/utils";
 
@@ -39,7 +39,12 @@ export default async function handler(
     return res.status(401).json({ message: "Unauthorized" });
   }
 
-  const { key } = req.body as { key: string };
+  const { key, expiresIn: requestedExpiresIn } = req.body as {
+    key: string;
+    expiresIn?: number;
+  };
+
+  const expiration = Math.min(requestedExpiresIn || TWO_MINUTES, ONE_HOUR);
 
   try {
     // Extract teamId from key (format: teamId/docId/filename)
@@ -64,7 +69,7 @@ export default async function handler(
         url: distributionUrl.toString(),
         keyPairId: `${config.distributionKeyId}`,
         privateKey: `${config.distributionKeyContents}`,
-        dateLessThan: new Date(Date.now() + TWO_MINUTES).toISOString(),
+        dateLessThan: new Date(Date.now() + expiration).toISOString(),
       });
 
       return res.status(200).json({ url });
@@ -76,7 +81,7 @@ export default async function handler(
     });
 
     const url = await getS3SignedUrl(client, getObjectCommand, {
-      expiresIn: TWO_MINUTES / ONE_SECOND,
+      expiresIn: expiration / ONE_SECOND,
     });
 
     return res.status(200).json({ url });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The CloudFront/S3 signed URLs were globally set to a 2-minute expiration. This caused MuPDF PDF-to-image conversion to fail for large documents because:

1. A single signed URL is generated in `pdf-to-image-route.ts`
2. That URL is reused sequentially for `get-pages` and every `convert-page` call
3. For documents with many pages, the total processing time easily exceeds 2 minutes, causing the signed URL to expire mid-conversion

## Solution

Added an optional `expiresIn` parameter (in milliseconds) that flows through the signed URL generation pipeline:

- **`pages/api/file/s3/get-presigned-get-url.ts`** — Accepts optional `expiresIn` in the request body. Defaults to 2 minutes, capped at 1 hour for safety. Applied to both CloudFront `dateLessThan` and S3 `expiresIn`.
- **`lib/files/get-file.ts`** — Threads the `expiresIn` option through `getFile()` → `getFileFromS3()` → `fetchPresignedUrl()` (server-side only).
- **`lib/trigger/pdf-to-image-route.ts`** — Passes `expiresIn: ONE_HOUR` when requesting the signed URL for MuPDF processing.

All other callers of `getFile()` (viewer downloads, watermarking, browser-side fetches) are unaffected and continue using the default 2-minute expiration.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4200fbf0-1047-4113-842e-033bc3322f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4200fbf0-1047-4113-842e-033bc3322f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File download URLs now support configurable expiration times (maximum 1 hour)
  * PDF-to-image conversion enhanced with extended expiration window for generated content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->