### PR TITLE
fix: improve table border visibility in Notion document viewer

### DIFF
--- a/styles/custom-notion-styles.css
+++ b/styles/custom-notion-styles.css
@@ -76,25 +76,26 @@
 }
 
 /* Dark mode: lighter borders for simple tables */
-.dark-mode .notion-simple-table td {
+.dark .notion-simple-table td {
   border-bottom-color: rgba(255, 255, 255, 0.15);
   border-right-color: rgba(255, 255, 255, 0.15);
 }
 
-.dark-mode .notion-simple-table tr:first-child td {
+.dark .notion-simple-table tr:first-child td {
   border-top-color: rgba(255, 255, 255, 0.15);
 }
 
-.dark-mode .notion-simple-table td:first-child {
+.dark .notion-simple-table td:first-child {
   border-left-color: rgba(255, 255, 255, 0.15);
 }
 
-.dark-mode .notion-simple-table-header-row td {
+.dark .notion-simple-table-header-row td {
   background: rgba(255, 255, 255, 0.06);
 }
 
-.dark-mode .notion-simple-table-header-cell {
+.dark .notion-simple-table-header-cell {
   background: rgba(255, 255, 255, 0.06);
+}
 }
 
 /* On mobile, everything uses full width */

--- a/styles/custom-notion-styles.css
+++ b/styles/custom-notion-styles.css
@@ -39,7 +39,7 @@
   max-width: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  border: 1px solid rgb(233, 233, 231);
+  border: none;
 }
 
 .notion-simple-table > table {
@@ -47,10 +47,23 @@
   width: auto; /* Size to content, don't force full width */
 }
 
-/* Give table cells visible borders and proper spacing */
+/*
+ * Cell borders use bottom+right only, with first-row top and first-column left,
+ * to produce single 1px lines despite display:block disabling border-collapse.
+ */
 .notion-simple-table td {
   padding: 8px 10px;
-  border: 1px solid rgb(233, 233, 231);
+  border: none;
+  border-bottom: 1px solid rgb(233, 233, 231);
+  border-right: 1px solid rgb(233, 233, 231);
+}
+
+.notion-simple-table tr:first-child td {
+  border-top: 1px solid rgb(233, 233, 231);
+}
+
+.notion-simple-table td:first-child {
+  border-left: 1px solid rgb(233, 233, 231);
 }
 
 /* Simple table header rows get a subtle background tint */
@@ -63,12 +76,17 @@
 }
 
 /* Dark mode: lighter borders for simple tables */
-.dark-mode .notion-simple-table {
-  border-color: rgba(255, 255, 255, 0.15);
+.dark-mode .notion-simple-table td {
+  border-bottom-color: rgba(255, 255, 255, 0.15);
+  border-right-color: rgba(255, 255, 255, 0.15);
 }
 
-.dark-mode .notion-simple-table td {
-  border-color: rgba(255, 255, 255, 0.15);
+.dark-mode .notion-simple-table tr:first-child td {
+  border-top-color: rgba(255, 255, 255, 0.15);
+}
+
+.dark-mode .notion-simple-table td:first-child {
+  border-left-color: rgba(255, 255, 255, 0.15);
 }
 
 .dark-mode .notion-simple-table-header-row td {

--- a/styles/custom-notion-styles.css
+++ b/styles/custom-notion-styles.css
@@ -39,6 +39,7 @@
   max-width: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+  border: 1px solid rgb(233, 233, 231);
 }
 
 .notion-simple-table > table {
@@ -46,9 +47,36 @@
   width: auto; /* Size to content, don't force full width */
 }
 
-/* Give table cells proper spacing */
+/* Give table cells visible borders and proper spacing */
 .notion-simple-table td {
   padding: 8px 10px;
+  border: 1px solid rgb(233, 233, 231);
+}
+
+/* Simple table header rows get a subtle background tint */
+.notion-simple-table-header-row td {
+  background: rgb(247, 246, 243);
+}
+
+.notion-simple-table-header-cell {
+  background: rgb(247, 246, 243);
+}
+
+/* Dark mode: lighter borders for simple tables */
+.dark-mode .notion-simple-table {
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.dark-mode .notion-simple-table td {
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.dark-mode .notion-simple-table-header-row td {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.dark-mode .notion-simple-table-header-cell {
+  background: rgba(255, 255, 255, 0.06);
 }
 
 /* On mobile, everything uses full width */
@@ -204,6 +232,50 @@ textarea,
 
 .notion-simple-table-row td {
   vertical-align: top;
+}
+
+/* Collection/Database table: visible header and cell borders */
+.notion-table-header-inner {
+  border-top: 1px solid rgb(233, 233, 231);
+  border-bottom: 1px solid rgb(233, 233, 231);
+}
+
+.notion-table-view-header-cell-inner {
+  border-right: 1px solid rgb(233, 233, 231);
+}
+
+.notion-table-th:last-child .notion-table-view-header-cell-inner {
+  border-right: 0 none;
+}
+
+.notion-table-row {
+  border-bottom: 1px solid rgb(233, 233, 231);
+}
+
+.notion-table-cell {
+  border-right: 1px solid rgb(233, 233, 231);
+}
+
+.notion-table-cell:last-child {
+  border-right: 0 none;
+}
+
+/* Dark mode: collection/database table borders */
+.dark-mode .notion-table-header-inner {
+  border-top-color: rgba(255, 255, 255, 0.15);
+  border-bottom-color: rgba(255, 255, 255, 0.15);
+}
+
+.dark-mode .notion-table-view-header-cell-inner {
+  border-right-color: rgba(255, 255, 255, 0.15);
+}
+
+.dark-mode .notion-table-row {
+  border-bottom-color: rgba(255, 255, 255, 0.15);
+}
+
+.dark-mode .notion-table-cell {
+  border-right-color: rgba(255, 255, 255, 0.15);
 }
 
 /* Collection/Database table wrapper for horizontal scroll */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Tables in Notion documents rendered via `react-notion-x` have nearly invisible border lines, degrading readability. The root cause is that `react-notion-x` default styles use extremely low-opacity colors for table borders:

- **Simple tables** (`.notion-simple-table`): `--fg-color-5` = `rgba(55, 53, 47, 0.024)` — only **2.4% opacity**
- **Collection/database tables**: `--fg-color-0` / `--fg-color-1` = 9–16% opacity

Additionally, because `.notion-simple-table` uses `display: block` (for horizontal scroll), `border-collapse` is disabled — so naively adding `border` to both the table and cells produces **doubled 2px borders** between adjacent cells.

## Solution

Override table border styles in `styles/custom-notion-styles.css` with Notion's actual visible border color `rgb(233, 233, 231)` for light mode and `rgba(255, 255, 255, 0.15)` for dark mode.

For simple tables, use **directional borders** (bottom+right on all cells, top on first row, left on first column) to produce clean single 1px borders despite `display: block` disabling `border-collapse`.

### Changes

**Simple tables** (`.notion-simple-table`):
- Directional cell borders producing single 1px lines without doubling
- Header rows/cells get subtle background tint `rgb(247, 246, 243)`

**Collection/database tables** (`.notion-table`):
- Header inner border (top + bottom)
- Header cell inner borders (vertical dividers)
- Row borders (bottom)
- Cell borders (right-side dividers)

**Dark mode** support for all table types with `rgba(255, 255, 255, 0.15)` borders.

## Before vs After

### Double border fix (zoomed to 300%)

Before — doubled 2px borders between cells:
[Before: doubled borders at 300% zoom](https://cursor.com/agents/bc-f9223c3f-5726-4592-aa43-b48a770721df/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdouble_border_before_zoomed.webp)

After — clean single 1px borders:
[After: single 1px borders at 300% zoom](https://cursor.com/agents/bc-f9223c3f-5726-4592-aa43-b48a770721df/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdouble_border_after_zoomed.webp)

### Full comparison

[double_border_fix_before_after.mp4](https://cursor.com/agents/bc-f9223c3f-5726-4592-aa43-b48a770721df/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdouble_border_fix_before_after.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9223c3f-5726-4592-aa43-b48a770721df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9223c3f-5726-4592-aa43-b48a770721df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Implemented consistent single-line grid borders for simple tables to improve readability.
  * Applied subtle header tinting to table header rows and header cells for clearer hierarchy.
  * Added explicit borders and separators for collection/database tables to emphasize structure.
  * Refined row and cell border rules for improved alignment and visual separation.
  * Added dark-mode color variants to maintain contrast and visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->