### PR TITLE
feat(self-hosted): add GHL webhook integration and remove plan gates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,11 +27,23 @@ PROJECT_ID_VERCEL=
 TEAM_ID_VERCEL=
 AUTH_BEARER_TOKEN=
 
-# Upstash QStash – required for queues and background jobs
+# Self-hosted mode — set to "true" to bypass plan-gating on webhooks so all
+# teams can use webhooks regardless of their billing plan.
+NEXT_PUBLIC_SELF_HOSTED=
+
+# Upstash QStash – optional for self-hosted; used for reliable async webhook delivery.
+# When omitted, webhooks are delivered via direct HTTP fetch instead.
 # Get your QStash Token here: https://upstash.com/docs/qstash/overall/getstarted
 QSTASH_TOKEN=
 QSTASH_CURRENT_SIGNING_KEY=
 QSTASH_NEXT_SIGNING_KEY=
+
+# GoHighLevel (GHL) webhook integration — self-hosted only.
+# Paste the Inbound Webhook trigger URL from your GHL workflow here.
+# When set, every document link view is forwarded to GHL as a flat contact
+# payload so GHL can create/update contacts automatically.
+# Leave blank to disable.
+GHL_WEBHOOK_URL=
 
 # HANKO - required for signup with passkey
 # Get your HANKO keys here: https://docs.hanko.io/passkey-api/reference/credentials/list-credentials

--- a/lib/api/views/send-webhook-event.ts
+++ b/lib/api/views/send-webhook-event.ts
@@ -1,5 +1,6 @@
 import { isTeamPausedById } from "@/ee/features/billing/cancellation/lib/is-team-paused";
 
+import { sendGhlViewEvent } from "@/lib/integrations/ghl/send-ghl-event";
 import prisma from "@/lib/prisma";
 import { log } from "@/lib/utils";
 import { sendWebhooks } from "@/lib/webhook/send-webhooks";
