### PR TITLE
docs: fix Node.js version requirement to match package.json engines field

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Papermark is the open-source document-sharing alternative to DocSend, featuring 
 
 Here's what you need to run Papermark:
 
-- Node.js (version >= 18.17.0)
+- Node.js (version >= 24)
 - PostgreSQL Database
 - Blob storage (currently [AWS S3](https://aws.amazon.com/s3/) or [Vercel Blob](https://vercel.com/storage/blob))
 - [Resend](https://resend.com) (for sending emails)


### PR DESCRIPTION
The README states Node.js >= 18.17.0 is required, but package.json declares "engines": { "node": ">=24" }. This updates the README to match the actual requirement, avoiding confusion for new contributors trying to run the project locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented Node.js prerequisite to version 24 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->