### PR TITLE
fix: deduplicate document overview API response and fix Date serialization

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -918,6 +918,10 @@ export function serializeFileSize(obj: any): any {
     return obj;
   }
 
+  if (Object.prototype.toString.call(obj) === "[object Date]") {
+    return obj;
+  }
+
   if (Array.isArray(obj)) {
     return obj.map(serializeFileSize);
   }

--- a/pages/api/teams/[teamId]/documents/[id]/overview.ts
+++ b/pages/api/teams/[teamId]/documents/[id]/overview.ts
@@ -144,7 +144,27 @@ export default async function handle(
     // Basic response for instant loading
     const response = {
       document: {
-        ...serializeFileSize(document),
+        id: document.id,
+        name: document.name,
+        description: document.description,
+        file: document.file,
+        originalFile: document.originalFile,
+        type: document.type,
+        contentType: document.contentType,
+        storageType: document.storageType,
+        numPages: document.numPages,
+        ownerId: document.ownerId,
+        teamId: document.teamId,
+        agentsEnabled: document.agentsEnabled,
+        advancedExcelEnabled: document.advancedExcelEnabled,
+        downloadOnly: document.downloadOnly,
+        createdAt: document.createdAt,
+        updatedAt: document.updatedAt,
+        folderId: document.folderId,
+        isExternalUpload: document.isExternalUpload,
+        folder: document.folder,
+        datarooms: document.datarooms,
+        _count: document._count,
         primaryVersion: serializeFileSize(primaryVersion),
         hasPageLinks,
         isEmpty: !hasLinks && !hasViews, // Flag for empty state optimization


### PR DESCRIPTION
Issue #2175

## Summary

This PR fixes two issues in the document overview API response:

### 1. Duplicate primary version data

The response was unintentionally including version information twice. This happened because `serializeFileSize(document)` spread the entire serialized document object, including the `versions` array, while the API also returned an explicit `primaryVersion` field.

To resolve this, the response now explicitly selects the required document fields instead of spreading the serialized object, preventing duplicate version data from being returned.

### 2. Incorrect Date serialization

`createdAt` and `updatedAt` values could be serialized as `{}` when Prisma Date objects originated from a different JavaScript realm. The existing `instanceof Date` check was not reliable across realms.

The Date detection logic in `serializeFileSize()` has been updated to use:

`Object.prototype.toString.call(obj) === "[object Date]"`

This provides reliable Date detection and ensures timestamps are correctly serialized.

## Files Changed

* `lib/utils.ts`

  * Improved cross-realm Date detection for serialization.

* `pages/api/teams/[teamId]/documents/[id]/overview.ts`

  * Removed the `...serializeFileSize(document)` spread.
  * Explicitly returned required document fields to avoid duplicate version data.

## Result

* No duplicate version information in the overview response.
* Consistent serialization of `createdAt` and `updatedAt`.
* Backward-compatible API behavior with cleaner response data.

Closes #2175 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Corrected date object handling in API serialization to prevent misprocessing
* Improved file size field serialization in document overview API responses for accurate data representation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->