### PR TITLE
fix: add size to bulk download

### DIFF
--- a/lib/trigger/bulk-download.ts
+++ b/lib/trigger/bulk-download.ts
@@ -123,11 +123,25 @@ export const bulkDownloadTask = task({
         progress: 0,
       });
 
-      // For small datarooms, process in a single batch
-      if (fileKeys.length <= MAX_FILES_PER_BATCH) {
+      // Calculate total size from folder structure for batch decisions
+      const totalPayloadSize = Object.values(folderStructure).reduce(
+        (sum, folder) =>
+          sum +
+          folder.files.reduce((fSum, file) => fSum + (file.size || 0), 0),
+        0,
+      );
+      const hasReliableSizeInfo = totalPayloadSize > 0;
+
+      // For small datarooms, process in a single batch (check both count AND size)
+      const fitsInSingleBatch =
+        fileKeys.length <= MAX_FILES_PER_BATCH &&
+        (!hasReliableSizeInfo || totalPayloadSize <= MAX_ZIP_SIZE_BYTES);
+
+      if (fitsInSingleBatch) {
         logger.info("Processing as single batch", {
           jobId,
           fileCount: fileKeys.length,
+          totalSizeMB: Math.round(totalPayloadSize / (1024 * 1024)),
         });
 
         const result = await processDownloadBatch({
@@ -188,6 +202,7 @@ export const bulkDownloadTask = task({
       logger.info("Processing as multiple batches", {
         jobId,
         fileCount: fileKeys.length,
+        totalSizeMB: Math.round(totalPayloadSize / (1024 * 1024)),
         maxFilesPerBatch: MAX_FILES_PER_BATCH,
         maxSizePerBatch: `${MAX_ZIP_SIZE_BYTES / (1024 * 1024)}MB`,
       });

--- a/pages/api/links/download/bulk.ts
+++ b/pages/api/links/download/bulk.ts
@@ -98,6 +98,7 @@ export default async function handle(
                         originalFile: true,
                         contentType: true,
                         numPages: true,
+                        fileSize: true,
                       },
                       take: 1,
                     },
@@ -286,6 +287,7 @@ export default async function handle(
           type?: string;
           numPages?: number;
           needsWatermark?: boolean;
+          size?: number; // File size in bytes
         }[];
       };
     } = {};
@@ -297,6 +299,7 @@ export default async function handle(
       fileKey: string,
       fileType?: string,
       numPages?: number,
+      fileSize?: number,
     ) => {
       const pathParts = path.split("/").filter(Boolean);
       let currentPath = "";
@@ -334,6 +337,7 @@ export default async function handle(
         type: fileType,
         numPages: numPages,
         needsWatermark: needsWatermark ?? undefined,
+        size: fileSize,
       });
       fileKeys.push(fileKey);
     };
@@ -356,6 +360,9 @@ export default async function handle(
           fileKey,
           doc.document.versions[0].type ?? undefined,
           doc.document.versions[0].numPages ?? undefined,
+          doc.document.versions[0].fileSize
+            ? Number(doc.document.versions[0].fileSize)
+            : undefined,
         );
       });
 
@@ -394,6 +401,9 @@ export default async function handle(
             fileKey,
             doc.document.versions[0].type ?? undefined,
             doc.document.versions[0].numPages ?? undefined,
+            doc.document.versions[0].fileSize
+              ? Number(doc.document.versions[0].fileSize)
+              : undefined,
           );
         });
 

--- a/pages/api/links/download/dataroom-folder.ts
+++ b/pages/api/links/download/dataroom-folder.ts
@@ -179,6 +179,7 @@ export default async function handler(
                 originalFile: true,
                 numPages: true,
                 contentType: true,
+                fileSize: true,
               },
               take: 1,
             },
@@ -247,6 +248,7 @@ export default async function handler(
           type?: string;
           numPages?: number;
           needsWatermark?: boolean;
+          size?: number;
         }[];
       };
     } = {};
@@ -260,6 +262,7 @@ export default async function handler(
       fileKey: string,
       fileType?: string,
       numPages?: number,
+      fileSize?: number,
     ) => {
       let relativePath = "";
       if (computedFolderPath !== rootFolderInfo.computedPath) {
@@ -300,6 +303,7 @@ export default async function handler(
           type: fileType,
           numPages: numPages,
           needsWatermark: needsWatermark ?? undefined,
+          size: fileSize,
         });
         fileKeys.push(fileKey);
       }
@@ -353,6 +357,7 @@ export default async function handler(
           fileKey,
           version.type ?? undefined,
           version.numPages ?? undefined,
+          version.fileSize ? Number(version.fileSize) : undefined,
         );
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk download batch selection now evaluates both file count and aggregated payload size for more robust batch determination.
  * Enhanced logging displays total payload size metrics in MB across single and multi-batch download operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->