### PR TITLE
feat: visitor upload notifications

### DIFF
--- a/app/(ee)/api/links/[id]/upload/route.ts
+++ b/app/(ee)/api/links/[id]/upload/route.ts
@@ -333,8 +333,8 @@ export async function POST(
     }
 
     // 5. Notify other dataroom visitors about the new upload (each visitor gets their own email)
-    //    Uses cancel-and-retrigger as a debounce: the delayed task queries
-    //    DocumentUpload at runtime to batch all recent uploads into one notification.
+    //    Uses cancel-and-retrigger as a debounce: cancelled runs' document IDs
+    //    are accumulated into the new run so no uploads are lost.
     if (link.dataroom?.enableVisitorUploadChangeNotifications) {
       try {
         const existingChangeRuns = await runs.list({
@@ -350,13 +350,25 @@ export async function POST(
             run.tags?.includes(`visitor_upload_${viewerId}`),
         );
 
+        let accumulatedDocIds: string[] = [newDataroomDocument.id];
+        for (const run of matchingChangeRuns) {
+          const fullRun = await runs.retrieve(run.id);
+          const existingIds = (
+            fullRun.payload as { dataroomDocumentIds?: string[] } | undefined
+          )?.dataroomDocumentIds;
+          if (Array.isArray(existingIds)) {
+            accumulatedDocIds.push(...existingIds);
+          }
+        }
+        accumulatedDocIds = [...new Set(accumulatedDocIds)];
+
         await Promise.all(matchingChangeRuns.map((run) => runs.cancel(run.id)));
 
         waitUntil(
           sendDataroomChangeNotificationTask.trigger(
             {
               dataroomId,
-              uploaderViewerId: viewerId,
+              dataroomDocumentIds: accumulatedDocIds,
               senderUserId: null,
               teamId: link.teamId,
               excludeViewerId: viewerId,

--- a/app/(ee)/api/links/[id]/upload/route.ts
+++ b/app/(ee)/api/links/[id]/upload/route.ts
@@ -337,17 +337,16 @@ export async function POST(
     //    DocumentUpload at runtime to batch all recent uploads into one notification.
     if (link.dataroom?.enableVisitorUploadChangeNotifications) {
       try {
-        const changeNotifTag = `dataroom_${dataroomId}`;
         const existingChangeRuns = await runs.list({
           taskIdentifier: ["send-dataroom-change-notification"],
-          tag: [changeNotifTag, `visitor_upload_${viewerId}`],
+          tag: [`dataroom_${dataroomId}`, `visitor_upload_${viewerId}`],
           status: ["DELAYED", "QUEUED"],
           period: "15m",
         });
 
         const matchingChangeRuns = existingChangeRuns.data.filter(
           (run) =>
-            run.tags?.includes(changeNotifTag) &&
+            run.tags?.includes(`dataroom_${dataroomId}`) &&
             run.tags?.includes(`visitor_upload_${viewerId}`),
         );
 
@@ -366,7 +365,7 @@ export async function POST(
               idempotencyKey: `visitor-change-notification-${link.teamId}-${dataroomId}-${viewerId}-${Date.now()}`,
               tags: [
                 `team_${link.teamId}`,
-                changeNotifTag,
+                `dataroom_${dataroomId}`,
                 `visitor_upload_${viewerId}`,
               ],
               delay: new Date(Date.now() + 10 * 60 * 1000),

--- a/app/(ee)/api/links/[id]/upload/route.ts
+++ b/app/(ee)/api/links/[id]/upload/route.ts
@@ -1,15 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { runs } from "@trigger.dev/sdk";
+import { waitUntil } from "@vercel/functions";
+
 import { processDocument } from "@/lib/api/documents/process-document";
 import { verifyDataroomSession } from "@/lib/auth/dataroom-auth";
 import { DocumentData } from "@/lib/documents/create-document";
 import prisma from "@/lib/prisma";
 import { sendDataroomChangeNotificationTask } from "@/lib/trigger/dataroom-change-notification";
 import { sendDataroomUploadNotificationTask } from "@/lib/trigger/dataroom-upload-notification";
-import { sanitizePlainText } from "@/lib/utils/sanitize-html";
 import { supportsAdvancedExcelMode } from "@/lib/utils/get-content-type";
-import { runs } from "@trigger.dev/sdk";
-import { waitUntil } from "@vercel/functions";
+import { sanitizePlainText } from "@/lib/utils/sanitize-html";
 
 /**
  * GET /api/links/[id]/upload?dataroomId=xxx
@@ -38,10 +39,7 @@ export async function GET(
     );
 
     if (!dataroomSession || !dataroomSession.viewerId) {
-      return NextResponse.json(
-        { message: "Unauthorized" },
-        { status: 401 },
-      );
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
     const { viewerId } = dataroomSession;
@@ -227,7 +225,8 @@ export async function POST(
     const updatedDocumentData = {
       ...documentData,
       name: sanitizedDocumentName,
-      enableExcelAdvancedMode: documentData.supportedFileType === "sheet" &&
+      enableExcelAdvancedMode:
+        documentData.supportedFileType === "sheet" &&
         link.team?.enableExcelAdvancedMode &&
         supportsAdvancedExcelMode(documentData.contentType),
     };
@@ -350,9 +349,7 @@ export async function POST(
             run.tags?.includes(`visitor_upload_${viewerId}`),
         );
 
-        await Promise.all(
-          matchingChangeRuns.map((run) => runs.cancel(run.id)),
-        );
+        await Promise.all(matchingChangeRuns.map((run) => runs.cancel(run.id)));
 
         waitUntil(
           sendDataroomChangeNotificationTask.trigger(

--- a/app/(ee)/api/links/[id]/upload/route.ts
+++ b/app/(ee)/api/links/[id]/upload/route.ts
@@ -4,6 +4,7 @@ import { processDocument } from "@/lib/api/documents/process-document";
 import { verifyDataroomSession } from "@/lib/auth/dataroom-auth";
 import { DocumentData } from "@/lib/documents/create-document";
 import prisma from "@/lib/prisma";
+import { sendDataroomChangeNotificationTask } from "@/lib/trigger/dataroom-change-notification";
 import { sendDataroomUploadNotificationTask } from "@/lib/trigger/dataroom-upload-notification";
 import { sanitizePlainText } from "@/lib/utils/sanitize-html";
 import { supportsAdvancedExcelMode } from "@/lib/utils/get-content-type";
@@ -160,6 +161,11 @@ export async function POST(
           select: {
             plan: true,
             enableExcelAdvancedMode: true,
+          },
+        },
+        dataroom: {
+          select: {
+            enableVisitorUploadChangeNotifications: true,
           },
         },
       },
@@ -324,6 +330,56 @@ export async function POST(
         );
       } catch (error) {
         console.error("Error triggering upload notification:", error);
+      }
+    }
+
+    // 5. Notify other dataroom visitors about the new upload (each visitor gets their own email)
+    if (link.dataroom?.enableVisitorUploadChangeNotifications) {
+      try {
+        const changeNotifTag = `dataroom_${dataroomId}`;
+        const existingChangeRuns = await runs.list({
+          taskIdentifier: ["send-dataroom-change-notification"],
+          tag: [changeNotifTag, `visitor_upload_${viewerId}`],
+          status: ["DELAYED", "QUEUED"],
+          period: "10m",
+        });
+
+        const matchingChangeRuns = existingChangeRuns.data.filter(
+          (run) =>
+            run.tags?.includes(changeNotifTag) &&
+            run.tags?.includes(`visitor_upload_${viewerId}`),
+        );
+
+        await Promise.all(
+          matchingChangeRuns.map((run) => runs.cancel(run.id)),
+        );
+
+        waitUntil(
+          sendDataroomChangeNotificationTask.trigger(
+            {
+              dataroomId,
+              dataroomDocumentId: newDataroomDocument.id,
+              senderUserId: null,
+              teamId: link.teamId,
+              excludeViewerId: viewerId,
+            },
+            {
+              idempotencyKey: `visitor-change-notification-${link.teamId}-${dataroomId}-${newDataroomDocument.id}`,
+              tags: [
+                `team_${link.teamId}`,
+                changeNotifTag,
+                `document_${newDataroomDocument.id}`,
+                `visitor_upload_${viewerId}`,
+              ],
+              delay: new Date(Date.now() + 10 * 60 * 1000), // 10 minute delay (same as admin)
+            },
+          ),
+        );
+      } catch (error) {
+        console.error(
+          "Error triggering visitor upload change notification:",
+          error,
+        );
       }
     }
 

--- a/app/(ee)/api/links/[id]/upload/route.ts
+++ b/app/(ee)/api/links/[id]/upload/route.ts
@@ -333,6 +333,8 @@ export async function POST(
     }
 
     // 5. Notify other dataroom visitors about the new upload (each visitor gets their own email)
+    //    Uses cancel-and-retrigger as a debounce: the delayed task queries
+    //    DocumentUpload at runtime to batch all recent uploads into one notification.
     if (link.dataroom?.enableVisitorUploadChangeNotifications) {
       try {
         const changeNotifTag = `dataroom_${dataroomId}`;
@@ -340,7 +342,7 @@ export async function POST(
           taskIdentifier: ["send-dataroom-change-notification"],
           tag: [changeNotifTag, `visitor_upload_${viewerId}`],
           status: ["DELAYED", "QUEUED"],
-          period: "10m",
+          period: "15m",
         });
 
         const matchingChangeRuns = existingChangeRuns.data.filter(
@@ -355,20 +357,19 @@ export async function POST(
           sendDataroomChangeNotificationTask.trigger(
             {
               dataroomId,
-              dataroomDocumentId: newDataroomDocument.id,
+              uploaderViewerId: viewerId,
               senderUserId: null,
               teamId: link.teamId,
               excludeViewerId: viewerId,
             },
             {
-              idempotencyKey: `visitor-change-notification-${link.teamId}-${dataroomId}-${newDataroomDocument.id}`,
+              idempotencyKey: `visitor-change-notification-${link.teamId}-${dataroomId}-${viewerId}-${Date.now()}`,
               tags: [
                 `team_${link.teamId}`,
                 changeNotifTag,
-                `document_${newDataroomDocument.id}`,
                 `visitor_upload_${viewerId}`,
               ],
-              delay: new Date(Date.now() + 10 * 60 * 1000), // 10 minute delay (same as admin)
+              delay: new Date(Date.now() + 10 * 60 * 1000),
             },
           ),
         );

--- a/components/datarooms/settings/notification-settings.tsx
+++ b/components/datarooms/settings/notification-settings.tsx
@@ -34,6 +34,7 @@ export default function NotificationSettings({
     name: string;
     pId: string;
     enableChangeNotifications: boolean;
+    enableVisitorUploadChangeNotifications: boolean;
   }>(
     dataroomId ? `/api/teams/${teamId}/datarooms/${dataroomId}` : null,
     fetcher,
@@ -46,7 +47,10 @@ export default function NotificationSettings({
     fetcher,
   );
 
-  const handleNotificationToggle = async (checked: boolean) => {
+  const handleNotificationToggle = async (
+    field: "enableChangeNotifications" | "enableVisitorUploadChangeNotifications",
+    checked: boolean,
+  ) => {
     if (!dataroomId || !teamId) return;
 
     if (!isDataroomsPlus && !isTrial && !features?.roomChangeNotifications) {
@@ -61,7 +65,7 @@ export default function NotificationSettings({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          enableChangeNotifications: checked,
+          [field]: checked,
         }),
       }).then(async (res) => {
         if (!res.ok) {
@@ -87,19 +91,39 @@ export default function NotificationSettings({
           ) : null}
         </CardTitle>
         <CardDescription>
-          {!dataroomData?.enableChangeNotifications ? "Enable" : "Disable"}{" "}
-          change notification for this dataroom.
+          Configure change notifications for this dataroom.
         </CardDescription>
       </CardHeader>
-      <CardContent className="flex items-center justify-between">
-        <Label htmlFor="notification-toggle">
-          Notify visitors when new documents are added
-        </Label>
-        <Switch
-          id="notification-toggle"
-          checked={dataroomData?.enableChangeNotifications ?? false}
-          onCheckedChange={handleNotificationToggle}
-        />
+      <CardContent className="space-y-6">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="notification-toggle">
+            Notify visitors when new documents are added
+          </Label>
+          <Switch
+            id="notification-toggle"
+            checked={dataroomData?.enableChangeNotifications ?? false}
+            onCheckedChange={(checked) =>
+              handleNotificationToggle("enableChangeNotifications", checked)
+            }
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <Label htmlFor="visitor-upload-notification-toggle">
+            Notify visitors when another visitor uploads a document
+          </Label>
+          <Switch
+            id="visitor-upload-notification-toggle"
+            checked={
+              dataroomData?.enableVisitorUploadChangeNotifications ?? false
+            }
+            onCheckedChange={(checked) =>
+              handleNotificationToggle(
+                "enableVisitorUploadChangeNotifications",
+                checked,
+              )
+            }
+          />
+        </div>
       </CardContent>
       <CardFooter className="flex items-center justify-between rounded-b-lg border-t bg-muted px-6 py-6">
         <p className="text-sm text-muted-foreground transition-colors">

--- a/components/emails/dataroom-digest-notification.tsx
+++ b/components/emails/dataroom-digest-notification.tsx
@@ -24,14 +24,14 @@ export default function DataroomDigestNotification({
     { documentName: "Document B" },
     { documentName: "Document C" },
   ],
-  senderEmail = "example@example.com",
+  senderEmail,
   url = "https://app.papermark.com/datarooms/123",
   preferencesUrl = "https://app.papermark.com/notification-preferences?token=abc",
   frequency = "daily",
 }: {
   dataroomName: string;
   documents: DocumentChange[];
-  senderEmail: string;
+  senderEmail: string | null;
   url: string;
   preferencesUrl: string;
   frequency: "daily" | "weekly";
@@ -91,9 +91,14 @@ export default function DataroomDigestNotification({
                 reserved.
               </Text>
               <Text className="text-xs">
-                You received this {frequency} digest from{" "}
-                <span className="font-semibold">{senderEmail}</span> because you
-                viewed the dataroom{" "}
+                You received this {frequency} digest{" "}
+                {senderEmail ? (
+                  <>
+                    from{" "}
+                    <span className="font-semibold">{senderEmail}</span>{" "}
+                  </>
+                ) : null}
+                because you viewed the dataroom{" "}
                 <span className="font-semibold">{dataroomName}</span> on
                 Papermark. If you have any feedback or questions about this
                 email, simply reply to it.{" "}

--- a/components/emails/dataroom-digest-notification.tsx
+++ b/components/emails/dataroom-digest-notification.tsx
@@ -34,10 +34,15 @@ export default function DataroomDigestNotification({
   senderEmail: string | null;
   url: string;
   preferencesUrl: string;
-  frequency: "daily" | "weekly";
+  frequency: "daily" | "weekly" | "instant";
 }) {
   const count = documents.length;
-  const periodLabel = frequency === "daily" ? "today" : "this week";
+  const periodLabel =
+    frequency === "instant"
+      ? "recently"
+      : frequency === "daily"
+        ? "today"
+        : "this week";
 
   return (
     <Html>
@@ -91,7 +96,8 @@ export default function DataroomDigestNotification({
                 reserved.
               </Text>
               <Text className="text-xs">
-                You received this {frequency} digest{" "}
+                You received this{" "}
+                {frequency !== "instant" ? `${frequency} digest ` : "notification "}
                 {senderEmail ? (
                   <>
                     from{" "}

--- a/components/emails/dataroom-notification.tsx
+++ b/components/emails/dataroom-notification.tsx
@@ -16,13 +16,13 @@ import {
 export default function DataroomNotification({
   dataroomName = "Example Data Room",
   documentName = "Example Document",
-  senderEmail = "example@example.com",
+  senderEmail,
   url = "https://app.papermark.com/datarooms/123",
   unsubscribeUrl = "https://app.papermark.com/datarooms/123/unsubscribe",
 }: {
   dataroomName: string;
   documentName: string | undefined;
-  senderEmail: string;
+  senderEmail: string | null;
   url: string;
   unsubscribeUrl: string;
 }) {
@@ -67,9 +67,14 @@ export default function DataroomNotification({
                 reserved.
               </Text>
               <Text className="text-xs">
-                You received this email from{" "}
-                <span className="font-semibold">{senderEmail}</span> because you
-                viewed the dataroom{" "}
+                You received this email{" "}
+                {senderEmail ? (
+                  <>
+                    from{" "}
+                    <span className="font-semibold">{senderEmail}</span>{" "}
+                  </>
+                ) : null}
+                because you viewed the dataroom{" "}
                 <span className="font-semibold">{dataroomName}</span> on
                 Papermark. If you have any feedback or questions about this
                 email, simply reply to it.{" "}

--- a/lib/emails/process-dataroom-digest.ts
+++ b/lib/emails/process-dataroom-digest.ts
@@ -116,7 +116,7 @@ async function processBatch(batch: DigestBatch, frequency: "daily" | "weekly") {
     await sendDataroomDigestNotification({
       dataroomName: dataroom?.name ?? "Unknown Dataroom",
       documents,
-      senderEmail: senderUser?.email ?? "noreply@papermark.com",
+      senderEmail: senderUser?.email ?? null,
       to: viewer.email,
       url: linkUrl,
       preferencesUrl,

--- a/lib/emails/send-dataroom-digest-notification.ts
+++ b/lib/emails/send-dataroom-digest-notification.ts
@@ -17,10 +17,15 @@ export const sendDataroomDigestNotification = async ({
   to: string;
   url: string;
   preferencesUrl: string;
-  frequency: "daily" | "weekly";
+  frequency: "daily" | "weekly" | "instant";
 }) => {
   const count = documents.length;
-  const periodLabel = frequency === "daily" ? "today" : "this week";
+  const periodLabel =
+    frequency === "instant"
+      ? "recently"
+      : frequency === "daily"
+        ? "today"
+        : "this week";
 
   try {
     await sendEmail({

--- a/lib/emails/send-dataroom-digest-notification.ts
+++ b/lib/emails/send-dataroom-digest-notification.ts
@@ -13,7 +13,7 @@ export const sendDataroomDigestNotification = async ({
 }: {
   dataroomName: string;
   documents: { documentName: string }[];
-  senderEmail: string;
+  senderEmail: string | null;
   to: string;
   url: string;
   preferencesUrl: string;

--- a/lib/emails/send-dataroom-notification.ts
+++ b/lib/emails/send-dataroom-notification.ts
@@ -12,7 +12,7 @@ export const sendDataroomNotification = async ({
 }: {
   dataroomName: string;
   documentName: string | undefined;
-  senderEmail: string;
+  senderEmail: string | null;
   to: string;
   url: string;
   unsubscribeUrl: string;

--- a/lib/redis/dataroom-notification-queue.ts
+++ b/lib/redis/dataroom-notification-queue.ts
@@ -4,7 +4,7 @@ const ITEM_TTL_SECONDS = 8 * 24 * 60 * 60; // 8 days
 
 type QueueItem = {
   dataroomDocumentId: string;
-  senderUserId: string;
+  senderUserId: string | null;
   queuedAt: number;
 };
 
@@ -44,7 +44,7 @@ export async function queueNotification({
   dataroomId: string;
   teamId: string;
   dataroomDocumentId: string;
-  senderUserId: string;
+  senderUserId: string | null;
 }) {
   const key = itemsKey(viewerId, dataroomId);
   const item: QueueItem = {

--- a/lib/trigger/dataroom-change-notification.ts
+++ b/lib/trigger/dataroom-change-notification.ts
@@ -1,30 +1,62 @@
-import { logger, task } from "@trigger.dev/sdk";
+import { logger, schemaTask } from "@trigger.dev/sdk";
+import { z } from "zod";
 
 import prisma from "@/lib/prisma";
 import { queueNotification } from "@/lib/redis/dataroom-notification-queue";
 import { ZViewerNotificationPreferencesSchema } from "@/lib/zod/schemas/notifications";
 
-type NotificationPayload = {
-  dataroomId: string;
-  dataroomDocumentId: string;
-  senderUserId: string | null;
-  teamId: string;
-  excludeViewerId?: string;
-};
+const NotificationPayloadSchema = z.object({
+  dataroomId: z.string().cuid(),
+  dataroomDocumentId: z.string().cuid().optional(),
+  uploaderViewerId: z.string().cuid().optional(),
+  senderUserId: z.string().cuid().nullable(),
+  teamId: z.string().cuid(),
+  excludeViewerId: z.string().cuid().optional(),
+});
 
-export const sendDataroomChangeNotificationTask = task({
+export const sendDataroomChangeNotificationTask = schemaTask({
   id: "send-dataroom-change-notification",
+  schema: NotificationPayloadSchema,
   retry: { maxAttempts: 3 },
-  run: async (payload: NotificationPayload) => {
-    const dataroomDocument = await prisma.dataroomDocument.findUnique({
-      where: { id: payload.dataroomDocumentId },
+  run: async (payload) => {
+    // --- Resolve document IDs ---
+    let dataroomDocumentIds: string[];
+
+    if (payload.uploaderViewerId) {
+      const fifteenMinutesAgo = new Date(Date.now() - 15 * 60 * 1000);
+      const recentUploads = await prisma.documentUpload.findMany({
+        where: {
+          dataroomId: payload.dataroomId,
+          viewerId: payload.uploaderViewerId,
+          uploadedAt: { gte: fifteenMinutesAgo },
+        },
+        select: { dataroomDocumentId: true },
+        orderBy: { uploadedAt: "desc" },
+      });
+      dataroomDocumentIds = recentUploads
+        .map((u) => u.dataroomDocumentId)
+        .filter((id): id is string => id !== null);
+    } else if (payload.dataroomDocumentId) {
+      dataroomDocumentIds = [payload.dataroomDocumentId];
+    } else {
+      logger.error("Either dataroomDocumentId or uploaderViewerId is required");
+      return;
+    }
+
+    if (dataroomDocumentIds.length === 0) {
+      logger.info("No documents to notify about", {
+        dataroomId: payload.dataroomId,
+      });
+      return;
+    }
+
+    const dataroomDocuments = await prisma.dataroomDocument.findMany({
+      where: { id: { in: dataroomDocumentIds } },
       select: { id: true, folderId: true },
     });
 
-    if (!dataroomDocument) {
-      logger.error("Dataroom document not found", {
-        dataroomDocumentId: payload.dataroomDocumentId,
-      });
+    if (dataroomDocuments.length === 0) {
+      logger.error("Dataroom documents not found", { dataroomDocumentIds });
       return;
     }
 
@@ -80,28 +112,23 @@ export const sendDataroomChangeNotificationTask = task({
       return;
     }
 
-    // Cache folder-access results per group to avoid duplicate queries
     const folderAccessCache = new Map<string, boolean>();
 
     const canViewFolder = async (
       groupId: string | null | undefined,
       permissionGroupId: string | null | undefined,
+      folderId: string | null,
     ): Promise<boolean> => {
-      // No group restriction → unrestricted access
       if (!groupId && !permissionGroupId) {
         return true;
       }
 
-      // Document is in the root (no folder) → always notify
-      if (!dataroomDocument.folderId) {
+      if (!folderId) {
         return true;
       }
 
-      const folderId = dataroomDocument.folderId;
-
-      // groupId
       if (groupId) {
-        const cacheKey = `viewer-group:${groupId}`;
+        const cacheKey = `viewer-group:${groupId}:${folderId}`;
         if (folderAccessCache.has(cacheKey)) {
           return folderAccessCache.get(cacheKey)!;
         }
@@ -116,9 +143,8 @@ export const sendDataroomChangeNotificationTask = task({
         return result;
       }
 
-      // permissionGroupId
       if (permissionGroupId) {
-        const cacheKey = `permission-group:${permissionGroupId}`;
+        const cacheKey = `permission-group:${permissionGroupId}:${folderId}`;
         if (folderAccessCache.has(cacheKey)) {
           return folderAccessCache.get(cacheKey)!;
         }
@@ -138,6 +164,13 @@ export const sendDataroomChangeNotificationTask = task({
 
     const viewerResults = await Promise.all(
       viewers.map(async (viewer) => {
+        // TODO: KNOWN LIMITATION: Only the most recent view (views[0]) is checked for
+        // folder access. A viewer with multiple verified links may be
+        // incorrectly skipped if views[0]'s link lacks access but another
+        // link in viewer.views does grant it via canViewFolder(). The fix is
+        // to iterate over all viewer.views and pick any link where
+        // canViewFolder(link.groupId, link.permissionGroupId) returns true
+        // for dataroomDocument.folderId before deciding to skip.
         const view = viewer.views[0];
         const link = view?.link;
 
@@ -149,23 +182,29 @@ export const sendDataroomChangeNotificationTask = task({
           return null;
         }
 
-        const hasAccess = await canViewFolder(
-          link.groupId,
-          link.permissionGroupId,
-        );
-
-        if (!hasAccess) {
-          logger.info(
-            "Skipping viewer notification: link group does not have access to the document folder",
-            {
-              viewerId: viewer.id,
-              linkId: link.id,
-              groupId: link.groupId,
-              permissionGroupId: link.permissionGroupId,
-              folderId: dataroomDocument.folderId,
-              dataroomDocumentId: payload.dataroomDocumentId,
-            },
+        const accessibleDocIds: string[] = [];
+        for (const doc of dataroomDocuments) {
+          const hasAccess = await canViewFolder(
+            link.groupId,
+            link.permissionGroupId,
+            doc.folderId,
           );
+          if (hasAccess) {
+            accessibleDocIds.push(doc.id);
+          } else {
+            logger.info(
+              "Skipping document for viewer: link group lacks folder access",
+              {
+                viewerId: viewer.id,
+                linkId: link.id,
+                dataroomDocumentId: doc.id,
+                folderId: doc.folderId,
+              },
+            );
+          }
+        }
+
+        if (accessibleDocIds.length === 0) {
           return null;
         }
 
@@ -197,6 +236,7 @@ export const sendDataroomChangeNotificationTask = task({
           id: viewer.id,
           linkUrl,
           frequency,
+          accessibleDocIds,
         };
       }),
     );
@@ -208,28 +248,33 @@ export const sendDataroomChangeNotificationTask = task({
         id: string;
         linkUrl: string;
         frequency: "instant" | "daily" | "weekly";
+        accessibleDocIds: string[];
       } => viewer !== null,
     );
 
     logger.info("Processed viewer links", {
       viewerCount: viewersWithLinks.length,
+      documentCount: dataroomDocuments.length,
     });
 
     for (const viewer of viewersWithLinks) {
       try {
         if (viewer.frequency === "daily" || viewer.frequency === "weekly") {
-          await queueNotification({
-            frequency: viewer.frequency,
-            viewerId: viewer.id,
-            dataroomId: payload.dataroomId,
-            teamId: payload.teamId,
-            dataroomDocumentId: payload.dataroomDocumentId,
-            senderUserId: payload.senderUserId,
-          });
+          for (const docId of viewer.accessibleDocIds) {
+            await queueNotification({
+              frequency: viewer.frequency,
+              viewerId: viewer.id,
+              dataroomId: payload.dataroomId,
+              teamId: payload.teamId,
+              dataroomDocumentId: docId,
+              senderUserId: payload.senderUserId,
+            });
+          }
 
-          logger.info("Queued notification for digest", {
+          logger.info("Queued notifications for digest", {
             viewerId: viewer.id,
             frequency: viewer.frequency,
+            documentCount: viewer.accessibleDocIds.length,
           });
           continue;
         }
@@ -241,7 +286,7 @@ export const sendDataroomChangeNotificationTask = task({
             body: JSON.stringify({
               dataroomId: payload.dataroomId,
               linkUrl: viewer.linkUrl,
-              dataroomDocumentId: payload.dataroomDocumentId,
+              dataroomDocumentIds: viewer.accessibleDocIds,
               viewerId: viewer.id,
               senderUserId: payload.senderUserId,
               teamId: payload.teamId,
@@ -266,6 +311,7 @@ export const sendDataroomChangeNotificationTask = task({
         logger.info("Notification sent successfully", {
           viewerId: viewer.id,
           message,
+          documentCount: viewer.accessibleDocIds.length,
         });
       } catch (error) {
         logger.error("Error sending notification", {
@@ -278,6 +324,7 @@ export const sendDataroomChangeNotificationTask = task({
     logger.info("Completed sending notifications", {
       dataroomId: payload.dataroomId,
       viewerCount: viewers.length,
+      documentCount: dataroomDocuments.length,
     });
     return;
   },

--- a/lib/trigger/dataroom-change-notification.ts
+++ b/lib/trigger/dataroom-change-notification.ts
@@ -7,8 +7,9 @@ import { ZViewerNotificationPreferencesSchema } from "@/lib/zod/schemas/notifica
 type NotificationPayload = {
   dataroomId: string;
   dataroomDocumentId: string;
-  senderUserId: string;
+  senderUserId: string | null;
   teamId: string;
+  excludeViewerId?: string;
 };
 
 export const sendDataroomChangeNotificationTask = task({
@@ -18,6 +19,9 @@ export const sendDataroomChangeNotificationTask = task({
     const viewers = await prisma.viewer.findMany({
       where: {
         teamId: payload.teamId,
+        ...(payload.excludeViewerId && {
+          id: { not: payload.excludeViewerId },
+        }),
         views: {
           some: {
             dataroomId: payload.dataroomId,

--- a/lib/trigger/dataroom-change-notification.ts
+++ b/lib/trigger/dataroom-change-notification.ts
@@ -5,14 +5,23 @@ import prisma from "@/lib/prisma";
 import { queueNotification } from "@/lib/redis/dataroom-notification-queue";
 import { ZViewerNotificationPreferencesSchema } from "@/lib/zod/schemas/notifications";
 
-const NotificationPayloadSchema = z.object({
-  dataroomId: z.string().cuid(),
-  dataroomDocumentId: z.string().cuid().optional(),
-  uploaderViewerId: z.string().cuid().optional(),
-  senderUserId: z.string().cuid().nullable(),
-  teamId: z.string().cuid(),
-  excludeViewerId: z.string().cuid().optional(),
-});
+const NotificationPayloadSchema = z
+  .object({
+    dataroomId: z.string().cuid(),
+    dataroomDocumentId: z.string().cuid().optional(),
+    uploaderViewerId: z.string().cuid().optional(),
+    senderUserId: z.string().cuid().nullable(),
+    teamId: z.string().cuid(),
+    excludeViewerId: z.string().cuid().optional(),
+  })
+  .refine(
+    (data) =>
+      Boolean(data.dataroomDocumentId) !== Boolean(data.uploaderViewerId),
+    {
+      message:
+        "Exactly one of dataroomDocumentId or uploaderViewerId must be provided",
+    },
+  );
 
 export const sendDataroomChangeNotificationTask = schemaTask({
   id: "send-dataroom-change-notification",

--- a/lib/trigger/dataroom-change-notification.ts
+++ b/lib/trigger/dataroom-change-notification.ts
@@ -5,70 +5,31 @@ import prisma from "@/lib/prisma";
 import { queueNotification } from "@/lib/redis/dataroom-notification-queue";
 import { ZViewerNotificationPreferencesSchema } from "@/lib/zod/schemas/notifications";
 
-const NotificationPayloadSchema = z
-  .object({
-    dataroomId: z.string().cuid(),
-    dataroomDocumentId: z.string().cuid().optional(),
-    uploaderViewerId: z.string().cuid().optional(),
-    senderUserId: z.string().cuid().nullable(),
-    teamId: z.string().cuid(),
-    excludeViewerId: z.string().cuid().optional(),
-  })
-  .refine(
-    (data) =>
-      Boolean(data.dataroomDocumentId) !== Boolean(data.uploaderViewerId),
-    {
-      message:
-        "Exactly one of dataroomDocumentId or uploaderViewerId must be provided",
-    },
-  );
+const NotificationPayloadSchema = z.object({
+  dataroomId: z.string().cuid(),
+  dataroomDocumentIds: z.array(z.string().cuid()).min(1),
+  senderUserId: z.string().cuid().nullable(),
+  teamId: z.string().cuid(),
+  excludeViewerId: z.string().cuid().optional(),
+});
 
 export const sendDataroomChangeNotificationTask = schemaTask({
   id: "send-dataroom-change-notification",
   schema: NotificationPayloadSchema,
   retry: { maxAttempts: 3 },
   run: async (payload) => {
-    // --- Resolve document IDs ---
-    let dataroomDocumentIds: string[];
-
-    if (payload.uploaderViewerId) {
-      const fifteenMinutesAgo = new Date(Date.now() - 15 * 60 * 1000);
-      const recentUploads = await prisma.documentUpload.findMany({
-        where: {
-          dataroomId: payload.dataroomId,
-          viewerId: payload.uploaderViewerId,
-          uploadedAt: { gte: fifteenMinutesAgo },
-        },
-        select: { dataroomDocumentId: true },
-        orderBy: { uploadedAt: "desc" },
-      });
-      dataroomDocumentIds = recentUploads
-        .map((u) => u.dataroomDocumentId)
-        .filter((id): id is string => id !== null);
-    } else if (payload.dataroomDocumentId) {
-      dataroomDocumentIds = [payload.dataroomDocumentId];
-    } else {
-      logger.error("Either dataroomDocumentId or uploaderViewerId is required");
-      return;
-    }
-
-    if (dataroomDocumentIds.length === 0) {
-      logger.info("No documents to notify about", {
-        dataroomId: payload.dataroomId,
-      });
-      return;
-    }
-
     const dataroomDocuments = await prisma.dataroomDocument.findMany({
       where: {
-        id: { in: dataroomDocumentIds },
+        id: { in: payload.dataroomDocumentIds },
         dataroomId: payload.dataroomId,
       },
       select: { id: true, folderId: true },
     });
 
     if (dataroomDocuments.length === 0) {
-      logger.error("Dataroom documents not found", { dataroomDocumentIds });
+      logger.error("Dataroom documents not found", {
+        dataroomDocumentIds: payload.dataroomDocumentIds,
+      });
       return;
     }
 

--- a/lib/trigger/dataroom-change-notification.ts
+++ b/lib/trigger/dataroom-change-notification.ts
@@ -16,6 +16,18 @@ export const sendDataroomChangeNotificationTask = task({
   id: "send-dataroom-change-notification",
   retry: { maxAttempts: 3 },
   run: async (payload: NotificationPayload) => {
+    const dataroomDocument = await prisma.dataroomDocument.findUnique({
+      where: { id: payload.dataroomDocumentId },
+      select: { id: true, folderId: true },
+    });
+
+    if (!dataroomDocument) {
+      logger.error("Dataroom document not found", {
+        dataroomDocumentId: payload.dataroomDocumentId,
+      });
+      return;
+    }
+
     const viewers = await prisma.viewer.findMany({
       where: {
         teamId: payload.teamId,
@@ -52,6 +64,8 @@ export const sendDataroomChangeNotificationTask = task({
                 domainId: true,
                 isArchived: true,
                 expiresAt: true,
+                groupId: true,
+                permissionGroupId: true,
               },
             },
           },
@@ -66,8 +80,64 @@ export const sendDataroomChangeNotificationTask = task({
       return;
     }
 
-    const viewersWithLinks = viewers
-      .map((viewer) => {
+    // Cache folder-access results per group to avoid duplicate queries
+    const folderAccessCache = new Map<string, boolean>();
+
+    const canViewFolder = async (
+      groupId: string | null | undefined,
+      permissionGroupId: string | null | undefined,
+    ): Promise<boolean> => {
+      // No group restriction → unrestricted access
+      if (!groupId && !permissionGroupId) {
+        return true;
+      }
+
+      // Document is in the root (no folder) → always notify
+      if (!dataroomDocument.folderId) {
+        return true;
+      }
+
+      const folderId = dataroomDocument.folderId;
+
+      // groupId
+      if (groupId) {
+        const cacheKey = `viewer-group:${groupId}`;
+        if (folderAccessCache.has(cacheKey)) {
+          return folderAccessCache.get(cacheKey)!;
+        }
+        const ac = await prisma.viewerGroupAccessControls.findUnique({
+          where: {
+            groupId_itemId: { groupId, itemId: folderId },
+          },
+          select: { canView: true },
+        });
+        const result = ac?.canView === true;
+        folderAccessCache.set(cacheKey, result);
+        return result;
+      }
+
+      // permissionGroupId
+      if (permissionGroupId) {
+        const cacheKey = `permission-group:${permissionGroupId}`;
+        if (folderAccessCache.has(cacheKey)) {
+          return folderAccessCache.get(cacheKey)!;
+        }
+        const ac = await prisma.permissionGroupAccessControls.findUnique({
+          where: {
+            groupId_itemId: { groupId: permissionGroupId, itemId: folderId },
+          },
+          select: { canView: true },
+        });
+        const result = ac?.canView === true;
+        folderAccessCache.set(cacheKey, result);
+        return result;
+      }
+
+      return false;
+    };
+
+    const viewerResults = await Promise.all(
+      viewers.map(async (viewer) => {
         const view = viewer.views[0];
         const link = view?.link;
 
@@ -76,6 +146,26 @@ export const sendDataroomChangeNotificationTask = task({
           link.isArchived ||
           (link.expiresAt && new Date(link.expiresAt) < new Date())
         ) {
+          return null;
+        }
+
+        const hasAccess = await canViewFolder(
+          link.groupId,
+          link.permissionGroupId,
+        );
+
+        if (!hasAccess) {
+          logger.info(
+            "Skipping viewer notification: link group does not have access to the document folder",
+            {
+              viewerId: viewer.id,
+              linkId: link.id,
+              groupId: link.groupId,
+              permissionGroupId: link.permissionGroupId,
+              folderId: dataroomDocument.folderId,
+              dataroomDocumentId: payload.dataroomDocumentId,
+            },
+          );
           return null;
         }
 
@@ -91,11 +181,10 @@ export const sendDataroomChangeNotificationTask = task({
           return null;
         }
 
-        const frequency =
-          parsedPreferences.success
-            ? (parsedPreferences.data.dataroom[payload.dataroomId]?.frequency ??
-              "instant")
-            : "instant";
+        const frequency = parsedPreferences.success
+          ? (parsedPreferences.data.dataroom[payload.dataroomId]?.frequency ??
+            "instant")
+          : "instant";
 
         let linkUrl = "";
         if (link.domainId && link.domainSlug && link.slug) {
@@ -109,16 +198,18 @@ export const sendDataroomChangeNotificationTask = task({
           linkUrl,
           frequency,
         };
-      })
-      .filter(
-        (
-          viewer,
-        ): viewer is {
-          id: string;
-          linkUrl: string;
-          frequency: "instant" | "daily" | "weekly";
-        } => viewer !== null,
-      );
+      }),
+    );
+
+    const viewersWithLinks = viewerResults.filter(
+      (
+        viewer,
+      ): viewer is {
+        id: string;
+        linkUrl: string;
+        frequency: "instant" | "daily" | "weekly";
+      } => viewer !== null,
+    );
 
     logger.info("Processed viewer links", {
       viewerCount: viewersWithLinks.length,

--- a/lib/trigger/dataroom-change-notification.ts
+++ b/lib/trigger/dataroom-change-notification.ts
@@ -60,7 +60,10 @@ export const sendDataroomChangeNotificationTask = schemaTask({
     }
 
     const dataroomDocuments = await prisma.dataroomDocument.findMany({
-      where: { id: { in: dataroomDocumentIds } },
+      where: {
+        id: { in: dataroomDocumentIds },
+        dataroomId: payload.dataroomId,
+      },
       select: { id: true, folderId: true },
     });
 

--- a/pages/api/jobs/send-dataroom-new-document-notification.ts
+++ b/pages/api/jobs/send-dataroom-new-document-notification.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
+import { sendDataroomDigestNotification } from "@/lib/emails/send-dataroom-digest-notification";
 import { sendDataroomNotification } from "@/lib/emails/send-dataroom-notification";
 import prisma from "@/lib/prisma";
 import { log } from "@/lib/utils";
@@ -13,17 +14,14 @@ export default async function handle(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  // We only allow POST requests
   if (req.method !== "POST") {
     res.status(405).json({ message: "Method Not Allowed" });
     return;
   }
 
-  // Extract the API Key from the Authorization header
   const authHeader = req.headers.authorization;
-  const token = authHeader?.split(" ")[1]; // Assuming the format is "Bearer [token]"
+  const token = authHeader?.split(" ")[1];
 
-  // Check if the API Key matches
   if (token !== process.env.INTERNAL_API_KEY) {
     res.status(401).json({ message: "Unauthorized" });
     return;
@@ -33,22 +31,32 @@ export default async function handle(
     linkUrl,
     dataroomId,
     dataroomDocumentId,
+    dataroomDocumentIds,
     viewerId,
     senderUserId,
     teamId,
   } = req.body as {
     linkUrl: string;
     dataroomId: string;
-    dataroomDocumentId: string;
+    dataroomDocumentId?: string;
+    dataroomDocumentIds?: string[];
     viewerId: string;
     senderUserId: string | null;
     teamId: string;
   };
 
+  const docIds =
+    dataroomDocumentIds ??
+    (dataroomDocumentId ? [dataroomDocumentId] : []);
+
+  if (docIds.length === 0) {
+    res.status(400).json({ message: "No document IDs provided" });
+    return;
+  }
+
   let viewer: { email: string } | null = null;
 
   try {
-    // Fetch the link to verify the settings
     viewer = await prisma.viewer.findUnique({
       where: {
         id: viewerId,
@@ -73,12 +81,10 @@ export default async function handle(
     return;
   }
 
-  // POST /api/jobs/send-datarooom-notification
   try {
-    // Fetch the document to verify the settings
-    const document = await prisma.dataroomDocument.findUnique({
+    const documents = await prisma.dataroomDocument.findMany({
       where: {
-        id: dataroomDocumentId,
+        id: { in: docIds },
         dataroomId: dataroomId,
       },
       select: {
@@ -94,6 +100,11 @@ export default async function handle(
         },
       },
     });
+
+    if (documents.length === 0) {
+      res.status(404).json({ message: "No documents found." });
+      return;
+    }
 
     let senderEmail: string | null = null;
     if (senderUserId) {
@@ -115,23 +126,40 @@ export default async function handle(
       teamId,
     });
 
-    await sendDataroomNotification({
-      dataroomName: document?.dataroom?.name || "",
-      documentName: document?.document?.name || "",
-      senderEmail,
-      to: viewer.email!,
-      url: linkUrl,
-      unsubscribeUrl,
-    });
+    const dataroomName = documents[0]?.dataroom?.name || "";
+
+    if (documents.length === 1) {
+      await sendDataroomNotification({
+        dataroomName,
+        documentName: documents[0]?.document?.name || "",
+        senderEmail,
+        to: viewer.email!,
+        url: linkUrl,
+        unsubscribeUrl,
+      });
+    } else {
+      await sendDataroomDigestNotification({
+        dataroomName,
+        documents: documents.map((doc) => ({
+          documentName: doc.document?.name || "Untitled",
+        })),
+        senderEmail,
+        to: viewer.email!,
+        url: linkUrl,
+        preferencesUrl: unsubscribeUrl,
+        frequency: "instant",
+      });
+    }
 
     res.status(200).json({
       message: "Successfully sent dataroom change notification",
       viewerId,
+      documentCount: documents.length,
     });
     return;
   } catch (error) {
     log({
-      message: `Failed to send invite email for dataroom ${dataroomId} to viewer: ${viewerId}. \n\n Error: ${error} \n\n*Metadata*: \`{dataroomId: ${dataroomId}, viewerId: ${viewerId}}\``,
+      message: `Failed to send notification for dataroom ${dataroomId} to viewer: ${viewerId}. \n\n Error: ${error} \n\n*Metadata*: \`{dataroomId: ${dataroomId}, viewerId: ${viewerId}, docCount: ${docIds.length}}\``,
       type: "error",
       mention: true,
     });

--- a/pages/api/jobs/send-dataroom-new-document-notification.ts
+++ b/pages/api/jobs/send-dataroom-new-document-notification.ts
@@ -41,7 +41,7 @@ export default async function handle(
     dataroomId: string;
     dataroomDocumentId: string;
     viewerId: string;
-    senderUserId: string;
+    senderUserId: string | null;
     teamId: string;
   };
 
@@ -95,14 +95,18 @@ export default async function handle(
       },
     });
 
-    const user = await prisma.user.findUnique({
-      where: { id: senderUserId },
-      select: { email: true },
-    });
+    let senderEmail = "noreply@papermark.com";
+    if (senderUserId) {
+      const user = await prisma.user.findUnique({
+        where: { id: senderUserId },
+        select: { email: true },
+      });
 
-    if (!user) {
-      res.status(404).json({ message: "Sender not found." });
-      return;
+      if (!user) {
+        res.status(404).json({ message: "Sender not found." });
+        return;
+      }
+      senderEmail = user.email!;
     }
 
     const unsubscribeUrl = generateUnsubscribeUrl({
@@ -114,7 +118,7 @@ export default async function handle(
     await sendDataroomNotification({
       dataroomName: document?.dataroom?.name || "",
       documentName: document?.document?.name || "",
-      senderEmail: user.email!,
+      senderEmail,
       to: viewer.email!,
       url: linkUrl,
       unsubscribeUrl,

--- a/pages/api/jobs/send-dataroom-new-document-notification.ts
+++ b/pages/api/jobs/send-dataroom-new-document-notification.ts
@@ -95,7 +95,7 @@ export default async function handle(
       },
     });
 
-    let senderEmail = "noreply@papermark.com";
+    let senderEmail: string | null = null;
     if (senderUserId) {
       const user = await prisma.user.findUnique({
         where: { id: senderUserId },

--- a/pages/api/teams/[teamId]/datarooms/[id]/documents/index.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/documents/index.ts
@@ -284,21 +284,38 @@ export default async function handle(
       // Check if the team has the dataroom change notification enabled
       if (dataroomDocument.dataroom.enableChangeNotifications) {
         // Get all delayed and queued runs for this dataroom
-        const allRuns = await runs.list({
+        const existingChangeRuns = await runs.list({
           taskIdentifier: ["send-dataroom-change-notification"],
-          tag: [`dataroom_${dataroomId}`],
+          tag: [`dataroom_${dataroomId}`, `user_upload_${userId}`],
           status: ["DELAYED", "QUEUED"],
-          period: "10m",
+          period: "15m",
         });
 
-        // Cancel any existing unsent notification runs for this dataroom
-        await Promise.all(allRuns.data.map((run) => runs.cancel(run.id)));
+        const matchingChangeRuns = existingChangeRuns.data.filter(
+          (run) =>
+            run.tags?.includes(`dataroom_${dataroomId}`) &&
+            run.tags?.includes(`user_upload_${userId}`),
+        );
+
+        let accumulatedDocIds: string[] = [dataroomDocument.id];
+        for (const run of matchingChangeRuns) {
+          const fullRun = await runs.retrieve(run.id);
+          const existingIds = (
+            fullRun.payload as { dataroomDocumentIds?: string[] } | undefined
+          )?.dataroomDocumentIds;
+          if (Array.isArray(existingIds)) {
+            accumulatedDocIds.push(...existingIds);
+          }
+        }
+        accumulatedDocIds = [...new Set(accumulatedDocIds)];
+
+        await Promise.all(matchingChangeRuns.map((run) => runs.cancel(run.id)));
 
         waitUntil(
           sendDataroomChangeNotificationTask.trigger(
             {
               dataroomId,
-              dataroomDocumentId: dataroomDocument.id,
+              dataroomDocumentIds: accumulatedDocIds,
               senderUserId: userId,
               teamId,
             },
@@ -308,6 +325,7 @@ export default async function handle(
                 `team_${teamId}`,
                 `dataroom_${dataroomId}`,
                 `document_${dataroomDocument.id}`,
+                `user_upload_${userId}`,
               ],
               delay: new Date(Date.now() + 10 * 60 * 1000), // 10 minute delay
             },

--- a/pages/api/teams/[teamId]/datarooms/[id]/index.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/index.ts
@@ -112,6 +112,7 @@ export default async function handle(
         name,
         internalName,
         enableChangeNotifications,
+        enableVisitorUploadChangeNotifications,
         defaultPermissionStrategy,
         allowBulkDownload,
         showLastUpdated,
@@ -123,6 +124,7 @@ export default async function handle(
         name?: string;
         internalName?: string | null;
         enableChangeNotifications?: boolean;
+        enableVisitorUploadChangeNotifications?: boolean;
         defaultPermissionStrategy?: DefaultPermissionStrategy;
         allowBulkDownload?: boolean;
         showLastUpdated?: boolean;
@@ -137,7 +139,8 @@ export default async function handle(
       const isTrial = team.plan.includes("drtrial");
 
       if (
-        enableChangeNotifications !== undefined &&
+        (enableChangeNotifications !== undefined ||
+          enableVisitorUploadChangeNotifications !== undefined) &&
         !isDataroomsPlus &&
         !isTrial &&
         !featureFlags.roomChangeNotifications
@@ -165,6 +168,9 @@ export default async function handle(
             }),
             ...(typeof enableChangeNotifications === "boolean" && {
               enableChangeNotifications,
+            }),
+            ...(typeof enableVisitorUploadChangeNotifications === "boolean" && {
+              enableVisitorUploadChangeNotifications,
             }),
             ...(defaultPermissionStrategy && { defaultPermissionStrategy }),
             ...(typeof allowBulkDownload === "boolean" && {

--- a/prisma/migrations/20260408000000_add_visitor_upload_change_notifications/migration.sql
+++ b/prisma/migrations/20260408000000_add_visitor_upload_change_notifications/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Dataroom" ADD COLUMN "enableVisitorUploadChangeNotifications" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema/dataroom.prisma
+++ b/prisma/schema/dataroom.prisma
@@ -35,7 +35,8 @@ model Dataroom {
   tags TagItem[]
 
   // notification settings
-  enableChangeNotifications Boolean @default(false)
+  enableChangeNotifications              Boolean @default(false)
+  enableVisitorUploadChangeNotifications Boolean @default(false)
 
   // unified permission strategy
   defaultPermissionStrategy DefaultPermissionStrategy @default(INHERIT_FROM_PARENT)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visitor Upload Notifications: owners can enable alerts when another visitor uploads to a dataroom.

* **Improvements**
  * Separate toggles for "new documents" and "visitor uploads" in notification settings.
  * Smarter queuing/debouncing to reduce duplicate or stacked notifications.
  * Support for an "instant" notification frequency and graceful handling when sender info is missing.
  * Updated email copy for clearer frequency and sender display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->