### PR TITLE
feat: show uploadFolderIds name directly

### DIFF
--- a/app/(ee)/api/links/[id]/upload/route.ts
+++ b/app/(ee)/api/links/[id]/upload/route.ts
@@ -152,7 +152,6 @@ export async function POST(
         name: true,
         enableUpload: true,
         enableNotification: true,
-        uploadFolderId: true,
         uploadFolderIds: true,
         dataroomId: true,
         teamId: true,
@@ -249,19 +248,11 @@ export async function POST(
     //     inside that allow-list. If it isn't (e.g. the visitor is currently
     //     browsing another folder), fall back to the first allowed folder so
     //     uploads never silently escape the allow-list.
-    //
-    // `uploadFolderIds` is the new source of truth, but until the legacy
-    // `uploadFolderId` column has been backfilled into it we fall back to
-    // `[uploadFolderId]` for rows where the array is still empty. The
-    // fallback becomes inert post-backfill.
-    const allowedUploadFolderIds: string[] =
-      Array.isArray(link.uploadFolderIds) && link.uploadFolderIds.length > 0
-        ? link.uploadFolderIds.filter(
-            (id): id is string => typeof id === "string" && !!id,
-          )
-        : link.uploadFolderId
-          ? [link.uploadFolderId]
-          : [];
+    const allowedUploadFolderIds = Array.isArray(link.uploadFolderIds)
+      ? link.uploadFolderIds.filter(
+          (id): id is string => typeof id === "string" && !!id,
+        )
+      : [];
 
     let dataroomFolderId: string | null = null;
 
@@ -290,8 +281,8 @@ export async function POST(
       if (folderId && allowedSet.has(folderId)) {
         dataroomFolderId = folderId;
       } else {
-        // Preserve admin-selected ordering so the "primary" allowed folder
-        // (historically `uploadFolderId`) wins when multiple are allowed.
+        // Preserve admin-selected ordering so the first allowed folder wins
+        // when the visitor isn't currently inside one of the allowed folders.
         dataroomFolderId =
           allowedUploadFolderIds.find((id) => allowedSet.has(id)) ?? null;
       }

--- a/app/api/views-dataroom/route.ts
+++ b/app/api/views-dataroom/route.ts
@@ -145,7 +145,6 @@ export async function POST(request: NextRequest) {
           },
         },
         enableUpload: true,
-        uploadFolderId: true,
         uploadFolderIds: true,
         dataroom: {
           select: {
@@ -754,19 +753,11 @@ export async function POST(request: NextRequest) {
           | { id: string; name: string; path: string }[]
           | null = null;
         if (link.enableUpload) {
-          // `uploadFolderIds` is the new source of truth, but until the
-          // legacy `uploadFolderId` column has been backfilled into it we
-          // fall back to `[uploadFolderId]` for rows where the array is
-          // still empty. The fallback becomes inert post-backfill.
-          const allowedIds: string[] =
-            Array.isArray(link.uploadFolderIds) &&
-            link.uploadFolderIds.length > 0
-              ? link.uploadFolderIds.filter(
-                  (id): id is string => typeof id === "string" && !!id,
-                )
-              : link.uploadFolderId
-                ? [link.uploadFolderId]
-                : [];
+          const allowedIds = Array.isArray(link.uploadFolderIds)
+            ? link.uploadFolderIds.filter(
+                (id): id is string => typeof id === "string" && !!id,
+              )
+            : [];
           if (allowedIds.length > 0) {
             const folders = await prisma.dataroomFolder.findMany({
               where: {

--- a/components/links/link-sheet/index.tsx
+++ b/components/links/link-sheet/index.tsx
@@ -91,8 +91,6 @@ export const DEFAULT_LINK_PROPS = (
   enableAIAgents: false,
   enableUpload: false,
   isFileRequestOnly: false,
-  uploadFolderId: null,
-  uploadFolderName: "Home",
   uploadFolderIds: [],
   uploadFolders: [],
   enableIndexFile: false,
@@ -138,8 +136,6 @@ export type DEFAULT_LINK_TYPE = {
   enableAIAgents: boolean;
   enableUpload: boolean;
   isFileRequestOnly: boolean;
-  uploadFolderId: string | null;
-  uploadFolderName: string;
   uploadFolderIds: string[];
   uploadFolders: { id: string; name: string; path?: string | null }[];
   enableIndexFile: boolean;
@@ -480,7 +476,6 @@ export default function LinkSheet({
         "enableAIAgents",
         "enableUpload",
         "isFileRequestOnly",
-        "uploadFolderId",
         "uploadFolderIds",
         "enableIndexFile",
         "permissionGroupId",

--- a/components/links/link-sheet/upload-section/index.tsx
+++ b/components/links/link-sheet/upload-section/index.tsx
@@ -288,13 +288,7 @@ export default function UploadSection({
   }: LinkUpgradeOptions) => void;
   targetId: string;
 }) {
-  const {
-    enableUpload,
-    uploadFolderId,
-    uploadFolderName,
-    uploadFolderIds,
-    uploadFolders,
-  } = data;
+  const { enableUpload, uploadFolderIds, uploadFolders } = data;
   const [enabled, setEnabled] = useState<boolean>(false);
   // Legacy single-folder selection kept for document links / all-documents.
   const [legacyFolder, setLegacyFolder] = useState<TSelectedFolder | null>(
@@ -308,12 +302,16 @@ export default function UploadSection({
     setEnabled(enableUpload!);
   }, [enableUpload]);
 
-  // Hydrate the legacy single-folder selection for the all-documents picker.
+  // Hydrate the legacy single-folder selection for the all-documents picker
+  // from the (single-entry) allow-list.
   useEffect(() => {
-    if (uploadFolderId) {
-      setLegacyFolder({ id: uploadFolderId, name: uploadFolderName });
+    const first = uploadFolders?.[0];
+    if (first) {
+      setLegacyFolder({ id: first.id, name: first.name });
+    } else {
+      setLegacyFolder(null);
     }
-  }, [uploadFolderId, uploadFolderName]);
+  }, [uploadFolders]);
 
   // Normalise the allow-list of folders shown as chips for dataroom links.
   const selectedFolders = useMemo<UploadFolderSummary[]>(() => {
@@ -324,27 +322,13 @@ export default function UploadSection({
         path: f.path ?? null,
       }));
     }
-    // Server didn't enrich folder metadata; synthesise names from the id list
-    // using the legacy fields so the chip still has a meaningful label.
+    // Server didn't enrich folder metadata (rare race condition for stale
+    // cache entries); show ids so the chip is still removable.
     if (Array.isArray(uploadFolderIds) && uploadFolderIds.length > 0) {
-      return uploadFolderIds.map((id) => ({
-        id,
-        name:
-          id === uploadFolderId && uploadFolderName
-            ? uploadFolderName
-            : "Folder",
-      }));
-    }
-    if (uploadFolderId) {
-      return [
-        {
-          id: uploadFolderId,
-          name: uploadFolderName || "Folder",
-        },
-      ];
+      return uploadFolderIds.map((id) => ({ id, name: "Folder" }));
     }
     return [];
-  }, [uploadFolders, uploadFolderIds, uploadFolderId, uploadFolderName]);
+  }, [uploadFolders, uploadFolderIds]);
 
   const handleUpload = async () => {
     const updatedUpload = !enabled;
@@ -361,8 +345,6 @@ export default function UploadSection({
     setLegacyFolder(selectedFolder);
     setData({
       ...data,
-      uploadFolderId: selectedFolder?.id ?? null,
-      uploadFolderName: selectedFolder?.name || "Home",
       uploadFolderIds: selectedFolder?.id ? [selectedFolder.id] : [],
       uploadFolders: selectedFolder?.id
         ? [{ id: selectedFolder.id, name: selectedFolder.name }]
@@ -375,9 +357,6 @@ export default function UploadSection({
       ...data,
       uploadFolderIds: folders.map((f) => f.id),
       uploadFolders: folders,
-      // Keep the legacy columns in sync so existing consumers keep working.
-      uploadFolderId: folders[0]?.id ?? null,
-      uploadFolderName: folders[0]?.name ?? "Home",
     });
   };
 

--- a/components/links/links-table.tsx
+++ b/components/links/links-table.tsx
@@ -427,33 +427,16 @@ export default function LinksTable({
       enableConversation: link.enableConversation ?? false,
       enableUpload: link.enableUpload ?? false,
       isFileRequestOnly: link.isFileRequestOnly ?? false,
-      uploadFolderId: link.uploadFolderId ?? null,
-      uploadFolderName: link.uploadFolderName ?? "Home",
-      uploadFolderIds: (() => {
-        const ids = Array.isArray((link as any).uploadFolderIds)
-          ? ((link as any).uploadFolderIds as string[])
-          : [];
-        if (ids.length > 0) return ids;
-        return link.uploadFolderId ? [link.uploadFolderId] : [];
-      })(),
-      uploadFolders: (() => {
-        const folders = Array.isArray((link as any).uploadFolders)
-          ? ((link as any).uploadFolders as {
-              id: string;
-              name: string;
-              path?: string | null;
-            }[])
-          : [];
-        if (folders.length > 0) return folders;
-        return link.uploadFolderId
-          ? [
-              {
-                id: link.uploadFolderId,
-                name: link.uploadFolderName ?? "Folder",
-              },
-            ]
-          : [];
-      })(),
+      uploadFolderIds: Array.isArray((link as any).uploadFolderIds)
+        ? ((link as any).uploadFolderIds as string[])
+        : [],
+      uploadFolders: Array.isArray((link as any).uploadFolders)
+        ? ((link as any).uploadFolders as {
+            id: string;
+            name: string;
+            path?: string | null;
+          }[])
+        : [],
       enableIndexFile: link.enableIndexFile ?? false,
       permissionGroupId: link.permissionGroupId ?? null,
       welcomeMessage: link.welcomeMessage ?? null,

--- a/components/links/links-table.tsx
+++ b/components/links/links-table.tsx
@@ -427,16 +427,10 @@ export default function LinksTable({
       enableConversation: link.enableConversation ?? false,
       enableUpload: link.enableUpload ?? false,
       isFileRequestOnly: link.isFileRequestOnly ?? false,
-      uploadFolderIds: Array.isArray((link as any).uploadFolderIds)
-        ? ((link as any).uploadFolderIds as string[])
+      uploadFolderIds: Array.isArray(link.uploadFolderIds)
+        ? link.uploadFolderIds
         : [],
-      uploadFolders: Array.isArray((link as any).uploadFolders)
-        ? ((link as any).uploadFolders as {
-            id: string;
-            name: string;
-            path?: string | null;
-          }[])
-        : [],
+      uploadFolders: Array.isArray(link.uploadFolders) ? link.uploadFolders : [],
       enableIndexFile: link.enableIndexFile ?? false,
       permissionGroupId: link.permissionGroupId ?? null,
       welcomeMessage: link.welcomeMessage ?? null,

--- a/ee/features/permissions/components/dataroom-link-sheet.tsx
+++ b/ee/features/permissions/components/dataroom-link-sheet.tsx
@@ -636,7 +636,6 @@ export function DataroomLinkSheet({
         "enableAIAgents",
         "enableUpload",
         "isFileRequestOnly",
-        "uploadFolderId",
         "uploadFolderIds",
         "enableIndexFile",
         "permissionGroupId",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -66,7 +66,6 @@ export interface LinkWithViews extends Link {
   feedback: { id: true; data: { question: string; type: string } } | null;
   customFields: CustomField[];
   tags: TagProps[];
-  uploadFolderName: string | undefined;
   uploadFolders?: { id: string; name: string; path: string | null }[];
   visitorGroups?: { visitorGroupId: string }[];
 }

--- a/pages/api/links/[id]/index.ts
+++ b/pages/api/links/[id]/index.ts
@@ -22,32 +22,13 @@ import { authOptions } from "../../auth/[...nextauth]";
 /** See pages/api/links/index.ts — same semantics. */
 function normalizeUploadFolderIds(linkData: {
   uploadFolderIds?: unknown;
-  uploadFolderId?: unknown;
 }): string[] {
-  if (Array.isArray(linkData.uploadFolderIds)) {
-    const ids: string[] = [];
-    for (const id of linkData.uploadFolderIds) {
-      if (typeof id === "string" && id.length > 0) ids.push(id);
-    }
-    if (ids.length > 0) {
-      return Array.from(new Set(ids));
-    }
+  if (!Array.isArray(linkData.uploadFolderIds)) return [];
+  const ids: string[] = [];
+  for (const id of linkData.uploadFolderIds) {
+    if (typeof id === "string" && id.length > 0) ids.push(id);
   }
-  if (
-    typeof linkData.uploadFolderId === "string" &&
-    linkData.uploadFolderId.length > 0
-  ) {
-    return Array.from(new Set([linkData.uploadFolderId]));
-  }
-  return [];
-}
-
-function primaryUploadFolderId(linkData: {
-  uploadFolderIds?: unknown;
-  uploadFolderId?: unknown;
-}): string | null {
-  const ids = normalizeUploadFolderIds(linkData);
-  return ids[0] ?? null;
+  return Array.from(new Set(ids));
 }
 
 export default async function handle(
@@ -412,10 +393,10 @@ export default async function handle(
     // check, a tampered payload could persist arbitrary folder cuids (including
     // ones from other datarooms/teams) into the link.
     let validatedUploadFolderIds: string[] = [];
-    let validatedPrimaryUploadFolderId: string | null = null;
+    let validatedUploadFolders: { id: string; name: string; path: string }[] =
+      [];
     if (linkData.enableUpload) {
       const normalizedIds = normalizeUploadFolderIds(linkData);
-      const primaryId = primaryUploadFolderId(linkData);
 
       if (normalizedIds.length > 0) {
         if (!dataroomLink || !targetId) {
@@ -429,22 +410,21 @@ export default async function handle(
             id: { in: normalizedIds },
             dataroomId: targetId,
           },
-          select: { id: true },
+          select: { id: true, name: true, path: true },
         });
-        const validIdSet = new Set(validFolders.map((f) => f.id));
+        const byId = new Map(validFolders.map((f) => [f.id, f]));
 
-        if (validIdSet.size !== normalizedIds.length) {
+        if (byId.size !== normalizedIds.length) {
           return res.status(400).json({
             error:
               "One or more upload folders do not belong to this data room.",
           });
         }
 
-        validatedUploadFolderIds = normalizedIds.filter((id) =>
-          validIdSet.has(id),
-        );
-        validatedPrimaryUploadFolderId =
-          primaryId && validIdSet.has(primaryId) ? primaryId : null;
+        validatedUploadFolderIds = normalizedIds.filter((id) => byId.has(id));
+        validatedUploadFolders = validatedUploadFolderIds
+          .map((id) => byId.get(id))
+          .filter((f): f is { id: string; name: string; path: string } => !!f);
       }
     }
 
@@ -531,9 +511,6 @@ export default async function handle(
           uploadFolderIds: linkData.enableUpload
             ? validatedUploadFolderIds
             : [],
-          uploadFolderId: linkData.enableUpload
-            ? validatedPrimaryUploadFolderId
-            : null,
         },
         include: {
           customFields: true,
@@ -647,7 +624,14 @@ export default async function handle(
       updatedLink.password = decryptEncrpytedPassword(updatedLink.password);
     }
 
-    return res.status(200).json(updatedLink);
+    // Echo the resolved folder allow-list so the client can render chips with
+    // the correct folder names without an extra round-trip.
+    const responseLink = {
+      ...updatedLink,
+      uploadFolders: validatedUploadFolders,
+    };
+
+    return res.status(200).json(responseLink);
   } else if (req.method == "DELETE") {
     // DELETE /api/links/:id
     const session = await getServerSession(req, res, authOptions);

--- a/pages/api/links/[id]/index.ts
+++ b/pages/api/links/[id]/index.ts
@@ -23,7 +23,15 @@ import { authOptions } from "../../auth/[...nextauth]";
 function normalizeUploadFolderIds(linkData: {
   uploadFolderIds?: unknown;
 }): string[] {
-  if (!Array.isArray(linkData.uploadFolderIds)) return [];
+  if (
+    !Object.prototype.hasOwnProperty.call(linkData, "uploadFolderIds") ||
+    linkData.uploadFolderIds === undefined
+  ) {
+    return [];
+  }
+  if (!Array.isArray(linkData.uploadFolderIds)) {
+    throw new TypeError("uploadFolderIds must be an array.");
+  }
   const ids: string[] = [];
   for (const id of linkData.uploadFolderIds) {
     if (typeof id === "string" && id.length > 0) ids.push(id);
@@ -396,7 +404,15 @@ export default async function handle(
     let validatedUploadFolders: { id: string; name: string; path: string }[] =
       [];
     if (linkData.enableUpload) {
-      const normalizedIds = normalizeUploadFolderIds(linkData);
+      let normalizedIds: string[];
+      try {
+        normalizedIds = normalizeUploadFolderIds(linkData);
+      } catch (err) {
+        if (err instanceof TypeError) {
+          return res.status(400).json({ error: err.message });
+        }
+        throw err;
+      }
 
       if (normalizedIds.length > 0) {
         if (!dataroomLink || !targetId) {

--- a/pages/api/links/index.ts
+++ b/pages/api/links/index.ts
@@ -27,40 +27,19 @@ export interface DomainObject {
 }
 
 /**
- * Normalize the list of allowed upload folder ids from the incoming payload.
- * Accepts the new `uploadFolderIds` array as well as the legacy single
- * `uploadFolderId` field, and deduplicates the result while dropping falsy
- * entries. An empty array represents "visitor may upload anywhere".
+ * Normalize the list of allowed upload folder ids from the incoming payload,
+ * deduplicating and dropping falsy entries. An empty array represents
+ * "visitor may upload anywhere".
  */
 function normalizeUploadFolderIds(linkData: {
   uploadFolderIds?: unknown;
-  uploadFolderId?: unknown;
 }): string[] {
+  if (!Array.isArray(linkData.uploadFolderIds)) return [];
   const ids: string[] = [];
-  if (Array.isArray(linkData.uploadFolderIds)) {
-    for (const id of linkData.uploadFolderIds) {
-      if (typeof id === "string" && id.length > 0) ids.push(id);
-    }
-  }
-  if (
-    typeof linkData.uploadFolderId === "string" &&
-    linkData.uploadFolderId.length > 0
-  ) {
-    ids.push(linkData.uploadFolderId);
+  for (const id of linkData.uploadFolderIds) {
+    if (typeof id === "string" && id.length > 0) ids.push(id);
   }
   return Array.from(new Set(ids));
-}
-
-/**
- * Legacy single-folder column mirrors the first entry of the allow-list so
- * callers still reading the old column keep working.
- */
-function primaryUploadFolderId(linkData: {
-  uploadFolderIds?: unknown;
-  uploadFolderId?: unknown;
-}): string | null {
-  const ids = normalizeUploadFolderIds(linkData);
-  return ids[0] ?? null;
 }
 
 export default async function handler(
@@ -233,10 +212,10 @@ export default async function handler(
       // check, a tampered payload could persist arbitrary folder cuids
       // (including ones from other datarooms/teams) into the link.
       let validatedUploadFolderIds: string[] = [];
-      let validatedPrimaryUploadFolderId: string | null = null;
+      let validatedUploadFolders: { id: string; name: string; path: string }[] =
+        [];
       if (linkData.enableUpload) {
         const normalizedIds = normalizeUploadFolderIds(linkData);
-        const primaryId = primaryUploadFolderId(linkData);
 
         if (normalizedIds.length > 0) {
           if (!dataroomLink || !targetId) {
@@ -250,22 +229,23 @@ export default async function handler(
               id: { in: normalizedIds },
               dataroomId: targetId,
             },
-            select: { id: true },
+            select: { id: true, name: true, path: true },
           });
-          const validIdSet = new Set(validFolders.map((f) => f.id));
+          const byId = new Map(validFolders.map((f) => [f.id, f]));
 
-          if (validIdSet.size !== normalizedIds.length) {
+          if (byId.size !== normalizedIds.length) {
             return res.status(400).json({
               error:
                 "One or more upload folders do not belong to this data room.",
             });
           }
 
-          validatedUploadFolderIds = normalizedIds.filter((id) =>
-            validIdSet.has(id),
-          );
-          validatedPrimaryUploadFolderId =
-            primaryId && validIdSet.has(primaryId) ? primaryId : null;
+          validatedUploadFolderIds = normalizedIds.filter((id) => byId.has(id));
+          validatedUploadFolders = validatedUploadFolderIds
+            .map((id) => byId.get(id))
+            .filter(
+              (f): f is { id: string; name: string; path: string } => !!f,
+            );
         }
       }
 
@@ -330,7 +310,6 @@ export default async function handler(
               enableUpload: linkData.enableUpload,
               isFileRequestOnly: linkData.isFileRequestOnly,
               uploadFolderIds: validatedUploadFolderIds,
-              uploadFolderId: validatedPrimaryUploadFolderId,
             }),
             enableAIAgents: linkData.enableAIAgents || false,
             enableConversation: linkData.enableConversation || false,
@@ -407,6 +386,9 @@ export default async function handler(
 
       const linkWithView = {
         ...updatedLink,
+        // Echo the resolved folder allow-list so the client can render chips
+        // with the correct folder names without an extra round-trip.
+        uploadFolders: validatedUploadFolders,
         _count: { views: 0 },
         views: [],
       };

--- a/pages/api/links/index.ts
+++ b/pages/api/links/index.ts
@@ -29,12 +29,22 @@ export interface DomainObject {
 /**
  * Normalize the list of allowed upload folder ids from the incoming payload,
  * deduplicating and dropping falsy entries. An empty array represents
- * "visitor may upload anywhere".
+ * "visitor may upload anywhere". An omitted/undefined property is treated as
+ * an empty array; any other non-array shape is rejected so the caller can
+ * surface a 400 instead of silently dropping malformed input.
  */
 function normalizeUploadFolderIds(linkData: {
   uploadFolderIds?: unknown;
 }): string[] {
-  if (!Array.isArray(linkData.uploadFolderIds)) return [];
+  if (
+    !Object.prototype.hasOwnProperty.call(linkData, "uploadFolderIds") ||
+    linkData.uploadFolderIds === undefined
+  ) {
+    return [];
+  }
+  if (!Array.isArray(linkData.uploadFolderIds)) {
+    throw new TypeError("uploadFolderIds must be an array.");
+  }
   const ids: string[] = [];
   for (const id of linkData.uploadFolderIds) {
     if (typeof id === "string" && id.length > 0) ids.push(id);
@@ -215,7 +225,15 @@ export default async function handler(
       let validatedUploadFolders: { id: string; name: string; path: string }[] =
         [];
       if (linkData.enableUpload) {
-        const normalizedIds = normalizeUploadFolderIds(linkData);
+        let normalizedIds: string[];
+        try {
+          normalizedIds = normalizeUploadFolderIds(linkData);
+        } catch (err) {
+          if (err instanceof TypeError) {
+            return res.status(400).json({ error: err.message });
+          }
+          throw err;
+        }
 
         if (normalizedIds.length > 0) {
           if (!dataroomLink || !targetId) {

--- a/pages/api/teams/[teamId]/datarooms/[id]/groups/[groupId]/links.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/groups/[groupId]/links.ts
@@ -87,21 +87,13 @@ export default async function handle(
             if (link.password !== null) {
               link.password = decryptEncrpytedPassword(link.password);
             }
-            // Get the upload folder name(s) if any folder is restricted.
-            // `uploadFolderIds` is the new source of truth, but until the
-            // legacy `uploadFolderId` column has been backfilled into it we
-            // fall back to `[uploadFolderId]` for rows where the array is
-            // still empty. The fallback becomes inert post-backfill.
+            // Resolve the upload-folder allow-list when restricted.
             if (link.enableUpload) {
-              const allowedIds: string[] =
-                Array.isArray(link.uploadFolderIds) &&
-                link.uploadFolderIds.length > 0
-                  ? link.uploadFolderIds.filter(
-                      (id): id is string => typeof id === "string" && !!id,
-                    )
-                  : link.uploadFolderId
-                    ? [link.uploadFolderId]
-                    : [];
+              const allowedIds = Array.isArray(link.uploadFolderIds)
+                ? link.uploadFolderIds.filter(
+                    (id): id is string => typeof id === "string" && !!id,
+                  )
+                : [];
 
               if (allowedIds.length > 0) {
                 const folders = await prisma.dataroomFolder.findMany({
@@ -112,11 +104,9 @@ export default async function handle(
                   select: { id: true, name: true, path: true },
                 });
                 const byId = new Map(folders.map((f) => [f.id, f]));
-                const ordered = allowedIds
+                link.uploadFolders = allowedIds
                   .map((id) => byId.get(id))
                   .filter((f): f is (typeof folders)[number] => !!f);
-                link.uploadFolders = ordered;
-                link.uploadFolderName = ordered[0]?.name;
               }
             }
             // Get the tags for the link

--- a/pages/api/teams/[teamId]/datarooms/[id]/links.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/links.ts
@@ -84,19 +84,11 @@ export default async function handle(
               link.password = decryptEncrpytedPassword(link.password);
             }
             if (link.enableUpload) {
-              // `uploadFolderIds` is the new source of truth, but until the
-              // legacy `uploadFolderId` column has been backfilled into it we
-              // fall back to `[uploadFolderId]` for rows where the array is
-              // still empty. The fallback becomes inert post-backfill.
-              const allowedIds: string[] =
-                Array.isArray(link.uploadFolderIds) &&
-                link.uploadFolderIds.length > 0
-                  ? link.uploadFolderIds.filter(
-                      (id): id is string => typeof id === "string" && !!id,
-                    )
-                  : link.uploadFolderId
-                    ? [link.uploadFolderId]
-                    : [];
+              const allowedIds = Array.isArray(link.uploadFolderIds)
+                ? link.uploadFolderIds.filter(
+                    (id): id is string => typeof id === "string" && !!id,
+                  )
+                : [];
 
               if (allowedIds.length > 0) {
                 const folders = await prisma.dataroomFolder.findMany({
@@ -108,11 +100,9 @@ export default async function handle(
                 });
                 // Preserve the admin-selected order when possible.
                 const byId = new Map(folders.map((f) => [f.id, f]));
-                const ordered = allowedIds
+                link.uploadFolders = allowedIds
                   .map((id) => byId.get(id))
                   .filter((f): f is (typeof folders)[number] => !!f);
-                link.uploadFolders = ordered;
-                link.uploadFolderName = ordered[0]?.name;
               }
             }
             const tags = await prisma.tag.findMany({

--- a/prisma/schema/link.prisma
+++ b/prisma/schema/link.prisma
@@ -80,7 +80,9 @@ model Link {
   // upload
   enableUpload      Boolean? @default(false) // Optional give user a option to enable the upload document function
   isFileRequestOnly Boolean? @default(false) // Optional give user a option to enable the file request only
-  uploadFolderId    String? // Deprecated: first entry of `uploadFolderIds`; kept for backward compatibility. Nullable = no restriction.
+  /// Deprecated: replaced by `uploadFolderIds`. Retained in the DB only so old
+  /// rows can be inspected; no application code reads or writes this column.
+  uploadFolderId    String?
   uploadFolderIds   String[] @default([]) // Allow-list of dataroom folder ids where visitors may upload. Empty = no restriction (visitor chooses).
   enableIndexFile   Boolean? @default(false)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified upload-folder handling: UI and APIs now rely on the multi-folder list, removing legacy single-folder behavior.
  * Folder chips and selection display consistently; first allowed folder wins when applicable.
  * API responses include resolved folder metadata so the UI shows folders without extra requests.
  * Analytics no longer reports the deprecated single-folder field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->