### PR TITLE
fix: don't disable pull-to-refresh prevention in landscape mode

### DIFF
--- a/components/view/viewer/image-viewer.tsx
+++ b/components/view/viewer/image-viewer.tsx
@@ -72,7 +72,7 @@ export default function ImageViewer({
     rotate,
   } = useFullscreen();
 
-  useDisablePullToRefresh(!!isMobile);
+  useDisablePullToRefresh();
 
   // In fullscreen the overlay controls fade after a few seconds; a tap anywhere
   // reveals them again.

--- a/components/view/viewer/pages-horizontal-viewer.tsx
+++ b/components/view/viewer/pages-horizontal-viewer.tsx
@@ -98,7 +98,7 @@ export default function PagesHorizontalViewer({
     rotate,
   } = useFullscreen();
 
-  useDisablePullToRefresh(!!isMobile);
+  useDisablePullToRefresh();
 
   const showStatsSlideWithAccountCreation =
     showAccountCreationSlide && // if showAccountCreationSlide is enabled

--- a/components/view/viewer/pages-vertical-viewer.tsx
+++ b/components/view/viewer/pages-vertical-viewer.tsx
@@ -123,7 +123,7 @@ export default function PagesVerticalViewer({
     rotate,
   } = useFullscreen();
 
-  useDisablePullToRefresh(isMobile);
+  useDisablePullToRefresh();
 
   const numPages = pages.length;
   const numPagesWithFeedback =


### PR DESCRIPTION
## Summary

Fixes #2188 — on mobile, swiping to scroll a document in landscape mode could accidentally trigger the browser's native pull-to-refresh, reloading the page and losing scroll position.

`useDisablePullToRefresh()` already detects touch devices on its own (`ontouchstart` / `maxTouchPoints` / `pointer: coarse`), which doesn't change with device orientation. All three call sites additionally gated the hook behind the `isMobile` viewport-width breakpoint — but that breakpoint flips to `false` when a phone is rotated to landscape (width > breakpoint), silently turning the protection off exactly in the scenario the reporter described.

This is called out in an existing comment in `pages-horizontal-viewer.tsx` about a different piece of UI needing to handle the same landscape edge case, so the gate looks like an oversight rather than an intentional constraint.

## Change

Drop the `isMobile` gate on `useDisablePullToRefresh()` in:
- `components/view/viewer/pages-horizontal-viewer.tsx`
- `components/view/viewer/pages-vertical-viewer.tsx`
- `components/view/viewer/image-viewer.tsx`

The hook's own touch-device check is enough; no functional change on desktop (non-touch), since it already no-ops there.

## Test plan

- [ ] Open a document link on a phone in portrait, confirm pull-to-refresh still doesn't fire while scrolling
- [ ] Rotate to landscape mid-view, swipe near the top/bottom of the screen, confirm the browser no longer reloads
- [ ] Confirm desktop scrolling/zooming is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled browser pull-to-refresh across all viewer layouts and device types.
  * Improved scrolling behavior while viewing content, including on desktop devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->