### PR TITLE
Show descriptive permission error for block list and ignored domains

### DIFF
--- a/components/settings/global-block-list-form.tsx
+++ b/components/settings/global-block-list-form.tsx
@@ -68,7 +68,7 @@ export default function GlobalBlockListForm() {
     }).then(async (res) => {
       if (!res.ok) {
         const { error } = await res.json();
-        throw new Error(error?.message || "Failed to update block list.");
+        throw new Error(error || "Failed to update block list.");
       }
       await mutate();
       return res.json();

--- a/components/settings/ignored-domains-form.tsx
+++ b/components/settings/ignored-domains-form.tsx
@@ -68,7 +68,7 @@ export default function IgnoredDomainsForm() {
     }).then(async (res) => {
       if (!res.ok) {
         const { error } = await res.json();
-        throw new Error(error?.message || "Failed to update ignored domains.");
+        throw new Error(error || "Failed to update ignored domains.");
       }
       await mutate();
       return res.json();

--- a/pages/api/teams/[teamId]/global-block-list.ts
+++ b/pages/api/teams/[teamId]/global-block-list.ts
@@ -47,7 +47,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   if (req.method === "PUT") {
     if (teamAccess.role !== "ADMIN" && teamAccess.role !== "MANAGER") {
-      return res.status(403).json({ error: "Forbidden" });
+      return res.status(403).json({
+        error: "Only admins and managers can manage the block list.",
+      });
     }
 
     try {

--- a/pages/api/teams/[teamId]/ignored-domains.ts
+++ b/pages/api/teams/[teamId]/ignored-domains.ts
@@ -47,7 +47,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   if (req.method === "PUT") {
     if (teamAccess.role !== "ADMIN" && teamAccess.role !== "MANAGER") {
-      return res.status(403).json({ error: "Forbidden" });
+      return res.status(403).json({
+        error: "Only admins and managers can manage ignored domains.",
+      });
     }
 
     try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a member-role user tries to edit the global block list or ignored domains, they see a generic error toast:

> Failed to update block list.

This doesn't explain *why* the update failed, leaving users confused.

## Fix

**API routes** (`global-block-list.ts`, `ignored-domains.ts`): Changed the 403 response from a generic `"Forbidden"` to a descriptive message:
- `"Only admins and managers can manage the block list."`
- `"Only admins and managers can manage ignored domains."`

**Frontend forms** (`global-block-list-form.tsx`, `ignored-domains-form.tsx`): Fixed error parsing — the API returns `{ error: "string" }` but the code was reading `error?.message` (treating it as an object). Changed to `error || "fallback"` so the API message is correctly shown in the toast.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86ed89fd-79bd-4cbb-95e1-c3b471d27caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86ed89fd-79bd-4cbb-95e1-c3b471d27caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when users lack sufficient permissions to manage block lists and ignored domains, now displaying role-specific restrictions instead of generic errors
  * Enhanced error handling in settings forms for more reliable feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->