### PR TITLE
Auto-focus folder name input when Add Folder dialog opens

### DIFF
--- a/components/folders/add-folder-modal.tsx
+++ b/components/folders/add-folder-modal.tsx
@@ -195,6 +195,7 @@ export function AddFolderModal({
               id="folder-name"
               placeholder="Choose a helpful name"
               className="flex-1"
+              autoFocus
               value={folderName}
               onChange={(e) => setFolderName(e.target.value)}
             />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `autoFocus` to the folder name `Input` in the Add Folder modal so the cursor is placed in the text field as soon as the dialog opens, allowing users to start typing immediately without an extra click.

### Changes
- `components/folders/add-folder-modal.tsx`: Added `autoFocus` prop to the folder name `Input` element.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-036ab7e5-0cdd-482c-b6b1-e745960f3e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-036ab7e5-0cdd-482c-b6b1-e745960f3e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Add Folder modal now automatically focuses the input field when opened, allowing you to start typing immediately without clicking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->