### PR TITLE
fix: restrict CORS origins for TUS viewer uploads

### DIFF
--- a/lib/files/cors-utils.ts
+++ b/lib/files/cors-utils.ts
@@ -1,0 +1,45 @@
+
+function getTrustedOrigins(): string[] {
+  const trusted: string[] = [];
+
+  if (process.env.NEXT_PUBLIC_BASE_URL) {
+    try {
+      trusted.push(new URL(process.env.NEXT_PUBLIC_BASE_URL).origin);
+    } catch {
+      // If the env value is not a valid URL, skip it silently.
+    }
+  }
+
+  if (process.env.NEXT_PUBLIC_MARKETING_URL) {
+    try {
+      trusted.push(new URL(process.env.NEXT_PUBLIC_MARKETING_URL).origin);
+    } catch {
+      // If the env value is not a valid URL, skip it silently.
+    }
+  }
+
+  // Allow localhost explicitly during local development.
+  if (process.env.NODE_ENV === "development") {
+    trusted.push("http://localhost:3000");
+    trusted.push("http://localhost");
+  }
+
+  return trusted;
+}
+
+
+//  Returns the origin string if it is in the trusted list, or null if not.
+export function getAllowedOrigin(
+  requestOrigin: string | undefined,
+): string | null {
+  if (!requestOrigin) return null;
+
+  try {
+    const normalizedOrigin = new URL(requestOrigin).origin;
+    const trustedOrigins = getTrustedOrigins();
+    return trustedOrigins.includes(normalizedOrigin) ? normalizedOrigin : null;
+  } catch {
+  
+    return null;
+  }
+}

--- a/pages/api/file/tus-viewer/[[...file]].ts
+++ b/pages/api/file/tus-viewer/[[...file]].ts
@@ -236,7 +236,15 @@ const setCorsHeaders = (
   req: NextApiRequest,
   res: NextApiResponse,
 ): boolean => {
-  const allowedOrigin = getAllowedOrigin(req.headers.origin);
+  const requestOrigin = req.headers.origin;
+  
+  // Let it through without adding CORS headers.
+  if (!requestOrigin) {
+    return true;
+  }
+
+  // Origin header is present — check if it is trusted.
+  const allowedOrigin = getAllowedOrigin(requestOrigin);
 
   if (!allowedOrigin) {
     res.status(403).end("Forbidden: untrusted origin");
@@ -245,7 +253,6 @@ const setCorsHeaders = (
 
   res.setHeader("Access-Control-Allow-Credentials", "true");
   res.setHeader("Access-Control-Allow-Origin", allowedOrigin);
-  // Vary: Origin is required so caches do not reuse a response
   res.setHeader("Vary", "Origin");
   res.setHeader(
     "Access-Control-Allow-Methods",

--- a/pages/api/file/tus-viewer/[[...file]].ts
+++ b/pages/api/file/tus-viewer/[[...file]].ts
@@ -13,6 +13,7 @@ import { newId } from "@/lib/id-helper";
 import prisma from "@/lib/prisma";
 import { lockerRedisClient } from "@/lib/redis";
 import { log } from "@/lib/utils";
+import { getAllowedOrigin } from "@/lib/files/cors-utils";
 
 export const config = {
   maxDuration: 60,
@@ -230,11 +231,22 @@ const tusServer = new Server({
   },
 });
 
-// CORS headers to allow custom domains
-const setCorsHeaders = (req: NextApiRequest, res: NextApiResponse) => {
-  // Set CORS headers
+// CORS headers to allow custom domains.
+const setCorsHeaders = (
+  req: NextApiRequest,
+  res: NextApiResponse,
+): boolean => {
+  const allowedOrigin = getAllowedOrigin(req.headers.origin);
+
+  if (!allowedOrigin) {
+    res.status(403).end("Forbidden: untrusted origin");
+    return false;
+  }
+
   res.setHeader("Access-Control-Allow-Credentials", "true");
-  res.setHeader("Access-Control-Allow-Origin", req.headers.origin || "*");
+  res.setHeader("Access-Control-Allow-Origin", allowedOrigin);
+  // Vary: Origin is required so caches do not reuse a response
+  res.setHeader("Vary", "Origin");
   res.setHeader(
     "Access-Control-Allow-Methods",
     "POST, GET, OPTIONS, DELETE, PATCH, HEAD",
@@ -247,18 +259,21 @@ const setCorsHeaders = (req: NextApiRequest, res: NextApiResponse) => {
     "Access-Control-Expose-Headers",
     "Upload-Offset, Location, Upload-Length, Tus-Version, Tus-Resumable, Tus-Max-Size, Tus-Extension, Upload-Metadata, Upload-Defer-Length, Upload-Concat",
   );
+  return true;
 };
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  // Handle CORS preflight requests
+  // Handle CORS preflight requests.
   if (req.method === "OPTIONS") {
-    setCorsHeaders(req, res);
+    const allowed = setCorsHeaders(req, res);
+    if (!allowed) return;
     return res.status(204).end();
   }
 
-  // Set CORS headers for all requests
-  setCorsHeaders(req, res);
+  // Set CORS headers for all non-preflight requests.
+  const allowed = setCorsHeaders(req, res);
+  if (!allowed) return;
 
-  // No session check - authentication is handled via viewer metadata
+  
   return tusServer.handle(req, res);
 }


### PR DESCRIPTION
## Summary

This PR fixes the CORS configuration for the TUS viewer upload endpoint.

Previously, the endpoint reflected the incoming `Origin` header while also returning `Access-Control-Allow-Credentials: true`. As a result, any origin could receive credentialed CORS headers.

This change restricts credentialed CORS requests to trusted application origins derived from the existing environment configuration.

## Changes

- Added a small helper to validate trusted origins.
- Only return `Access-Control-Allow-Origin` for trusted origins.
- Return `403 Forbidden` for untrusted origins.
- Added `Vary: Origin` to avoid cached CORS responses being reused across different origins.

## Testing

Verified locally before and after the change.

### Before

Request:

```
Origin: https://evil.example
```

Response:

```
204 No Content
Access-Control-Allow-Origin: https://evil.example
Access-Control-Allow-Credentials: true
```

### After

Untrusted origin:

```
Origin: https://evil.example
```

Response:

```
403 Forbidden
```

Trusted origin:

```
Origin: http://localhost:3000
```

Response:

```
204 No Content
Access-Control-Allow-Origin: http://localhost:3000
Access-Control-Allow-Credentials: true
Vary: Origin
```

Fixes #2178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CORS origin validation for the file viewer API by using a trusted-origin allowlist.
  * Requests with missing, invalid, or untrusted origins are now rejected early (including preflight requests) instead of being handled permissively.
  * Local development still permits localhost origins to keep testing smooth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->