@@ -23,22 +24,21 @@ export async function sendLinkViewWebhook({
       throw new Error("Missing required parameters");
     }
 
-    // check if team is on paid plan
-    const team = await prisma.team.findUnique({
-      where: { id: teamId },
-      select: { plan: true },
-    });
+    // On self-hosted deployments all plans are webhook-eligible.
+    if (process.env.NEXT_PUBLIC_SELF_HOSTED !== "true") {
+      const team = await prisma.team.findUnique({
+        where: { id: teamId },
+        select: { plan: true },
+      });
 
-    if (team?.plan === "free" || team?.plan === "pro") {
-      // team is not on a webhook-eligible plan, so we don't send webhooks
-      return;
-    }
+      if (team?.plan === "free" || team?.plan === "pro") {
+        return;
+      }
 
-    // check if team is paused
-    const teamIsPaused = await isTeamPausedById(teamId);
-    if (teamIsPaused) {
-      // team is paused, so we don't send webhooks
-      return;
+      const teamIsPaused = await isTeamPausedById(teamId);
+      if (teamIsPaused) {
+        return;
+      }
     }
 
     // Get webhooks for team
@@ -182,14 +182,26 @@ export async function sendLinkViewWebhook({
       }),
     };
 
-    // Send webhooks
-    if (webhooks.length > 0) {
-      await sendWebhooks({
-        webhooks,
-        trigger: "link.viewed",
-        data: webhookData,
-      });
-    }
+    // Send Papermark webhooks and GHL event in parallel.
+    await Promise.all([
+      webhooks.length > 0
+        ? sendWebhooks({
+            webhooks,
+            trigger: "link.viewed",
+            data: webhookData,
+          })
+        : Promise.resolve(),
+      sendGhlViewEvent({
+        view: viewData,
+        link: linkData,
+        document: document
+          ? { name: document.name }
+          : null,
+        dataroom: dataroom
+          ? { name: dataroom.name }
+          : null,
+      }),
+    ]);
     return;
   } catch (error) {
     log({

--- a/lib/integrations/ghl/send-ghl-event.ts
+++ b/lib/integrations/ghl/send-ghl-event.ts
@@ -1,0 +1,107 @@
+/**
+ * GoHighLevel (GHL) webhook integration for self-hosted Papermark.
+ *
+ * When GHL_WEBHOOK_URL is set, every `link.viewed` event is forwarded to that
+ * URL as a flat contact payload that GHL workflow triggers understand natively.
+ *
+ * Set up in GHL:
+ *  1. Automations → Create workflow → Trigger: "Inbound Webhook"
+ *  2. Copy the trigger URL into GHL_WEBHOOK_URL in your .env
+ *  3. Map fields: email → Contact Email, firstName / lastName → name fields,
+ *     and any "papermark_*" custom fields you want stored on the contact.
+ */
+
+export interface GhlContactPayload {
+  email: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  /** ISO datetime the document link was viewed */
+  papermark_viewed_at: string;
+  /** Human-readable link name or ID */
+  papermark_link_name: string | null;
+  /** Full link URL e.g. https://yourhost/view/clxxx */
+  papermark_link_url: string;
+  /** Document name if the link points to a document */
+  papermark_document_name: string | null;
+  /** Dataroom name if the link points to a dataroom */
+  papermark_dataroom_name: string | null;
+  /** Viewer country (2-letter ISO code) */
+  papermark_country: string | null;
+  /** Viewer city */
+  papermark_city: string | null;
+  /** Viewer device type */
+  papermark_device: string | null;
+  /** Unique Papermark view ID */
+  papermark_view_id: string;
+}
+
+/**
+ * Sends a link.viewed event to GHL as a contact payload.
+ * No-ops silently when GHL_WEBHOOK_URL is not configured.
+ */
+export async function sendGhlViewEvent(data: {
+  view: {
+    viewId: string;
+    email: string | null;
+    viewedAt: string;
+    country?: string | null;
+    city?: string | null;
+    device?: string | null;
+  };
+  link: {
+    id: string;
+    url: string;
+    name: string | null;
+  };
+  document?: { name: string } | null;
+  dataroom?: { name: string } | null;
+}): Promise<void> {
+  const ghlUrl = process.env.GHL_WEBHOOK_URL;
+  if (!ghlUrl) return;
+
+  const rawEmail = data.view.email ?? "";
+  const nameParts = rawEmail.split("@")[0]?.split(/[._-]/) ?? [];
+  const firstName = nameParts[0]
+    ? nameParts[0].charAt(0).toUpperCase() + nameParts[0].slice(1)
+    : null;
+  const lastName =
+    nameParts.length > 1
+      ? nameParts
+          .slice(1)
+          .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+          .join(" ")
+      : null;
+
+  const payload: GhlContactPayload = {
+    email: data.view.email,
+    firstName,
+    lastName,
+    papermark_viewed_at: data.view.viewedAt,
+    papermark_link_name: data.link.name,
+    papermark_link_url: data.link.url,
+    papermark_document_name: data.document?.name ?? null,
+    papermark_dataroom_name: data.dataroom?.name ?? null,
+    papermark_country: data.view.country ?? null,
+    papermark_city: data.view.city ?? null,
+    papermark_device: data.view.device ?? null,
+    papermark_view_id: data.view.viewId,
+  };
+
+  try {
+    const response = await fetch(ghlUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      console.error(
+        `GHL webhook responded ${response.status}: ${text.slice(0, 200)}`,
+      );
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to send event to GHL webhook: ${msg}`);
+  }
+}

--- a/lib/webhook/send-webhooks.ts
+++ b/lib/webhook/send-webhooks.ts
@@ -1,7 +1,5 @@
 import { Webhook } from "@prisma/client";
 
-import { qstash } from "@/lib/cron";
-
 import { createWebhookSignature } from "./signature";
 import { prepareWebhookPayload } from "./transform";
 import { EventDataProps, WebhookPayload, WebhookTrigger } from "./types";
@@ -33,17 +31,17 @@ export const sendWebhooks = async ({
 
   const payload = prepareWebhookPayload(trigger, data);
 
-  // Use allSettled so that a single QStash failure (e.g. transient network
-  // error or rate limit on one endpoint) does not prevent the remaining
+  const deliverFn = process.env.QSTASH_TOKEN
+    ? publishWebhookEventToQStash
+    : publishWebhookEventDirect;
+
+  // Use allSettled so a single failure does not prevent the remaining
   // webhooks in the batch from being delivered.
   const results = await Promise.allSettled(
-    webhooks.map((webhook) =>
-      publishWebhookEventToQStash({ webhook, payload }),
-    ),
+    webhooks.map((webhook) => deliverFn({ webhook, payload })),
   );
 
-  const fulfilled: Awaited<ReturnType<typeof publishWebhookEventToQStash>>[] =
-    [];
+  const fulfilled: Awaited<ReturnType<typeof deliverFn>>[] = [];
   for (let i = 0; i < results.length; i++) {
     const result = results[i];
     if (result.status === "fulfilled") {
@@ -65,7 +63,50 @@ export const sendWebhooks = async ({
   return fulfilled;
 };
 
-// Publish webhook event to QStash
+// Deliver webhook event directly via fetch (used when QSTASH_TOKEN is not set,
+// e.g. self-hosted deployments that don't use Upstash).
+const publishWebhookEventDirect = async ({
+  webhook,
+  payload,
+}: {
+  webhook: Pick<Webhook, "pId" | "url" | "secret">;
+  payload: WebhookPayload;
+}) => {
+  const signature = await createWebhookSignature(webhook.secret, payload);
+
+  try {
+    const response = await fetch(webhook.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Papermark-Signature": signature,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      console.error(
+        `Webhook ${webhook.pId} (${redactUrl(webhook.url)}) responded ${response.status}: ${text}`,
+      );
+    }
+
+    return { ok: response.ok, status: response.status };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error
+        ? error.message
+        : typeof error === "string"
+          ? error
+          : "Unknown error";
+    console.error(
+      `Failed to deliver webhook ${webhook.pId} to ${redactUrl(webhook.url)}: ${errorMessage}`,
+    );
+    throw error;
+  }
+};
+
+// Publish webhook event to QStash (used when QSTASH_TOKEN is configured).
 const publishWebhookEventToQStash = async ({
   webhook,
   payload,
@@ -73,6 +114,10 @@ const publishWebhookEventToQStash = async ({
   webhook: Pick<Webhook, "pId" | "url" | "secret">;
   payload: WebhookPayload;
 }) => {
+  // Dynamic import so self-hosted builds without QSTASH_TOKEN never initialise
+  // the QStash client (which throws on missing token).
+  const { qstash } = await import("@/lib/cron");
+
   const callbackUrl = new URL(
     `${process.env.NEXT_PUBLIC_BASE_URL}/api/webhooks/callback`,
   );
@@ -100,8 +145,6 @@ const publishWebhookEventToQStash = async ({
 
     return response;
   } catch (error) {
-    // Surface which webhook failed so the caller's allSettled handler and
-    // logs make it easy to identify the broken endpoint.
     const errorMessage =
       error instanceof Error
         ? error.message

--- a/lib/webhook/triggers/document-created.ts
+++ b/lib/webhook/triggers/document-created.ts
@@ -18,22 +18,21 @@ export async function sendDocumentCreatedWebhook({
       throw new Error("Missing required parameters");
     }
 
-    // check if team is on paid plan
-    const team = await prisma.team.findUnique({
-      where: { id: teamId },
-      select: { plan: true },
-    });
+    // On self-hosted deployments all plans are webhook-eligible.
+    if (process.env.NEXT_PUBLIC_SELF_HOSTED !== "true") {
+      const team = await prisma.team.findUnique({
+        where: { id: teamId },
+        select: { plan: true },
+      });
 
-    if (team?.plan === "free" || team?.plan === "pro") {
-      // team is not on paid plan, so we don't need to send webhooks
-      return;
-    }
+      if (team?.plan === "free" || team?.plan === "pro") {
+        return;
+      }
 
-    // check if team is paused
-    const teamIsPaused = await isTeamPausedById(teamId);
-    if (teamIsPaused) {
-      // team is paused, so we don't send webhooks
-      return;
+      const teamIsPaused = await isTeamPausedById(teamId);
+      if (teamIsPaused) {
+        return;
+      }
     }
 
     // Get webhooks for team

--- a/lib/webhook/triggers/link-created.ts
+++ b/lib/webhook/triggers/link-created.ts
@@ -22,22 +22,21 @@ export async function sendLinkCreatedWebhook({
       throw new Error("Missing required parameters");
     }
 
-    // check if team is on paid plan
-    const team = await prisma.team.findUnique({
-      where: { id: teamId },
-      select: { plan: true },
-    });
+    // On self-hosted deployments all plans are webhook-eligible.
+    if (process.env.NEXT_PUBLIC_SELF_HOSTED !== "true") {
+      const team = await prisma.team.findUnique({
+        where: { id: teamId },
+        select: { plan: true },
+      });
 
-    if (team?.plan === "free" || team?.plan === "pro") {
-      // team is not on a webhook-eligible plan, so we don't send webhooks
-      return;
-    }
+      if (team?.plan === "free" || team?.plan === "pro") {
+        return;
+      }
 
-    // check if team is paused
-    const teamIsPaused = await isTeamPausedById(teamId);
-    if (teamIsPaused) {
-      // team is paused, so we don't send webhooks
-      return;
+      const teamIsPaused = await isTeamPausedById(teamId);
+      if (teamIsPaused) {
+        return;
+      }
     }
 
     // Get webhooks for team


### PR DESCRIPTION
- Replace QStash-only delivery in send-webhooks.ts with a direct fetch fallback used when QSTASH_TOKEN is not set, so self-hosted deployments work without an Upstash account.

- Guard the plan/paused checks in all three webhook trigger files (link.created, document.created, link.viewed) behind NEXT_PUBLIC_SELF_HOSTED !== "true" so every team on a self-hosted instance can use webhooks regardless of billing plan.

- Add lib/integrations/ghl/send-ghl-event.ts: when GHL_WEBHOOK_URL is set, every link.viewed event is forwarded to GoHighLevel as a flat contact payload (email, firstName, lastName, papermark_* custom fields) that GHL inbound-webhook workflow triggers understand natively.

- Wire sendGhlViewEvent into send-webhook-event.ts alongside the existing Papermark webhook dispatch (runs in parallel, silent no-op when GHL_WEBHOOK_URL is absent).

- Document both new variables in .env.example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GoHighLevel CRM integration for document view events
  * Enabled self-hosted deployment mode with independent configuration
  * Webhook delivery now supports direct HTTP as alternative to QStash

* **Configuration**
  * Updated environment variables to support self-hosted and cloud deployments
  * Made QStash configuration optional when using alternative delivery methods

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/papermark/papermark/pull/2176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->