### PR TITLE
feat: treat all CAD files (DWG + DXF) as download-only

### DIFF
--- a/lib/api/documents/process-document.ts
+++ b/lib/api/documents/process-document.ts
@@ -8,7 +8,6 @@ import notion from "@/lib/notion";
 import { getNotionPageIdFromSlug } from "@/lib/notion/utils";
 import prisma from "@/lib/prisma";
 import {
-  convertCadToPdfTask,
   convertFilesToPdfTask,
   convertKeynoteToPdfTask,
 } from "@/lib/trigger/convert-files";
@@ -126,7 +125,7 @@ export const processDocument = async ({
     type === "map" ||
     type === "email" ||
     contentType === "text/tab-separated-values" ||
-    contentType === "image/vnd.dwg";
+    type === "cad";
 
   // Save data to the database
   const document = await prisma.document.create({
@@ -205,26 +204,6 @@ export const processDocument = async ({
       },
       {
         idempotencyKey: `${teamId}-${document.versions[0].id}-docs`,
-        tags: [
-          `team_${teamId}`,
-          `document_${document.id}`,
-          `version:${document.versions[0].id}`,
-        ],
-        queue: conversionQueueName(teamPlan),
-        concurrencyKey: teamId,
-      },
-    );
-  }
-
-  if (type === "cad" && contentType !== "image/vnd.dwg") {
-    await convertCadToPdfTask.trigger(
-      {
-        documentId: document.id,
-        documentVersionId: document.versions[0].id,
-        teamId,
-      },
-      {
-        idempotencyKey: `${teamId}-${document.versions[0].id}-cad`,
         tags: [
           `team_${teamId}`,
           `document_${document.id}`,

--- a/lib/api/documents/process-document.ts
+++ b/lib/api/documents/process-document.ts
@@ -125,7 +125,8 @@ export const processDocument = async ({
     type === "zip" ||
     type === "map" ||
     type === "email" ||
-    contentType === "text/tab-separated-values";
+    contentType === "text/tab-separated-values" ||
+    contentType === "image/vnd.dwg";
 
   // Save data to the database
   const document = await prisma.document.create({
@@ -215,7 +216,7 @@ export const processDocument = async ({
     );
   }
 
-  if (type === "cad") {
+  if (type === "cad" && contentType !== "image/vnd.dwg") {
     await convertCadToPdfTask.trigger(
       {
         documentId: document.id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

All CAD files (DWG and DXF) are now treated as download-only instead of being sent through the Trigger.dev CAD-to-PDF conversion pipeline.

### Changes in `lib/api/documents/process-document.ts`

- Added `type === "cad"` to the `isDownloadOnly` condition, so all CAD uploads are flagged as `downloadOnly: true` and rendered with the `DownloadOnlyViewer`.
- Removed the entire `convertCadToPdfTask.trigger()` block — no CAD files are sent to the conversion pipeline.
- Removed the now-unused `convertCadToPdfTask` import.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4cf6e21-96de-4988-b299-c9dd8403cbe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4cf6e21-96de-4988-b299-c9dd8403cbe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * CAD file processing has been updated. Automatic PDF conversion for CAD uploads is no longer triggered, and CAD files are now classified as download-only items, simplifying document handling for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->