### PR TITLE
Fix: Prevent icon compression in Help Center dialog

### DIFF
--- a/components/profile-menu.tsx
+++ b/components/profile-menu.tsx
@@ -189,8 +189,9 @@ const ProfileMenu = ({ className, size }: ProfileMenuProps) => {
                       );
                       setSearchOpen(false);
                     }}
+                    className="gap-2"
                   >
-                    <FileText className="mr-2 h-4 w-4 text-[#fb7a00]" />
+                    <FileText className="h-4 w-4 shrink-0 text-[#fb7a00]" />
                     <div className="flex flex-col">
                       <span className="text-sm font-medium">
                         {article.data.title}

--- a/components/sidebar/nav-user.tsx
+++ b/components/sidebar/nav-user.tsx
@@ -211,8 +211,9 @@ export function NavUser() {
                       );
                       setSearchOpen(false);
                     }}
+                    className="gap-2"
                   >
-                    <FileTextIcon className="mr-2 h-4 w-4 text-[#fb7a00]" />
+                    <FileTextIcon className="h-4 w-4 shrink-0 text-[#fb7a00]" />
                     <div className="flex flex-col">
                       <span className="text-sm font-medium">
                         {article.data.title}


### PR DESCRIPTION
Fixed: #2173 
Description
This PR fixes a UI regression where icons in the Help Center list were being squished horizontally. This happened because the flex container was allowing the icons to shrink when the accompanying text (title/description) required more space.

Changes
Added flex-shrink-0 (or flex-shrink: 0;) to the icon container to ensure consistent dimensions.

Verified that icons maintain their aspect ratio across different screen sizes.

Screenshots
before: 
<img width="355" height="469" alt="image" src="https://github.com/user-attachments/assets/b7c9fbef-3e43-4b54-b97c-70174c169cf2" />

after:
<img width="530" height="232" alt="Screenshot 2026-05-08 120432" src="https://github.com/user-attachments/assets/b3b89382-0924-4fcb-a6e3-3615154a4df8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing layout for icons in help article menu items, changing from margin-based to gap-based spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->