### PR TITLE
fix: slack integration

### DIFF
--- a/lib/integrations/slack/uninstall.ts
+++ b/lib/integrations/slack/uninstall.ts
@@ -27,7 +27,18 @@ export const uninstallSlackIntegration = async ({
 }: {
   installation: InstalledIntegration;
 }): Promise<SlackUninstallResult> => {
-  const env = getSlackEnv();
+  let env: ReturnType<typeof getSlackEnv>;
+  try {
+    env = getSlackEnv();
+  } catch (e) {
+    console.error("[Slack App] Failed to load Slack env for uninstall:", e);
+    return {
+      ok: false,
+      error: "config_error",
+      recoverable: false,
+    };
+  }
+
   const credentials = installation.credentials as SlackCredential;
 
   let decryptedToken: string;

--- a/lib/integrations/slack/uninstall.ts
+++ b/lib/integrations/slack/uninstall.ts
@@ -4,32 +4,86 @@ import { getSlackEnv } from "./env";
 import { SlackCredential } from "./types";
 import { decryptSlackToken } from "./utils";
 
+// Slack error codes that mean the remote app is already effectively uninstalled
+// or the stored credentials are unusable. We treat these as "nothing left to do
+// remotely" so the local disconnect can still succeed.
+const ALREADY_UNINSTALLED_ERRORS = new Set([
+  "invalid_auth",
+  "not_authed",
+  "token_revoked",
+  "token_expired",
+  "account_inactive",
+  "invalid_client_id",
+  "bad_client_secret",
+  "invalid_grant",
+]);
+
+export type SlackUninstallResult =
+  | { ok: true }
+  | { ok: false; error: string; recoverable: boolean };
+
 export const uninstallSlackIntegration = async ({
   installation,
 }: {
   installation: InstalledIntegration;
-}) => {
+}): Promise<SlackUninstallResult> => {
   const env = getSlackEnv();
   const credentials = installation.credentials as SlackCredential;
 
+  let decryptedToken: string;
+  try {
+    decryptedToken = decryptSlackToken(credentials.accessToken);
+  } catch (e) {
+    console.error("[Slack App] Failed to decrypt access token:", e);
+    return {
+      ok: false,
+      error: "decrypt_failed",
+      recoverable: true,
+    };
+  }
+
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10_000);
-  const response = await fetch("https://slack.com/api/apps.uninstall", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      token: decryptSlackToken(credentials.accessToken),
-      client_id: env.SLACK_CLIENT_ID,
-      client_secret: env.SLACK_CLIENT_SECRET,
-    }),
-    signal: controller.signal,
-  });
+  let response: Response;
+  try {
+    response = await fetch("https://slack.com/api/apps.uninstall", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        token: decryptedToken,
+        client_id: env.SLACK_CLIENT_ID,
+        client_secret: env.SLACK_CLIENT_SECRET,
+      }),
+      signal: controller.signal,
+    });
+  } catch (e) {
+    clearTimeout(timeout);
+    console.error("[Slack App] Network error during apps.uninstall:", e);
+    return { ok: false, error: "network_error", recoverable: false };
+  }
   clearTimeout(timeout);
 
-  const data = await response.json();
-
-  if (!response.ok || !data.ok) {
-    console.error("[Slack App]", data);
-    throw new Error("Failed to remove the app from the Slack workspace.");
+  let data: { ok?: boolean; error?: string } = {};
+  try {
+    data = await response.json();
+  } catch {
+    // Ignore body parse errors; we'll treat this like an unknown failure below
   }
+
+  if (response.ok && data.ok) {
+    return { ok: true };
+  }
+
+  console.error("[Slack App] apps.uninstall failed:", {
+    status: response.status,
+    data,
+  });
+
+  const slackError = data.error || `http_${response.status}`;
+
+  if (ALREADY_UNINSTALLED_ERRORS.has(slackError)) {
+    return { ok: false, error: slackError, recoverable: true };
+  }
+
+  return { ok: false, error: slackError, recoverable: false };
 };

--- a/pages/api/teams/[teamId]/integrations/slack/index.ts
+++ b/pages/api/teams/[teamId]/integrations/slack/index.ts
@@ -202,10 +202,22 @@ async function handleDelete(
       return res.status(404).json({ error: "Slack integration not found" });
     }
 
-    // Uninstall the Slack integration from the Slack workspace
-    await uninstallSlackIntegration({ installation: integration });
+    // Best-effort remote uninstall. If the stored token is already invalid /
+    // revoked (e.g. after rotating SLACK_CLIENT_SECRET or reinstalling the app
+    // in Slack), we still want the user to be able to disconnect locally so
+    // they can reconnect with fresh credentials.
+    const uninstallResult = await uninstallSlackIntegration({
+      installation: integration,
+    });
 
-    // Delete the Slack integration from the database
+    if (!uninstallResult.ok && !uninstallResult.recoverable) {
+      return res.status(502).json({
+        error:
+          "Failed to uninstall Slack app from the workspace. Please try again.",
+        slackError: uninstallResult.error,
+      });
+    }
+
     await prisma.installedIntegration.delete({
       where: {
         teamId_integrationId: {
@@ -214,6 +226,14 @@ async function handleDelete(
         },
       },
     });
+
+    if (!uninstallResult.ok) {
+      return res.status(200).json({
+        message:
+          "Slack integration disconnected locally. The remote app token was already invalid, so no remote uninstall was performed.",
+        slackError: uninstallResult.error,
+      });
+    }
 
     return res
       .status(200)

--- a/pages/api/teams/[teamId]/integrations/slack/index.ts
+++ b/pages/api/teams/[teamId]/integrations/slack/index.ts
@@ -230,7 +230,7 @@ async function handleDelete(
     if (!uninstallResult.ok) {
       return res.status(200).json({
         message:
-          "Slack integration disconnected locally. The remote app token was already invalid, so no remote uninstall was performed.",
+          "Slack integration disconnected locally; remote uninstall was not performed.",
         slackError: uninstallResult.error,
       });
     }

--- a/pages/api/teams/[teamId]/integrations/slack/index.ts
+++ b/pages/api/teams/[teamId]/integrations/slack/index.ts
@@ -230,9 +230,10 @@ async function handleDelete(
     if (!uninstallResult.ok) {
       return res.status(200).json({
         message:
-          "Slack integration disconnected locally. The remote app token was already invalid, so no remote uninstall was performed.",
+          "Slack integration disconnected locally. Remote uninstall could not be completed, but no further remote action is required.",
         slackError: uninstallResult.error,
       });
+    }
     }
 
     return res


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable Slack disconnect: uninstall now handles remote failures gracefully and reports if remote removal wasn't completed.
  * Users receive clearer feedback when disconnect succeeds locally but remote uninstall encounters recoverable issues.
* **Bug Fixes**
  * Prevents hard failures during Slack uninstall by classifying errors and returning consistent responses.
  * Better resilience to network or decryption problems so uninstall remains best-effort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->