### PR TITLE
fix(dataroom-faq): show full question text in viewer

### DIFF
--- a/ee/features/conversations/components/viewer/faq-section.tsx
+++ b/ee/features/conversations/components/viewer/faq-section.tsx
@@ -208,7 +208,7 @@ export function FAQSection({
                         <span className="flex-shrink-0 rounded bg-secondary px-1.5 py-0.5 text-xs font-medium text-secondary-foreground">
                           Q
                         </span>
-                        <div className="line-clamp-2 min-w-0 flex-1 break-words text-left text-sm font-medium text-gray-900">
+                        <div className="min-w-0 flex-1 whitespace-pre-wrap break-words text-left text-sm font-medium text-gray-900">
                           {faq.editedQuestion}
                         </div>
                       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When viewers open a dataroom with published Q&A FAQs, the answer displays in full (even for long text) but the question is clipped to 2 lines, hiding the rest.

## Fix

Removed the `line-clamp-2` on the question in the viewer FAQ accordion trigger so long questions are fully visible, matching the existing behavior of the answer. Added `whitespace-pre-wrap` so line breaks in the question are preserved, matching the answer style.

File: `ee/features/conversations/components/viewer/faq-section.tsx`

## Before / After

Before: question was truncated to 2 lines with "..."; clicking to expand only revealed the answer, not the rest of the question.
After: the full question wraps naturally inside the accordion trigger, and the answer continues to render in full on expand.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-090d048e-306a-4796-b1f9-93c5f24c9dad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-090d048e-306a-4796-b1f9-93c5f24c9dad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * FAQ questions in the conversation viewer now properly display with original formatting, including line breaks and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->