### PR TITLE
fix(billing): reseta estado de loading do botão de upgrade ao voltar do Stripe Checkout

### DIFF
--- a/components/billing/unlimited-plan-modal.tsx
+++ b/components/billing/unlimited-plan-modal.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import React from "react";
 
 import { useTeam } from "@/context/team-context";
@@ -59,6 +59,20 @@ export function UnlimitedPlanModal({
   // locked to their current currency, then geo, then USD as the default.
   const currency: Currency =
     externalCurrency ?? subscriptionCurrency ?? geoCurrency ?? "usd";
+
+  // If the browser restores this page from bfcache (e.g. the user hits
+  // "back" from Stripe Checkout before completing payment), the component
+  // isn't remounted, so a stale `loading` state would leave the button
+  // stuck on "Redirecting to Stripe..." forever.
+  useEffect(() => {
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        setLoading(false);
+      }
+    };
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, []);
 
   const unlimitedPlan = PLANS.find(
     (p) => p.name === PlanEnum.DataRoomsUnlimited,

--- a/components/billing/upgrade-plan-modal-with-discount.tsx
+++ b/components/billing/upgrade-plan-modal-with-discount.tsx
@@ -166,6 +166,19 @@ export function UpgradePlanModalWithDiscount({
   const router = useRouter();
   const [period, setPeriod] = useState<"yearly" | "monthly">("yearly");
   const [selectedPlan, setSelectedPlan] = useState<string | null>(null);
+  // If the browser restores this page from bfcache (e.g. the user hits
+  // "back" from Stripe Checkout before completing payment), the component
+  // isn't remounted, so a stale `selectedPlan` would leave the button
+  // stuck on "Redirecting to Stripe..." forever.
+  useEffect(() => {
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        setSelectedPlan(null);
+      }
+    };
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, []);
   const teamInfo = useTeam();
   const teamId = teamInfo?.currentTeam?.id;
   const {

--- a/components/billing/upgrade-plan-modal.tsx
+++ b/components/billing/upgrade-plan-modal.tsx
@@ -211,6 +211,19 @@ export function UpgradePlanModal({
     subscriptionCurrency ?? currencyOverride ?? geoCurrency ?? "usd";
   const isCurrencyLocked = subscriptionCurrency != null;
   const [selectedPlan, setSelectedPlan] = useState<string | null>(null);
+  // If the browser restores this page from bfcache (e.g. the user hits
+  // "back" from Stripe Checkout before completing payment), the component
+  // isn't remounted, so a stale `selectedPlan` would leave the button
+  // stuck on "Redirecting to Stripe..." forever.
+  useEffect(() => {
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        setSelectedPlan(null);
+      }
+    };
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, []);
   const teamInfo = useTeam();
   const teamId = teamInfo?.currentTeam?.id;
   const { plan: teamPlan, isCustomer, isOldAccount, isTrial } = usePlan();

--- a/pages/settings/upgrade-holiday-offer.tsx
+++ b/pages/settings/upgrade-holiday-offer.tsx
@@ -139,6 +139,19 @@ export default function UpgradeHolidayOfferPage() {
   const router = useRouter();
   const [period, setPeriod] = useState<"yearly" | "monthly">("yearly");
   const [selectedPlan, setSelectedPlan] = useState<string | null>(null);
+  // If the browser restores this page from bfcache (e.g. the user hits
+  // "back" from Stripe Checkout before completing payment), the component
+  // isn't remounted, so a stale `selectedPlan` would leave the button
+  // stuck on "Redirecting to Stripe..." forever.
+  useEffect(() => {
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        setSelectedPlan(null);
+      }
+    };
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, []);
   const teamInfo = useTeam();
   const { plan: teamPlan, trial, isCustomer, isOldAccount } = usePlan();
   const analytics = useAnalytics();


### PR DESCRIPTION
## Resumo
Corrige #2184 — o botão "Atualizar" ficava travado em "Redirecting to Stripe..." e desabilitado quando o usuário voltava da página de checkout do Stripe usando o botão "Voltar" do navegador antes de concluir a compra.

## Causa raiz
Ao clicar em "Atualizar", o componente seta o estado de loading (`selectedPlan`/`loading`) e navega para o Stripe via `window.location.href`. Quando o usuário volta pelo navegador antes de finalizar o pagamento, a página é restaurada a partir do **bfcache** (back-forward cache) em vez de remontar o componente — então o estado antigo de loading permanece, deixando o botão travado até um refresh manual da página.

## Correção
Adicionado um listener do evento `pageshow` que reseta o estado de loading quando `event.persisted === true` (indicando restauração via bfcache), em todos os componentes que reproduzem esse fluxo de upgrade:

- `components/billing/upgrade-plan-modal.tsx`
- `components/billing/upgrade-plan-modal-with-discount.tsx`
- `components/billing/unlimited-plan-modal.tsx`
- `pages/settings/upgrade-holiday-offer.tsx`

## Teste
- [ ] Abrir o modal de preços, clicar em "Upgrade to Business/Data Rooms", aguardar redirecionamento ao Stripe
- [ ] Clicar em "Voltar" no navegador antes de concluir a compra
- [ ] Confirmar que o botão volta ao estado normal (habilitado, sem "Redirecting to Stripe...") sem precisar dar refresh na página

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed upgrade buttons remaining stuck in a “Redirecting to Stripe…” state after returning to a billing page using the browser’s back or forward navigation.
  * Billing and promotional upgrade screens now correctly restore their normal button state when revisited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->