### PR TITLE
investigation: duplicated dataroom settings inputs + small Form value sync fix

### DIFF
--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -52,7 +52,7 @@ export function Form({
   const [value, setValue] = useState(defaultValue);
 
   useEffect(() => {
-    if (defaultValue) setValue(defaultValue);
+    if (typeof defaultValue === "string") setValue(defaultValue);
   }, [defaultValue]);
 
   const saveDisabled = useMemo(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

User report:

> I duplicated a data room and in the settings it doesn't allow me to change the name, both external or internal. I cannot click the box to begin changing text.

## TL;DR

I could **not** reproduce the "cannot click the input" symptom in automated testing. Across desktop viewports (Chromium 1400x900) and mobile viewports (iPhone SE / iPhone 13 Pro / iPad Pro), the `Dataroom Name` and `Internal Name` inputs on the settings page of a duplicated dataroom are fully interactive — focusable, typeable, and saveable. The real bug, whatever it is on the user's side, is most likely client-side state (a stale bundle, a browser extension, or a lingering Radix overlay from an earlier dialog) rather than something structural in the current code.

While walking the flow I did find one genuine latent bug in `components/ui/form.tsx` that could produce confusing behavior on the exact page the user is describing — this PR patches that.

## The bug I fixed

`components/ui/form.tsx` keeps its internal `value` state in sync with the `defaultValue` prop via:

```tsx
useEffect(() => {
  if (defaultValue) setValue(defaultValue);
}, [defaultValue]);
```

The `if (defaultValue)` guard is a truthiness check, so a new `defaultValue` of `""` is silently ignored. The Form is used twice on the dataroom settings page:

- `Dataroom Name` — `defaultValue={dataroom.name}` (always a non-empty string)
- `Internal Name` — `defaultValue={dataroom.internalName ?? ""}` (empty string when the dataroom has no internal name, which is the case for every duplicated dataroom because `duplicate.ts` does not copy `internalName`)

When navigating from a dataroom that has an `internalName` set to one without (e.g. original → duplicate), if React happens to reuse the same Form instance (same route pattern `/datarooms/[id]/settings`), the Internal Name input keeps displaying the previous dataroom's internalName instead of clearing to `""`. Save is then enabled against stale state and typing on top of it edits the wrong value.

Switching the guard to `typeof defaultValue === "string"` lets `""` propagate:

```tsx
useEffect(() => {
  if (typeof defaultValue === "string") setValue(defaultValue);
}, [defaultValue]);
```

In practice the page-level `if (!dataroom) return <div>Loading...</div>` usually causes a remount across dataroom navigations, which hides the bug — but the fix is still correct and harmless.

## What I investigated and why I'm not more invasive

- **Duplicate API** — `pages/api/teams/[teamId]/datarooms/[id]/duplicate.ts` creates the new dataroom with `name: "<original> (Copy)"`, `internalName: null`, default flags, and a cloned brand. The GET endpoint returns the expected shape with `tags: []`, `frozenByUser: null`, `_count: {...}`.
- **`useDataroom`** — SWR keyed by `/api/teams/:teamId/datarooms/:id`. No stale key carryover between rooms.
- **Settings page** (`pages/datarooms/[id]/settings/index.tsx`) — no frozen/disabled gating on the inputs, no `disabledTooltip` passed into `Form`, no overlays conditional on duplicate.
- **Form component** — `disabled={!!disabledTooltip}` (always false here), `readOnly` only on the Dataroom ID field, `pointer-events: auto` on the input and on every ancestor.
- **Layout** — `AppLayout`, `MobileHeader`, `MobileBottomNav`, `BlockingModal`, `DataroomSidebarContent` all behave identically for original vs. duplicated rooms. No fixed overlay covers the Settings main content.
- **Duplicate-specific flow** — after `router.push(/datarooms/<newId>/documents)` the SWR cache is keyed by the new id and the page mounts cleanly.
- **Automated repro** — Playwright + a fresh NextAuth session, on 1400×900 desktop and iPhone SE / 13 Pro / iPad Pro. In every run:
  - `input[name="name"]` and `input[name="internalName"]` are `disabled=false`, `readOnly=false`, `pointer-events: auto`
  - `document.elementFromPoint` at the input center returns the `INPUT` itself (nothing covering it)
  - clicking, filling, and saving work; values persist after reload

Given that, I don't think there's a reproducible code path where the user literally can't click the inputs. The most likely causes on their side are:

1. A cached/stale build from before `feat: remove dataroom navigation and add header` (9281f8b4) — the help article still tells users to use the old top tabs; a stale bundle + new backend could produce odd overlays.
2. A leftover Radix dialog/sheet overlay that wasn't dismissed (e.g. the Share/Upgrade modal) — those are fixed, full-screen, pointer-events-auto.
3. A browser extension (password manager, uBlock, Grammarly) trapping focus on the input.

I'd recommend replying to the user with:

- "Force-refresh the page (Cmd/Ctrl+Shift+R) on the duplicated dataroom's settings, then try again."
- "If that doesn't work, please share a screenshot of the settings page and open DevTools → Console so we can see any errors."

## Walkthrough

Duplicated dataroom settings page after the fix — both inputs accept clicks, focus, typing, and the Save button enables:

[Duplicated dataroom settings with both inputs edited](https://cursor.com/agents/bc-d39b19c2-614d-4717-beda-13b1c93dc450/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverified_dup_settings_working.png)

Original dataroom settings for reference:

[Original dataroom settings](https://cursor.com/agents/bc-d39b19c2-614d-4717-beda-13b1c93dc450/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_original_settings.png)

Duplicated dataroom settings on a fresh load:

[Duplicated dataroom settings fresh load](https://cursor.com/agents/bc-d39b19c2-614d-4717-beda-13b1c93dc450/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_duplicated_settings.png)

Same page on small mobile viewport (iPhone SE) — still interactive:

[Duplicated dataroom settings on iPhone SE viewport](https://cursor.com/agents/bc-d39b19c2-614d-4717-beda-13b1c93dc450/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdevice_iPhone_SE_dup_settings.png)

## Testing

- ✅ `npx next lint --file components/ui/form.tsx`
- ✅ `npx tsc --noEmit`
- ✅ End-to-end Playwright against a local dev server: duplicate a dataroom via the API, load the new settings page, click + type in `name` and `internalName`, hit Save, reload, and confirm the values persisted.
- ✅ Same end-to-end flow on iPhone SE / iPhone 13 Pro / iPad Pro emulated viewports.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d39b19c2-614d-4717-beda-13b1c93dc450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d39b19c2-614d-4717-beda-13b1c93dc450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form initialization to correctly handle default values of all types, preventing issues when non-string or empty default values are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->